### PR TITLE
remove unknown sensor param causing issues

### DIFF
--- a/configs/cameras/victure_pc420
+++ b/configs/cameras/victure_pc420
@@ -3,7 +3,7 @@ FLASH_SIZE_8=y
 U_BOOT_ENV_TXT="$(BR2_EXTERNAL)/environment/victure-pc420.uenv.txt"
 BR2_AUDIO=y
 BR2_SDCARD=y
-BR2_SENSOR_PARAMS="sensor_max_fps=25 sensor_gpio_func=0 shvflip=1"
+BR2_SENSOR_PARAMS="sensor_max_fps=25 sensor_gpio_func=0"
 BR2_ISP_CLK_100MHZ=y
 BR2_PACKAGE_THINGINO_KOPT=y
 BR2_PACKAGE_THINGINO_KOPT_MMC=y


### PR DESCRIPTION
This camera/ sensor doesnt like the `SHVFLIP` param and crashes prudynt. It doesnt work anyway so removing it