### PR TITLE
Changes to support t31 4.4

### DIFF
--- a/configs/testing/exp_t31l_sc2336_atbm6031_kernel44
+++ b/configs/testing/exp_t31l_sc2336_atbm6031_kernel44
@@ -1,0 +1,6 @@
+# FRAG: soc toolchain ccache brand rootfs kernel system target local
+BR2_SOC_INGENIC_T31L=y
+BR2_SENSOR_MODEL="sc2336"
+BR2_PACKAGE_WIFI=y
+BR2_PACKAGE_WIFI_ATBM6031=y
+KERNEL_VERSION_4=y

--- a/external.mk
+++ b/external.mk
@@ -219,7 +219,7 @@ else ifeq ($(KERNEL_VERSION_4),y)
 $(info Building for kernel 4.x)
 KERNEL_VERSION = 4.4
 KERNEL_SITE = https://github.com/matteius/ingenic-t31-zrt-kernel-4.4.94
-KERNEL_BRANCH = 4.4-latest
+KERNEL_BRANCH = 4.4-stable
 endif
 KERNEL_HASH = $(shell git ls-remote $(KERNEL_SITE) $(KERNEL_BRANCH) | head -1 | cut -f1)
 $(info KERNEL_HASH=$(shell git ls-remote $(KERNEL_SITE) $(KERNEL_BRANCH) | head -1 | cut -f1))

--- a/package/prudynt-t/prudynt-t.mk
+++ b/package/prudynt-t/prudynt-t.mk
@@ -5,6 +5,9 @@ PRUDYNT_T_DEPENDENCIES = libconfig thingino-live555 ingenic-sdk thingino-freetyp
 PRUDYNT_T_GIT_SUBMODULES = YES
 
 PRUDYNT_CFLAGS += -DPLATFORM_$(shell echo $(SOC_FAMILY) | tr a-z A-Z)
+ifeq ($(KERNEL_VERSION_4),y)
+PRUDYNT_CFLAGS += -DKERNEL_VERSION_4
+endif
 
 PRUDYNT_CFLAGS += \
 	-DNO_OPENSSL=1 -Os \


### PR DESCRIPTION
* Minimal changes to get 4.4 image working without mods

Depends on:
* https://github.com/gtxaspec/prudynt-t/pull/3
* https://github.com/themactep/ingenic-sdk/pull/7

Open Questions:
I am still building this with my own toolchain build that I compiled against the 4.4 headers.   Noticed that the toolchain fragments reference the 3_10 kernel sources.

For example, this diff captures how I built locally to verify my changes (but I am not sure what the effect of the 3.10 toolchain would be).

```
diff --git a/configs/fragments/templates/toolchain.download.fragment b/configs/fragments/templates/toolchain.download.fragment
index 2a9228f1..f297ead7 100644
--- a/configs/fragments/templates/toolchain.download.fragment
+++ b/configs/fragments/templates/toolchain.download.fragment
@@ -1,7 +1,7 @@
 BR2_TOOLCHAIN_EXTERNAL=y
 BR2_TOOLCHAIN_EXTERNAL_CUSTOM=y
 BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=y
-BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/themactep/thingino-firmware/releases/download/toolchain/thingino-toolchain_xburst1_musl_gcc13-linux-mipsel.tar.gz"
+BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/matteius/ingenic-t31-zrt-kernel-4.4.94/releases/download/4.4.latest/mipsel-thingino-linux-musl_sdk-buildroot.tar.gz"
 BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_10=y
 BR2_TOOLCHAIN_EXTERNAL_CUSTOM_MUSL=y
 BR2_TOOLCHAIN_EXTERNAL_CXX=y
diff --git a/configs/fragments/toolchain.fragment b/configs/fragments/toolchain.fragment
index b2ae16a8..df19c7ad 100644
--- a/configs/fragments/toolchain.fragment
+++ b/configs/fragments/toolchain.fragment
@@ -2,8 +2,8 @@
 BR2_TOOLCHAIN_EXTERNAL=y
 BR2_TOOLCHAIN_EXTERNAL_CUSTOM=y
 BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=y
-BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/themactep/thingino-firmware/releases/download/toolchain/thingino-toolchain_xburst1_musl_gcc13-linux-mipsel.tar.gz"
-BR2_TOOLCHAIN_EXTERNAL_HEADERS_3_10=y
+BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/matteius/ingenic-t31-zrt-kernel-4.4.94/releases/download/4.4.latest/mipsel-thingino-linux-musl_sdk-buildroot.tar.gz"
+BR2_TOOLCHAIN_EXTERNAL_HEADERS_4_4=y
 BR2_TOOLCHAIN_EXTERNAL_CUSTOM_MUSL=y
 BR2_TOOLCHAIN_EXTERNAL_CXX=y
 BR2_INSTALL_LIBSTDCPP=y
