### PR TITLE
update sysctl.conf

### DIFF
--- a/overlay/etc/sysctl.conf
+++ b/overlay/etc/sysctl.conf
@@ -1,3 +1,2 @@
 # Level of messages on console
 kernel.printk = 3 3 1 3
-net.core.bpf_jit_enable=1


### PR DESCRIPTION
`error: 'net.core.bpf_jit_enable' is an unknown key`
option not valid for our platform