### PR TITLE
webui: Fix motor cgi parameters for absolute movement

### DIFF
--- a/package/thingino-webui/files/var/www/x/j/motor.cgi
+++ b/package/thingino-webui/files/var/www/x/j/motor.cgi
@@ -14,8 +14,8 @@ case "$d" in
 	r)
 		motors -r >/dev/null
 		;;
-	x)
-		motors -d x -x $x -y $y >/dev/null
+	h)
+		motors -d h -x $x -y $y >/dev/null
 		;;
 esac
 


### PR DESCRIPTION
Summary:
The motor.cgi script accepts an "x" url parameter to command motion. The underlying motors command does not support an x argument, and this parameter has no effect because it hits an error in the cgi script:

```
testcam # motors -d x -x 0 -y 0
Invalid Direction Argument x
Usage : motors -d
	 s (Stop)
	 c (Cruise)
	 b (Go to home position)
	 h (Set position X and Y)
	 g (Steps X and Y)
testcam #
```

The motors command supports an h argument, for commanding movement to absolute coordinates:
```
testcam # motors -d h -x 0 -y 0
testcam #
```

This patch replaces the invalid x parameter with a working h parameter, and plumbs the command through to the motors binary.

Testing:
The motors.cgi file was patched locally on a Cinnado D1 camera via the overlay filesystem. The following URLs successfully pan and tilt the camera to absolute positions:

`http://testcam/x/j/motor.cgi?d=h&x=0&y=0`

`http://testcam/x/j/motor.cgi?d=h&x=3000&y=900`