### PR TITLE
Add motor_speed env var to S09motor and webui

### DIFF
--- a/package/motors/files/S09motor
+++ b/package/motors/files/S09motor
@@ -57,7 +57,7 @@ start() {
 	[ -z "$motor_maxstep_v" ] && die " Tilt motor Steps are not set"
 	[ -z "$motor_speed"     ] && motor_speed=900
 
-	[ "$gpio_motor_invert" == "true" ] && gpio_motor_invert_opt="invert_gpio_dir=1"
+	[ "$gpio_motor_invert" = "true" ] && gpio_motor_invert_opt="invert_gpio_dir=1"
 
 	if grep -qE "^motor" /proc/modules; then
 		info "Module motor already loaded."
@@ -78,7 +78,7 @@ start() {
 	# FIXME: daemon should be reporting running state from the very first moment
 	sleep 1
 
-  set_motors_speed $motor_speed
+	set_motors_speed $motor_speed
 
 	if [ "true" = "$(get disable_homing)" ]; then
 		warn "Homing disabled"

--- a/package/motors/files/S09motor
+++ b/package/motors/files/S09motor
@@ -20,6 +20,11 @@ home_motors() {
 	motors -r > /dev/null 2>&1
 }
 
+set_motors_speed() {
+	info "Set motors speed to $motor_speed"
+	motors -s $1 > /dev/null 2>&1
+}
+
 position_motors() {
 	local x=$((motor_maxstep_h / 2))
 	local y=$((motor_maxstep_v / 2))
@@ -42,6 +47,7 @@ start() {
 	gpio_motor_invert=$(fw_printenv -n gpio_motor_invert)
 	motor_maxstep_h=$(fw_printenv -n motor_maxstep_h)
 	motor_maxstep_v=$(fw_printenv -n motor_maxstep_v)
+	motor_speed=$(fw_printenv -n motor_speed)
 
 	# Check if motors are supported
 	[ -z "$motors_app"      ] && die " No motors app found"
@@ -49,6 +55,7 @@ start() {
 	[ -z "$gpio_motor_v"    ] && die " Tilt motor GPIO pins are not set"
 	[ -z "$motor_maxstep_h" ] && die " Pan motor Steps are not set"
 	[ -z "$motor_maxstep_v" ] && die " Tilt motor Steps are not set"
+	[ -z "$motor_speed"     ] && motor_speed=900
 
 	[ "$gpio_motor_invert" == "true" ] && gpio_motor_invert_opt="invert_gpio_dir=1"
 
@@ -70,6 +77,8 @@ start() {
 	start_daemon
 	# FIXME: daemon should be reporting running state from the very first moment
 	sleep 1
+
+  set_motors_speed $motor_speed
 
 	if [ "true" = "$(get disable_homing)" ]; then
 		warn "Homing disabled"

--- a/package/thingino-webui/files/var/www/x/config-motors.cgi
+++ b/package/thingino-webui/files/var/www/x/config-motors.cgi
@@ -13,6 +13,7 @@ gpio_motor_v=$(get gpio_motor_v)
 motor_maxstep_h=$(get motor_maxstep_h)
 motor_maxstep_v=$(get motor_maxstep_v)
 motor_pos_0=$(get motor_pos_0)
+motor_speed=$(get motor_speed)
 
 # parse
 gpio_motor_h_1=$(echo $gpio_motor_h | awk '{print $1}')
@@ -46,6 +47,7 @@ if [ "POST" = "$REQUEST_METHOD" ]; then
 	disable_homing=$POST_disable_homing
 	motor_pos_0_x=$POST_motor_pos_0_x
 	motor_pos_0_y=$POST_motor_pos_0_y
+	motor_speed=$POST_motor_speed
 
 	# validate
 	if [ -z "$gpio_motor_h_1" ] || [ -z "$gpio_motor_h_2" ] || [ -z "$gpio_motor_h_3" ] || [ -z "$gpio_motor_h_4" ] || \
@@ -68,6 +70,10 @@ if [ "POST" = "$REQUEST_METHOD" ]; then
 			motor_pos_0=""
 		fi
 
+		if [ -z "$motor_speed" ]; then
+			motor_speed=900
+		fi
+
 		# save to env
 		tmpfile=$(mktemp -u)
 		{
@@ -77,6 +83,7 @@ if [ "POST" = "$REQUEST_METHOD" ]; then
 			echo "motor_maxstep_v $motor_maxstep_v"
 			echo "disable_homing $disable_homing"
 			echo "motor_pos_0 $motor_pos_0"
+			echo "motor_speed $motor_speed"
 		} > $tmpfile
 		fw_setenv -s $tmpfile
 		rm $tmpfile
@@ -104,6 +111,11 @@ fi
 		<div class="col"><% field_number "gpio_motor_v_2" "pin 2"%></div>
 		<div class="col"><% field_number "gpio_motor_v_3" "pin 3"%></div>
 		<div class="col"><% field_number "gpio_motor_v_4" "pin 4"%></div>
+	</div>
+
+  <h5>Motor Speed</h5>
+	<div class="row mb-1">
+		<div class="col"><% field_number "motor_speed" "speed"%></div>
 	</div>
 </div>
 <div class="col">
@@ -134,6 +146,7 @@ motor_maxstep_h: <%= $motor_maxstep_h %>
 motor_maxstep_v: <%= $motor_maxstep_v %>
 disable_homing: <%= $disable_homing %>
 motor_pos_0: <%= $motor_pos_0 %>
+motor_speed: <%= $motor_speed %>
 </pre>
 </div>
 </div>

--- a/package/thingino-webui/files/var/www/x/config-motors.cgi
+++ b/package/thingino-webui/files/var/www/x/config-motors.cgi
@@ -113,7 +113,7 @@ fi
 		<div class="col"><% field_number "gpio_motor_v_4" "pin 4"%></div>
 	</div>
 
-  <h5>Motor Speed</h5>
+	<h5>Motor Speed</h5>
 	<div class="row mb-1">
 		<div class="col"><% field_number "motor_speed" "speed"%></div>
 	</div>


### PR DESCRIPTION
Creates a new uboot env var `motor_speed` that sets the default motor speed for PTZ.
The webui is updated to allow viewing and modifying this value.
If no speed is specified, the S09motor init script uses 900 as the default.

Closes #225