### PR TITLE
prudynt-t: build faac for AAC audio encoding

### DIFF
--- a/Config.in
+++ b/Config.in
@@ -66,6 +66,7 @@ source "$BR2_EXTERNAL_THINGINO_PATH/package/thingino-live555/Config.in"
 source "$BR2_EXTERNAL_THINGINO_PATH/package/thingino-fonts/Config.in"
 source "$BR2_EXTERNAL_THINGINO_PATH/package/thingino-v4l2loopback/Config.in"
 source "$BR2_EXTERNAL_THINGINO_PATH/package/ingenic-audiodaemon/Config.in"
+source "$BR2_EXTERNAL_THINGINO_PATH/package/faac/Config.in"
 endif
 
 menu "Extra Packages"

--- a/package/faac/0001-reduce-max-channels-save-ram.patch
+++ b/package/faac/0001-reduce-max-channels-save-ram.patch
@@ -1,0 +1,13 @@
+diff --git a/libfaac/coder.h b/libfaac/coder.h
+index ec26a83..28ed06d 100644
+--- a/libfaac/coder.h
++++ b/libfaac/coder.h
+@@ -32,7 +32,7 @@ extern "C" {
+ /* Allow encoding of Digital Radio Mondiale (DRM) with transform length 1024 */
+ //#define DRM_1024
+ 
+-#define MAX_CHANNELS 64
++#define MAX_CHANNELS 1
+ 
+ #ifdef DRM
+ #ifdef DRM_1024

--- a/package/faac/Config.in
+++ b/package/faac/Config.in
@@ -1,0 +1,6 @@
+config BR2_PACKAGE_FAAC
+	bool "Freeware Advanced Audio Coder"
+	help
+	  FAAC is an open-source MPEG-2 and MPEG-4 AAC audio format encoder.
+
+	  http://sourceforge.net/projects/faac/

--- a/package/faac/faac.mk
+++ b/package/faac/faac.mk
@@ -1,0 +1,48 @@
+FAAC_SITE_METHOD = git
+FAAC_SITE = https://github.com/knik0/faac
+FAAC_SITE_BRANCH = master
+FAAC_VERSION = $(shell git ls-remote $(FAAC_SITE) $(FAAC_SITE_BRANCH) | head -1 | cut -f1)
+
+FAAC_LICENSE = MPEG-4-Reference-Code, LGPL-2.1+
+FAAC_LICENSE_FILES = COPYING
+
+FAAC_INSTALL_STAGING = YES
+FAAC_INSTALL_TARGET = YES
+
+FAAC_AUTORECONF = YES
+FAAC_DEPENDENCIES += host-pkgconf host-libtool
+
+FAAC_CONF_OPTS = --prefix=/usr --enable-shared --disable-static
+
+FAAC_CONF_ENV = PKG_CONFIG="$(PKG_CONFIG_HOST_BINARY)"
+
+define FAAC_CONFIGURE_CMDS
+	(cd $(FAAC_SRCDIR) && rm -rf config.cache && \
+	$(TARGET_CONFIGURE_OPTS) \
+	$(TARGET_CONFIGURE_ARGS) \
+	$(FAAC_CONF_ENV) \
+	./configure \
+		--host=$(GNU_TARGET_NAME) \
+		--build=$(GNU_HOST_NAME) \
+		--target=$(GNU_TARGET_NAME) \
+		$(FAAC_CONF_OPTS) \
+	)
+endef
+
+define FAAC_INSTALL_TARGET_CMDS
+	$(INSTALL) -m 0755 -d $(TARGET_DIR)/usr/lib
+	$(INSTALL) -m 0755 -D $(@D)/libfaac/.libs/libfaac.so.0.0.0 $(TARGET_DIR)/usr/lib/
+	ln -sf libfaac.so.0.0.0 $(TARGET_DIR)/usr/lib/libfaac.so.0
+	ln -sf libfaac.so.0.0.0 $(TARGET_DIR)/usr/lib/libfaac.so
+endef
+
+define FAAC_INSTALL_STAGING_CMDS
+	$(INSTALL) -m 0755 -D $(@D)/libfaac/.libs/libfaac.so.0.0.0 $(STAGING_DIR)/usr/lib/
+	ln -sf libfaac.so.0.0.0 $(STAGING_DIR)/usr/lib/libfaac.so.0
+	ln -sf libfaac.so.0.0.0 $(STAGING_DIR)/usr/lib/libfaac.so
+	$(INSTALL) -m 0644 -D $(@D)/include/faac.h $(STAGING_DIR)/usr/include/faac.h
+	$(INSTALL) -m 0644 -D $(@D)/include/faaccfg.h $(STAGING_DIR)/usr/include/faaccfg.h
+endef
+
+$(eval $(autotools-package))
+$(eval $(host-autotools-package))

--- a/package/prudynt-t/Config.in
+++ b/package/prudynt-t/Config.in
@@ -8,6 +8,7 @@ config BR2_PACKAGE_PRUDYNT_T
 	select BR2_PACKAGE_THINGINO_FREETYPE if !BR2_PACKAGE_PRUDYNT_T_NG
 	select BR2_PACKAGE_THINGINO_FONTS
 	select BR2_PACKAGE_OPUS
+	select BR2_PACKAGE_FAAC
 	help
 	  Video streamer for Ingenic T-series.
 

--- a/package/prudynt-t/prudynt-t.mk
+++ b/package/prudynt-t/prudynt-t.mk
@@ -8,7 +8,7 @@ PRUDYNT_T_SITE_BRANCH = prudynt-t-old
 endif
 PRUDYNT_T_VERSION = $(shell git ls-remote $(PRUDYNT_T_SITE) $(PRUDYNT_T_SITE_BRANCH) | head -1 | cut -f1)
 
-PRUDYNT_T_DEPENDENCIES = libconfig thingino-live555 thingino-fonts ingenic-lib opus
+PRUDYNT_T_DEPENDENCIES = libconfig thingino-live555 thingino-fonts ingenic-lib faac opus
 ifeq ($(BR2_PACKAGE_PRUDYNT_T_NG),y)
 PRUDYNT_T_DEPENDENCIES += libwebsockets libschrift
 else


### PR DESCRIPTION
Accompanying buildroot PR for Prudynt-T to support AAC encoding and save on bandwidth: https://github.com/gtxaspec/prudynt-t/pull/25

This replaces https://github.com/themactep/thingino-firmware/pull/180