### PR TITLE
prudynt-t: add device preset audio configurations

### DIFF
--- a/package/prudynt-t/files/configs/wyze_c3_t31al_atbm
+++ b/package/prudynt-t/files/configs/wyze_c3_t31al_atbm
@@ -1,0 +1,10 @@
+audio: {
+	input_high_pass_filter: true;
+	input_agc_enabled: true;
+	input_vol: 120;
+	input_gain: 30;
+	input_alc_gain: 7;
+	input_agc_target_level_dbfs: 30;
+	input_agc_compression_gain_db: 70;
+	input_noise_suppression: 3;
+};

--- a/package/prudynt-t/files/configs/wyze_c3_t31x_atbm
+++ b/package/prudynt-t/files/configs/wyze_c3_t31x_atbm
@@ -1,0 +1,10 @@
+audio: {
+	input_high_pass_filter: true;
+	input_agc_enabled: true;
+	input_vol: 120;
+	input_gain: 30;
+	input_alc_gain: 7;
+	input_agc_target_level_dbfs: 30;
+	input_agc_compression_gain_db: 70;
+	input_noise_suppression: 3;
+};

--- a/package/prudynt-t/files/configs/wyze_c3_t31x_rtl
+++ b/package/prudynt-t/files/configs/wyze_c3_t31x_rtl
@@ -1,0 +1,10 @@
+audio: {
+	input_high_pass_filter: true;
+	input_agc_enabled: true;
+	input_vol: 120;
+	input_gain: 30;
+	input_alc_gain: 7;
+	input_agc_target_level_dbfs: 30;
+	input_agc_compression_gain_db: 70;
+	input_noise_suppression: 3;
+};

--- a/package/prudynt-t/files/device_presets
+++ b/package/prudynt-t/files/device_presets
@@ -1,0 +1,90 @@
+#!/usr/bin/awk -f
+
+# Function to trim leading and trailing whitespace from a string
+function trim(s) {
+	gsub(/^[[:space:]]+|[[:space:]]+$/, "", s)
+	return s
+}
+
+# Function to handle going down a level
+function goDownLevel(level, line) {
+	gsub(/:[[:space:]]*{[[:space:]]*$/, "", line)
+	level = (level ? level "." : "") line
+	return level
+}
+
+# Function to handle going up a level
+function goUpLevel(level) {
+	split(level, keyArray, ".")
+	return (length(keyArray) > 1 ? substr(level, 1, length(level) - length(keyArray[length(keyArray)]) - 1) : "")
+}
+
+BEGIN {
+	# Check for the correct number of arguments
+	if (ARGC != 3) {
+		print "Usage: " ARGV[0] " <device_config_file> <global_config_file>"
+		exit 1
+	}
+
+	deviceFile = ARGV[1]
+	globalFile = ARGV[2]
+
+	# Track key-value pairs from device config
+	level = ""
+	while ((getline < deviceFile) > 0) {
+		line = trim($0)
+
+		# Handle nested objects
+		if (line ~ /[[:space:]]*{[[:space:]]*$/) {
+			level = goDownLevel(level, line)
+		} else if (line ~ /^[[:space:]]*}/) {
+			level = goUpLevel(level)
+		} else if (line ~ /^[^[:space:]]+:[[:space:]]*[^[:space:]]+/) {
+			split(line, kv, ":")
+			key = trim(kv[1])
+			value = trim(kv[2])
+			keyPath = (level ? level "." : "") key
+			config[keyPath] = value
+		}
+	}
+	close(deviceFile)
+
+	# Process global config with substitutions
+	level = ""
+	while ((getline < globalFile) > 0) {
+		line = $0
+		leading_whitespace = ""
+
+		# Capture leading whitespace
+		match(line, /^[[:space:]]*/)
+		leading_whitespace = substr(line, RSTART, RLENGTH)
+
+		# Strip whitespace and leading comments
+		clean = trim(line)
+		gsub(/^#[[:space:]]*/, "", clean)
+
+		# Handle nested objects
+		if (clean ~ /[[:space:]]*{[[:space:]]*$/) {
+			level = goDownLevel(level, clean)
+		} else if (clean ~ /^[[:space:]]*}/) {
+			level = goUpLevel(level)
+		} else if (clean ~ /^[^[:space:]]+:[[:space:]]*[^[:space:]]+/) {
+			split(clean, kv, ":")
+			key = trim(kv[1])
+			value = trim(kv[2])
+			keyPath = (level ? level "." : "") key
+
+			# Perform substitution if key exists in the device config
+			if (keyPath in config) {
+				sub(/:[[:space:]]*[^[:space:]]+/, ": " config[keyPath], line)
+
+				# Remove leading comment from the line
+				gsub(/^[[:space:]]*#[[:space:]]*/, leading_whitespace, line)
+			}
+		}
+
+		# Print the line with leading whitespace preserved
+		print line
+	}
+	close(globalFile)
+}

--- a/package/prudynt-t/prudynt-t.mk
+++ b/package/prudynt-t/prudynt-t.mk
@@ -51,7 +51,10 @@ endef
 
 define PRUDYNT_T_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 0755 -D $(@D)/bin/prudynt $(TARGET_DIR)/usr/bin/prudynt
-	$(INSTALL) -m 0644 -D $(@D)/prudynt.cfg.example $(TARGET_DIR)/etc/prudynt.cfg
+	awk -f $(PRUDYNT_T_PKGDIR)/files/device_presets \
+		$(PRUDYNT_T_PKGDIR)/files/configs/$(shell awk 'BEGIN {split("$(BR2_CONFIG)", a, "/"); print a[length(a)-1]}') \
+		$(@D)/prudynt.cfg.example > $(STAGING_DIR)/prudynt.cfg
+	$(INSTALL) -m 0644 -D $(STAGING_DIR)/prudynt.cfg $(TARGET_DIR)/etc/prudynt.cfg
 	sed -i 's/;.*$$/;/' $(TARGET_DIR)/etc/prudynt.cfg
 	$(INSTALL) -m 0755 -D $(PRUDYNT_T_PKGDIR)/files/S95prudynt $(TARGET_DIR)/etc/init.d/S95prudynt
 	$(INSTALL) -m 0755 -D $(PRUDYNT_T_PKGDIR)/files/S96record $(TARGET_DIR)/etc/init.d/S96record


### PR DESCRIPTION
This adds a nice go-to-market feature of audio defaults per camera device so it can be plug-and-play as much as possible versus stock firmwares. I only own Wyze V3 cameras so I'll be adding those for now. Anyone else can add their own defaults to the directory and the script will pick it up.

This isn't exclusive to audio, we can also tweak any other setting in prudynt-t per-device.