### PR TITLE
webui: fix (undefined, undefined) motor position in preview

### DIFF
--- a/package/thingino-webui/files/var/www/x/_motors.cgi
+++ b/package/thingino-webui/files/var/www/x/_motors.cgi
@@ -18,8 +18,8 @@
 function runMotorCmd(args) {
 	fetch(`/x/json-motor.cgi?${args}`)
 	.then(res => res.json())
-	.then(({message}) => {
-		$('#ptzpos').textContent = message.xpos + "," + message.ypos;
+	.then(({message: {xpos, ypos}}) => {
+		$('#ptzpos').textContent = xpos + "," + ypos;
 	});
 }
 


### PR DESCRIPTION
The destructuring assignment to xpos and ypos overlooked their nesting within the message key.