### PR TITLE
fix mjpeg.cgi to include Content-Length

### DIFF
--- a/package/thingino-webui/files/var/www/cgi-bin/mjpeg.cgi
+++ b/package/thingino-webui/files/var/www/cgi-bin/mjpeg.cgi
@@ -1,18 +1,18 @@
 #!/bin/sh
 preview=/tmp/snapshot.jpg
-frame="--frame\r\nContent-Type: image/jpeg\r\n\r\n"
+frame="--frame\r\nContent-Type: image/jpeg\r\n"
+endofheader="\r\n"
 echo "HTTP/1.1 200 OK
 Content-Type: multipart/x-mixed-replace; boundary=frame
+Cache-Control: no-cache
 Pragma: no-cache
-Connecton: close
+Connection: close
 "
 
-echo -n -e $frame
-cat $preview
-echo -n -e $frame
 while :; do
-	cat $preview
-	echo -n -e "\r\n\r\n"
 	echo -n -e $frame
+	echo -n -e "Content-Length: "$(stat -c %s ${preview})"\r\n"
+	echo -n -e $endofheader
+	cat $preview
 	sleep 1
 done


### PR DESCRIPTION
- corrected type in Connection: close
- added HTTP/1.1 Cache-Control header
- send Content-Length with each JPEG

- This is how other IP cameras seem to send their MJPEG stream and it made, for instance, the Roku app work.