### PR TITLE
save dropbear key to env

### DIFF
--- a/overlay/etc/init.d/S50dropbear
+++ b/overlay/etc/init.d/S50dropbear
@@ -18,6 +18,20 @@ start() {
 		fi
 	fi
 
+	SSHKEY_ENV=$(fw_printenv -n sshkey_ed25519)
+	DROPBEAR_KEY="/etc/dropbear/dropbear_ed25519_host_key"
+
+	[ -s "$DROPBEAR_KEY" ] || {
+		[ -n "$SSHKEY_ENV" ] && echo "$SSHKEY_ENV" | base64 -d | gzip -d > $DROPBEAR_KEY && logger -t S50dropbear "SSH Key restored." || {
+			dropbearkey -t ed25519 -f $DROPBEAR_KEY && logger -t S50dropbear "Generated dropbear host keys."
+		}
+	}
+
+	[ -z "$SSHKEY_ENV" ] && [ -s "$DROPBEAR_KEY" ] && {
+		SSHKEY_ENV=$(gzip -c $DROPBEAR_KEY | base64 | tr -d '\n')
+		fw_setenv sshkey_ed25519 "$SSHKEY_ENV" && logger -t S50dropbear "SSH key backed up."
+	}
+
 	printf "Starting dropbear sshd: "
 	umask 077
 


### PR DESCRIPTION
adapt init script to generate the ssh key for dropbear on firstboot; then save to env; restore from ENV if key is missing on overlay.

how to generate the key for uEnv.txt:

`dropbearkey -t ed25519 -f /tmp/test >/dev/null 2>&1; gzip -c /tmp/test | base64 | tr -d '\n'; echo \n;rm -f /tmp/test`


```
# dropbearkey -t ed25519 -f /tmp/test >
/dev/null 2>&1; gzip -c /tmp/test | base64 | tr -d '\n'; echo \n
H4sIAAAAAAAAAwFTAKz/AAAAC3NzaC1lZDI1NTE5AAAAQLccuUS/KjMbkK0Xady/eb/fC44qj14IC/yAj28gA5C+MxrmQw3AOprf4SaHtyKrCl3VhMf8yCSkxv4xhaFYJ7ihqOxMUwAAAA==n
```