### PR TITLE
Fix HTTP header line termination in file browser and dl2.cgi

### DIFF
--- a/package/thingino-webui/files/var/www/x/dl2.cgi
+++ b/package/thingino-webui/files/var/www/x/dl2.cgi
@@ -25,14 +25,14 @@ case "$log" in
 		;;
 esac
 check_file_exist $file
-echo -en "HTTP/1.0 200 OK\r\n
-Date: $(time_http)\r\n
-Server: $SERVER_SOFTWARE\r\n
-Content-type: text/plain\r\n
-Content-Disposition: attachment; filename=${log}-$(date +%s).txt\r\n
-Content-Length: $(stat -c%s $file)\r\n
-Cache-Control: no-store\r\n
-Pragma: no-cache\r\n
+echo -en "HTTP/1.0 200 OK\r\n\
+Date: $(time_http)\r\n\
+Server: $SERVER_SOFTWARE\r\n\
+Content-type: text/plain\r\n\
+Content-Disposition: attachment; filename=${log}-$(date +%s).txt\r\n\
+Content-Length: $(stat -c%s $file)\r\n\
+Cache-Control: no-store\r\n\
+Pragma: no-cache\r\n\
 \r\n"
 cat $file
 rm $file

--- a/package/thingino-webui/files/var/www/x/tool-file-manager.cgi
+++ b/package/thingino-webui/files/var/www/x/tool-file-manager.cgi
@@ -6,15 +6,15 @@ page_title="File Manager"
 if [ -n "$GET_dl" ]; then
 	file=$GET_dl
 	check_file_exist $file
-	echo "HTTP/1.0 200 OK
-Date: $(time_http)
-Server: $SERVER_SOFTWARE
-Content-type: application/octet-stream
-Content-Disposition: attachment; filename=$(basename $file)
-Content-Length: $(stat -c%s $file)
-Cache-Control: no-store
-Pragma: no-cache
-"
+	echo -en "HTTP/1.0 200 OK\r\n\
+Date: $(time_http)\r\n\
+Server: $SERVER_SOFTWARE\r\n\
+Content-type: application/octet-stream\r\n\
+Content-Disposition: attachment; filename=$(basename $file)\r\n\
+Content-Length: $(stat -c%s $file)\r\n\
+Cache-Control: no-store\r\n\
+Pragma: no-cache\r\n\
+\r\n"
 	cat $file
 	redirect_to $SCRIPT_NAME
 fi


### PR DESCRIPTION
Brings dl2.cgi and tool-file-manager.cgi into compliance with the HTTP specification by terminating headers with CR+LF instead of only LF.

The unescaped newlines in dl2.cgi caused headers to be interpreted as part of the body.
The use of only newlines in tool-file-manager.cgi while non conformant, did not cause any user visible issues but I thought I would keep the code consistent.

Tested with,
make rebuild-thingino-webui
make clean all
