### PR TITLE
webui: fix `config-prudynt.cgi` saving config to file

### DIFF
--- a/package/thingino-webui/files/var/www/x/config-prudynt.cgi
+++ b/package/thingino-webui/files/var/www/x/config-prudynt.cgi
@@ -173,7 +173,7 @@ function saveValue(domain, name) {
 		thread = ThreadAudio;
 	}
 
-	sendToWs(`{"${domain}":{"${name}":${value}}},"action":{"save_config":null,"restart_thread":${thread}}`);
+	sendToWs(`{"${domain}":{"${name}":${value}},"action":{"save_config":null,"restart_thread":${thread}}`);
 }
 
 for (const i in [0, 1]) {


### PR DESCRIPTION
Currently any changes made from the WEBUI on `config-prudynt.cgi` are not saved to the `prudynt.cfg` file.

This is caused by a extra curly brace in the json payload, removing this extra curly brace allows `save_config` action to be called and save the changes to the `prudynt.cfg` file.