### PR TITLE
check ssid for wpa_supplicant too

### DIFF
--- a/overlay/etc/init.d/S39wpa_supplicant
+++ b/overlay/etc/init.d/S39wpa_supplicant
@@ -10,8 +10,8 @@ start() {
 	ssid="$(fw_printenv -n wlanssid)"
 	pass="$(fw_printenv -n wlanpass)"
 
-	if [ -z "$pass" ]; then
-		echo "wlanpass is empty, exiting."
+	if [ -z "$ssid" ] || [ -z "$pass" ]; then
+		echo "WiFi credentials missing"
 		exit 0
 	fi
 


### PR DESCRIPTION
check is ssid or password is empty in ENV before configuring/launching the supplicant.