### PR TITLE
prudynt.cfg contains a mix of k:v and k=v, support both fmts

### DIFF
--- a/package/prudynt-t/files/S96record
+++ b/package/prudynt-t/files/S96record
@@ -5,7 +5,7 @@ DAEMON=openRTSP
 . /etc/init.d/rc.common
 
 read_config() {
-	sed -nE "s/^.*$1:\s*\"?([^\"]+)\"?;.*$/\1/p" /etc/prudynt.cfg | head -1
+	sed -nE "s/^.*$1\s*[:=]\s*\"?([^\"]+)\"?;.*$/\1/p" /etc/prudynt.cfg | head -1
 }
 
 # Get values from /etc/prudynt.cfg


### PR DESCRIPTION
prudynt.cfg contains a mix of both
key: value
and
key = value

support both formats, with optional whitespace before and after separator, as they seem to be added by prudynt upon parameter update

fixes #220 