### PR TITLE
ntp: use worldwide auto-localized ntp pool from ntppool.org

### DIFF
--- a/overlay/lower/etc/default/ntp.conf
+++ b/overlay/lower/etc/default/ntp.conf
@@ -1,3 +1,4 @@
-server clock.sjc.he.net iburst
-server clock.fmt.he.net iburst
-server clock.nyc.he.net iburst
+server 0.pool.ntp.org iburst
+server 1.pool.ntp.org iburst
+server 2.pool.ntp.org iburst
+server 3.pool.ntp.org iburst


### PR DESCRIPTION
Current ntp pool *.he.net has ping delays of 100-200ms from asia/europe.
Replace with auto-localized global pool, just like openwrt project.
With *.pool.ntp.org, ping roundtrip drop to a reasonable 2-5msec.