### PR TITLE
web-ui to configure wireguard, and associated startup script

### DIFF
--- a/overlay/lower/etc/init.d/S42wireguard
+++ b/overlay/lower/etc/init.d/S42wireguard
@@ -1,0 +1,75 @@
+#!/bin/sh
+
+. /etc/init.d/rc.common
+
+DEV="wg0"
+IP="$(get wg_address)"
+RESOLV_CONF="/tmp/resolv.conf"
+RESOLV_BAK="${RESOLV_CONF}.bak"
+
+case "$1" in
+	force | start)
+		# "force" is for testing, to start wireguard on demand without having it enabled at boot
+		[ "xtrue" = "x$(get wg_enabled)" -o "force" = "$1" ] || die "WireGuard not enabled"
+		ip link show $DEV 2>&1 | grep -q 'UP' && die "WireGuard interface $DEV already running"
+
+		starting
+		rm -f /tmp/wgconf_*
+		wgconf=$(mktemp /tmp/wgconf_XXXXXX)
+
+		echo '[Interface]' >> $wgconf
+		echo "PrivateKey=$(get wg_privkey)" >> $wgconf
+		v=$(get wg_port) ; if [ -n "$v" ] ; then echo "ListenPort=${v}" >> $wgconf ; fi
+
+		echo '[Peer]' >> $wgconf
+		echo "Endpoint=$(get wg_endpoint)" >> $wgconf
+		echo "PublicKey=$(get wg_peerpub)" >> $wgconf
+
+		v=$(get wg_peerpsk) ; if [ -n "$v" ] ; then echo "PresharedKey=${v}" >> $wgconf ; fi
+		v=$(get wg_allowed) ; if [ -n "$v" ] ; then echo "AllowedIPs=${v}" >> $wgconf ; fi
+		v=$(get wg_keepalive) ; if [ -n "$v" ] ; then echo "PersistentKeepalive=${v}" >> $wgconf ; fi
+
+		mtu=$(get wg_mtu) ; if [ -n "$mtu" ] ; then link_mtu="mtu ${mtu}" ; fi
+		run "ip link add dev $DEV type wireguard"
+		run "wg setconf $DEV $wgconf"
+		run "ip address add ${IP} dev $DEV"
+		run "ip link set $link_mtu up dev $DEV"
+
+		DNS=$(get wg_dns)
+		if [ -n "$DNS" ] ; then
+			resolv_tmp=$(mktemp)
+			grep -v nameserver $RESOLV_CONF >> $resolv_tmp
+			for x in $(echo $DNS | tr "," " ") ; do
+				echo "nameserver $x" >> $resolv_tmp
+			done
+			mv $RESOLV_CONF $RESOLV_BAK
+			mv $resolv_tmp $RESOLV_CONF
+		fi
+
+		for r in $(get wg_allowed | tr "," " ") ; do
+			run "ip route add $r dev $DEV"
+		done
+
+		true
+		check_result
+		;;
+
+	stop)
+		stopping
+		for r in $(ip route | awk '/dev wg/{print $1}') ; do
+			run "route del $r dev $DEV"
+		done
+		run "ip link set down $DEV"
+		[ -n "$IP" ] && run "ip address del $IP dev $DEV"
+		[ -s $RESOLV_BAK ] && mv $RESOLV_BAK $RESOLV_CONF
+
+		true
+		check_result
+		;;
+
+	*)
+		die "Usage: $0 {force|start|stop}"
+		;;
+esac
+
+exit 0

--- a/package/thingino-webui/files/var/www/x/config-wireguard.cgi
+++ b/package/thingino-webui/files/var/www/x/config-wireguard.cgi
@@ -1,0 +1,65 @@
+#!/bin/haserl
+<%in _common.cgi %>
+<%
+plugin="wireguard"
+page_title="WireGuard"
+
+[ -f /bin/wg ] || redirect_to "/" "danger" "Your camera does not seem to support WireGuard"
+
+wg_address=$(get wg_address)
+wg_allowed=$(get wg_allowed)
+wg_dns=$(get wg_dns)
+wg_enabled=$(get wg_enabled)
+wg_endpoint=$(get wg_endpoint)
+wg_keepalive=$(get wg_keepalive)
+wg_mtu=$(get wg_mtu)
+wg_peerpsk=$(get wg_peerpsk)
+wg_peerpub=$(get wg_peerpub)
+wg_port=$(get wg_port)
+wg_privkey=$(get wg_privkey)
+
+
+if [ "POST" = "$REQUEST_METHOD" ]; then
+	if [ "wgconfig" = "$POST_action" ] ; then
+	 	rm -f /tmp/wg_env_*
+		wg_env_script=$(mktemp wg_env_XXXXXX)
+		for k in address allowed dns enabled endpoint keepalive mtu peerpsk peerpub port privkey; do
+			eval echo wg_$k \$POST_wg_$k >> $wg_env_script
+		done
+		fw_setenv -s $wg_env_script
+	fi
+	redirect_to $SCRIPT_NAME
+fi
+%>
+
+<%in _header.cgi %>
+
+<div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mb-4">
+	<div class="col">
+		<form action="<%= $SCRIPT_NAME %>" method="post">
+		<h3>Interface Settings</h3>
+		<% field_hidden "action" "wgconfig" %>
+		<% field_password "wg_privkey" "Private Key" %>
+		<% field_password "wg_peerpsk" "Pre-Shared Key" %>
+		<% field_text "wg_address" "Address" %>
+		<% field_text "wg_port" "Listen Port" %>
+		<% field_text "wg_dns" "DNS" %>
+		<% field_switch "wg_enabled" "Enable WireGuard" %>
+	</div>
+	<div class="col">
+		<h3>Peer Settings</h3>
+		<% field_text "wg_endpoint" "Endpoint host:port" %>
+		<% field_text "wg_peerpub" "Peer Public Key" %>
+		<% field_text "wg_mtu" "MTU" %>
+		<% field_text "wg_keepalive" "Persistent Keepalive" %>
+		<% field_text "wg_allowed" "Allowed CIDRs" %>
+		<% button_submit %>
+		</form>
+	</div>
+	<div class="col">
+		<h3>Environment Settings</h3>
+		<% ex "fw_printenv | grep -E '^wg_' | sed -Ee 's/(key|psk)=.*$/\1=[__redacted__]/' | sort" %>
+	</div>
+</div>
+
+<%in _footer.cgi %>


### PR DESCRIPTION
Added a web-ui for WireGuard. Only handles simple cases, but this works well enough for me to have a remote camera behind a NAT somewhere, connecting back to my VPN where it can then be contacted by my NVR.

![wg_gui](https://github.com/user-attachments/assets/e31d409c-28fc-4c99-9de5-44e79aff784b)

