### PR TITLE
DHCP should replace ntp.conf if missing or default but ignore if set by user

### DIFF
--- a/overlay/lower/usr/share/udhcpc/default.script
+++ b/overlay/lower/usr/share/udhcpc/default.script
@@ -74,7 +74,7 @@ case "$1" in
 			echo "nameserver $i" >>$tmpfile
 		done
 		mv $tmpfile $realconf
-		if [ -n "$ntpsrv" ] && { [ ! -f /tmp/ntp.conf ] || [ -w /tmp/ntp.conf ]; }; then
+		if [ -n "$ntpsrv" ] && { [ ! -f /tmp/ntp.conf ] || stat -c%a /tmp/ntp.conf | grep -q '[67]'; }; then
 			echo $ntpsrv | tr ' ' '\n' | sed 's/^/server /; s/$/ iburst	#added by DHCP/' > /tmp/ntp.conf
 			/etc/init.d/S49ntpd reload
 		fi

--- a/overlay/lower/usr/share/udhcpc/default.script
+++ b/overlay/lower/usr/share/udhcpc/default.script
@@ -74,7 +74,7 @@ case "$1" in
 			echo "nameserver $i" >>$tmpfile
 		done
 		mv $tmpfile $realconf
-		if [ -n "$ntpsrv" ] && [ -w /tmp/ntp.conf ]; then
+		if [ -n "$ntpsrv" ] && [ -f /tmp/ntp.conf ] && [ -w /tmp/ntp.conf ]; then
 			echo $ntpsrv | tr ' ' '\n' | sed 's/^/server /; s/$/ iburst	#added by DHCP/' > /tmp/ntp.conf
 			/etc/init.d/S49ntpd reload
 		fi

--- a/overlay/lower/usr/share/udhcpc/default.script
+++ b/overlay/lower/usr/share/udhcpc/default.script
@@ -76,7 +76,7 @@ case "$1" in
 		done
 		mv $tmpfile $realconf
 		cp $NTP_DEFAULT $NTP_CONF
-		if [ -n "$ntpsrv" ] && stat -c%a $NTP_CONF | grep -q '[67]'; then
+		if [ -n "$ntpsrv" ] && [ "$(stat -c%a $NTP_CONF)" != '444' ]; then
 			echo $ntpsrv | tr ' ' '\n' | sed 's/^/server /; s/$/ iburst	#added by DHCP/' > $NTP_CONF
 			/etc/init.d/S49ntpd reload
 		fi

--- a/overlay/lower/usr/share/udhcpc/default.script
+++ b/overlay/lower/usr/share/udhcpc/default.script
@@ -74,7 +74,7 @@ case "$1" in
 			echo "nameserver $i" >>$tmpfile
 		done
 		mv $tmpfile $realconf
-		if [ -n "$ntpsrv" ] && [ -f /tmp/ntp.conf ] && [ -w /tmp/ntp.conf ]; then
+		if [ -n "$ntpsrv" ] && { [ ! -f /tmp/ntp.conf ] || [ -w /tmp/ntp.conf ]; }; then
 			echo $ntpsrv | tr ' ' '\n' | sed 's/^/server /; s/$/ iburst	#added by DHCP/' > /tmp/ntp.conf
 			/etc/init.d/S49ntpd reload
 		fi

--- a/overlay/lower/usr/share/udhcpc/default.script
+++ b/overlay/lower/usr/share/udhcpc/default.script
@@ -2,8 +2,9 @@
 # udhcpc script edited by Tim Riker <Tim@Rikers.org>
 
 [ -z "$1" ] && echo "Error: should be called from udhcpc" && exit 1
-
 RESOLV_CONF="/tmp/resolv.conf"
+NTP_DEFAULT="/etc/default/ntp.conf"
+NTP_CONF="/tmp/ntp.conf"
 
 NETMASK=""
 [ -n "$subnet" ] && NETMASK="/$subnet"
@@ -74,8 +75,9 @@ case "$1" in
 			echo "nameserver $i" >>$tmpfile
 		done
 		mv $tmpfile $realconf
-		if [ -n "$ntpsrv" ] && { [ ! -f /tmp/ntp.conf ] || stat -c%a /tmp/ntp.conf | grep -q '[67]'; }; then
-			echo $ntpsrv | tr ' ' '\n' | sed 's/^/server /; s/$/ iburst	#added by DHCP/' > /tmp/ntp.conf
+		cp $NTP_DEFAULT $NTP_CONF
+		if [ -n "$ntpsrv" ] && stat -c%a $NTP_CONF | grep -q '[67]'; then
+			echo $ntpsrv | tr ' ' '\n' | sed 's/^/server /; s/$/ iburst	#added by DHCP/' > $NTP_CONF
 			/etc/init.d/S49ntpd reload
 		fi
 		;;


### PR DESCRIPTION
On firstboot, or if you delete ntp.conf and reboot or restart dhcp, it should be able to recreate ntp.conf.  Right now it doesn't because on startup ntp.conf doesn't exist.  