### PR TITLE
allow wireguard page to start/stop the tunnel

### DIFF
--- a/package/thingino-webui/files/var/www/x/config-wireguard.cgi
+++ b/package/thingino-webui/files/var/www/x/config-wireguard.cgi
@@ -75,7 +75,7 @@ fi
 	</div>
 	<div class="col">
 		<h3>Environment Settings</h3>
-		<% ex "fw_printenv | grep '^wg_' | sed -Ee 's/(key|psk)=.*$/\1=[__redacted__]/'" %>
+		<% ex "fw_printenv | grep '^wg_' | sed -Ee 's/(key|psk)=.*$/\1=[__redacted__]/' | sort" %>
 		<% ex "wg show $WG_DEV 2>&1 | grep -A 5 endpoint" %>
 		<form action="<%= $SCRIPT_NAME %>" method="post">
 		<% field_hidden "action" "startstop" %>


### PR DESCRIPTION
There's a panel showing tunnel state, and a Big Red Switch to control the tunnel state on demand - no reboot required.

Removed some unnecessary stuff (`-E` and `sort`) from the environment output.

![wg_gui2](https://github.com/user-attachments/assets/ac77a78c-0380-40a1-9e68-4b9ef37d064a)
