### PR TITLE
Add support for Wyze Cam V3 T31X with ATBM6031 Wi-Fi

### DIFF
--- a/configs/cameras/wyze_c3_t31x_atbm
+++ b/configs/cameras/wyze_c3_t31x_atbm
@@ -1,3 +1,4 @@
 # MODULE: t31x_gc2053_atbm6031_defconfig
 FLASH_SIZE_16=y
+U_BOOT_ENV_TXT="$(BR2_EXTERNAL)/environment/wyze-c3-t31x-atbm6031.uenv.txt"
 BR2_SENSOR_PARAMS="sensor_max_fps=30 data_interface=1"

--- a/environment/wyze-c3-t31x-atbm6031.uenv.txt
+++ b/environment/wyze-c3-t31x-atbm6031.uenv.txt
@@ -1,0 +1,15 @@
+gpio_default=18O 38O 39O 47o 48o 49o 50i 51i 52o 53o 59i 62i 63o 25ID 26IDU
+gpio_default_net=48o
+gpio_button=51
+gpio_mmc_power=48o
+gpio_mmc_cd=59
+gpio_wlan=57O
+gpio_ircut=53 52
+gpio_ir850=47
+gpio_ir940=49
+gpio_speaker=63
+wlandev=atbm6031
+wlanssid=thingino
+wlanpass=thingino
+disable_eth=true
+enable_updates=true


### PR DESCRIPTION
Hopefully this will add support for Waze Cam V3 with T31X SoC and the ATBM6031 Wi-Fi chip.