### PR TITLE
webui: wrap `format, mode, input_format` in quotes

### DIFF
--- a/package/thingino-webui/files/var/www/x/config-prudynt.cgi
+++ b/package/thingino-webui/files/var/www/x/config-prudynt.cgi
@@ -161,7 +161,7 @@ function saveValue(domain, name) {
 		value = el.value;
 		if (name == "height" || name == "width") {
 			value = value &~ 15;
-		} else if (name == "format") {
+		} else if (["format", "mode", "input_format"].indexOf(name) !== -1) {
 			value = `"${value}"`;
 		}
 	}


### PR DESCRIPTION
Currently `mode` and `input_format` through errors when changing the values, this prevents stream Mode and audio Codec from being changed.

This PR wraps the `format, mode, input_format` fields in quotes to send a valid string in the json payload to the Web socket.