### PR TITLE
ONVIF PTZ improvements

### DIFF
--- a/package/onvif-simple-server/files/onvif.conf
+++ b/package/onvif-simple-server/files/onvif.conf
@@ -32,11 +32,11 @@ type=H264
 #PTZ
 ptz=1
 get_position=motors -p
-move_left=motors -d g -x -50
-move_right=motors -d g -x 50
-move_up=motors -d g -y -50
-move_down=motors -d g -y 50
-move_stop=motors -d s
+move_left=motors -q -d g -x -50
+move_right=motors -q -d g -x 50
+move_up=motors -q -d g -y -50
+move_down=motors -q -d g -y 50
+move_stop=motors -q -d s
 move_preset=/sbin/ptz_preset.sh -m %d
-goto_home_position=motors -d b
+goto_home_position=motors -q -d b
 get_presets=/sbin/ptz_preset.sh -g


### PR DESCRIPTION
Adds get_position command and redirects move_* output to /dev/null to prevent their output being injected as HTTP headers in ONVIF responses.

- The get_position command needs to be supported in order for Frigate (and perhaps other similar systems) to enable PTZ control
- The output of the `move_*` commands gets dumped into the HTTP response (before/in the HTTP headers), which leads to errors being logged by Frigate whenever it requests PTZ moves as it sees them as invalid/malformed headers