### PR TITLE
Remove double quotes in S96onvif

### DIFF
--- a/package/onvif-simple-server/files/S96onvif
+++ b/package/onvif-simple-server/files/S96onvif
@@ -9,7 +9,7 @@ iface=$(awk '($2~/0{8}/&&$3!~/0{8}/){print $1;exit}' /proc/net/route); [ -z "$if
 model=$(awk -F '=' '/^IMAGE_ID=/ {print $2}' /etc/os-release)
 
 # extract iface for daemon from onvif.conf
-DAEMON_ARGS="--if_name $(awk -F= '/^ifs=/{print $2}' /etc/onvif.conf) --xaddr \"http://%s/onvif/device_service\" -m $model -n thingino --pid_file /var/run/$DAEMON_SHORT.pid"
+DAEMON_ARGS="--if_name $(awk -F= '/^ifs=/{print $2}' /etc/onvif.conf) --xaddr http://%s/onvif/device_service -m $model -n thingino --pid_file /var/run/$DAEMON_SHORT.pid"
 
 # read web config, create if missing
 ONVIF_WEBUI_CONF=/etc/webui/onvif.conf


### PR DESCRIPTION
I don't know why but getopt is unable to parse double quotes in this string.
If I run manually the daemon with double quotes it works, but not inside S96onvif.
I removed them, it's not a problem because the string doesn't contain spaces.

This patch fixes ProbeMatches and Hello responses and allows onvif clients to run properly when discovery is used.
