### PR TITLE
irled: Implement option to read irled state

### DIFF
--- a/overlay/lower/usr/sbin/irled
+++ b/overlay/lower/usr/sbin/irled
@@ -32,6 +32,9 @@ case "$mode" in
 	off | 0)
 		gpio clear $pin > /dev/null
 		;;
+	read)
+		cat /sys/class/gpio/gpio${pin}/value
+		;;
 	~ | toggle)
 		gpio toggle $pin > /dev/null
 		;;


### PR DESCRIPTION
Summary:
Unlike motors and ircut, the irled script lacks a status reporting option. This patch implements a read option.

Although the underlying gpio script has a read function, this patch bypasses that abstraction to read the sys tree directly. This is a measured and intentional tradeoff. Output from the gpio script is decorated with unwanted formatting codes and superfluous data fields, which can't be disabled. As the intended application for this output is another program, clean and simple output is preferred.

This will be plumbed through to a web api in a future patch, pending reflection on the most natural way to mesh that feature with the existing APIs.

The targeted application is an unpublished Android mobile application for viewing and controlling thingino pan-tilt cameras on a local network, which will be open-sourced when ready.

A future submission may implement a clean output mode for the gpio script, and modify this call site to use that abstraction layer.

Testing:
This was tested from the ssh command line on a Cinnado D1 and a WUUK Y0510. In addition to verifying the correct readings, the state changes of the IR led were also verified by inspection.

```
test # irled on
test # irled read
1
test # irled off
test # irled read
0
test # irled read ir850
0
test # irled on ir850
test # irled read ir850
1
test #
```