### PR TITLE
Fix ptz aboslute and relative moves

### DIFF
--- a/package/onvif-simple-server/files/S96onvif
+++ b/package/onvif-simple-server/files/S96onvif
@@ -49,6 +49,10 @@ start() {
 		update_config "user" "$(awk -F '"' '/username:/ {print $2}' /etc/prudynt.cfg)"
 		update_config "password" "$(awk -F '"' '/password:/ {print $2}' /etc/prudynt.cfg)"
 		update_config "ptz" "$([ -n "$(fw_printenv -n gpio_motor_h)" ] && echo 1 || echo 0)"
+		update_config "max_step_x" "$(get motor_maxstep_h)"
+		update_config "max_step_y" "$(get motor_maxstep_v)"
+		update_config "move_right" "motors -q -d h -x $(get motor_maxstep_h)"
+		update_config "move_up" "motors -q -d h -y $(get motor_maxstep_v)"
 		sed -i '1i # GENERATED On '"$(date)" /etc/onvif.conf
 	fi
 }

--- a/package/onvif-simple-server/files/onvif.conf
+++ b/package/onvif-simple-server/files/onvif.conf
@@ -31,12 +31,16 @@ type=H264
 
 #PTZ
 ptz=1
+max_step_x=3700
+max_step_y=1000
 get_position=motors -p
-move_left=motors -q -d g -x -50
-move_right=motors -q -d g -x 50
-move_up=motors -q -d g -y -50
-move_down=motors -q -d g -y 50
+move_left=motors -q -d h -x 0
+move_right=motors -q -d h -x 3700
+move_up=motors -q -d h -y 1000
+move_down=motors -q -d h -y 0
 move_stop=motors -q -d s
 move_preset=/sbin/ptz_preset.sh %d
 goto_home_position=motors -q -d b
 get_presets=/sbin/ptz_preset.sh -g
+jump_to_abs=motors -q -d h -x %f -y %f
+jump_to_rel=motors -q -d g -x %f -y %f


### PR DESCRIPTION
This pr adds two parameters to specify the max horizontal and vertical steps used by onvif.
The init script reads them from u-boot env writes them to /etc/onvif.conf
And finally, it sets the shell commands to move the cam using AbsoluteMove and RelativeMove requests.
