### PR TITLE
webui: add CRLF to image.cgi HTTP headers for correct response formatting

### DIFF
--- a/package/thingino-webui/files/var/www/onvif/image.cgi
+++ b/package/thingino-webui/files/var/www/onvif/image.cgi
@@ -1,13 +1,12 @@
 #!/bin/sh
 preview=/tmp/snapshot.jpg
 date=$(TZ=GMT0 date +'%a, %d %b %Y %T %Z')
-echo "HTTP/1.1 200 OK
-Content-type: image/jpeg
-Content-Disposition: attachment; filename=preview-$(date +%s).jpg
-Cache-Control: no-store
-Pragma: no-cache
-Date: $date
-Expires: $date
-Connection: close
-"
+echo -ne "HTTP/1.1 200 OK\r\n\
+Content-type: image/jpeg\r\n\
+Content-Disposition: attachment; filename=preview-$(date +%s).jpg\r\n\
+Cache-Control: no-store\r\n\
+Pragma: no-cache\r\n\
+Date: $date\r\n\
+Expires: $date\r\n\
+Connection: close\r\n\r\n"
 cat $preview

--- a/package/thingino-webui/files/var/www/x/image.cgi
+++ b/package/thingino-webui/files/var/www/x/image.cgi
@@ -1,12 +1,11 @@
 #!/bin/sh
 preview=/tmp/snapshot.jpg
 date=$(TZ=GMT0 date +'%a, %d %b %Y %T %Z')
-echo -n "HTTP/1.1 200 OK
-Content-Disposition: attachment; filename=preview-$(date +%s).jpg
-Cache-Control: no-store
-Pragma: no-cache
-Date: $date
-Expires: $date
-Connection: close
-"
+echo -ne "HTTP/1.1 200 OK\r\n\
+Content-Disposition: attachment; filename=preview-$(date +%s).jpg\r\n\
+Cache-Control: no-store\r\n\
+Pragma: no-cache\r\n\
+Date: $date\r\n\
+Expires: $date\r\n\
+Connection: close\r\n"
 mjpeg_frame $preview


### PR DESCRIPTION
This fixes the following error parsing snapshots using the ONVIF plugin in Scrypted:

```
[Snapshot Plugin]: Snapshot failed, falling back to prebuffer RPCResultError: Parse Error: Invalid header value char
[Snapshot Plugin]:     at Socket.socketOnData (node:_http_client:540:22)
[Snapshot Plugin]:     at Socket.emit (node:events:519:28)
[Snapshot Plugin]:     at Socket.emit (node:domain:488:12)
[Snapshot Plugin]:     at addChunk (node:internal/streams/readable:559:12)
[Snapshot Plugin]:     at readableAddChunkPushByteMode (node:internal/streams/readable:510:3)
[Snapshot Plugin]:     at Socket.Readable.push (node:internal/streams/readable:390:5)
[Snapshot Plugin]:     at TCP.onStreamRead (node:internal/stream_base_commons:191:23)
[Snapshot Plugin]:     at TCP.callbackTrampoline (node:internal/async_hooks:130:17)
[Snapshot Plugin]: @scrypted/onvif:host
[Snapshot Plugin]: host:@scrypted/snapshot {
[Snapshot Plugin]:   cause: undefined
[Snapshot Plugin]: }
```