### PR TITLE
irled: Use gpio script to read led value

### DIFF
--- a/overlay/lower/usr/sbin/gpio
+++ b/overlay/lower/usr/sbin/gpio
@@ -26,6 +26,7 @@ Commands:
 
 	input <pin1>		Set <pin1> as input
 	read <pin1> [<pin2>]	Read values of a range of pins from <pin1> to <pin2>
+        value <pin1>            Read the bare value for a single pin <pin1>
 
 	high <pin1>		Set <pin1> output state to HIGH
 	low <pin1>		Set <pin1> output state to LOW
@@ -310,6 +311,9 @@ case "$1" in
 	get | read)
 		get_pin_value "$2" "$3"
 		;;
+        value)
+                get_only_pin_value "$2"
+                ;;
 	list)
 		[ -z "$(mount | grep /sys/kernel/debug)" ] && mount -t debugfs none /sys/kernel/debug
 		log_and_run "cat /sys/kernel/debug/gpio"

--- a/overlay/lower/usr/sbin/irled
+++ b/overlay/lower/usr/sbin/irled
@@ -33,7 +33,7 @@ case "$mode" in
 		gpio clear $pin > /dev/null
 		;;
 	read)
-		cat /sys/class/gpio/gpio${pin}/value
+		gpio value $pin
 		;;
 	~ | toggle)
 		gpio toggle $pin > /dev/null


### PR DESCRIPTION
Summary:
Add a new value option to the gpio script for retrieving the bare value of a gpio. Use that feature, rather than the /sys/class/gpio tree, to read values in the irled script.

Subsequent testing revealed that the gpio directory for the IR LED pin is not available upon boot. The gpio script provides the logic to export the gpio directory. Using the gpio script abstraction allows for reading the gpio without further concern for initialization state.

Testing:
With the patch, after a reboot, testing irled read:
```
test # irled read
0
test # irled on
test # irled read
1
test #
```

After another reboot, testing gpio value option:
```
test # ls /sys/class/gpio/
export      gpio57      gpio58      gpio8       gpiochip0   gpiochip32  gpiochip64  unexport
test # gpio value 9
0
test #
```

Without the patch, after a reboot, showing prior problem:
```
test # irled read
cat: can't open '/sys/class/gpio/gpio9/value': No such file or directory
test # irled on
test # irled read
1
test #
```