### PR TITLE
ntp: create /tmp/sync_status when ntp is synchronized + webui

### DIFF
--- a/overlay/lower/etc/init.d/S49ntpd
+++ b/overlay/lower/etc/init.d/S49ntpd
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-DAEMON_ARGS="-n"
+DAEMON_ARGS="-n -S /etc/ntpd_callback"
 
 DEF_CONF="/etc/default/ntp.conf"
 TMP_CONF="/tmp/ntp.conf"

--- a/overlay/lower/etc/ntpd_callback
+++ b/overlay/lower/etc/ntpd_callback
@@ -1,0 +1,6 @@
+#!/bin/sh
+# This script is called internally by ntpq when time synchronization updated, dont run it yourself
+
+SYNC_STATUS="/tmp/sync_status"
+
+echo -e "$1\nfreq_drift_ppm=$freq_drift_ppm\noffset=$offset\nstratum=$stratum\npoll_interval=$poll_interval" > $SYNC_STATUS

--- a/package/thingino-webui/files/var/www/x/config-time.cgi
+++ b/package/thingino-webui/files/var/www/x/config-time.cgi
@@ -9,6 +9,7 @@ config_file="$ui_config_dir/$plugin.conf"
 
 ntpd_static_config=/etc/default/ntp.conf
 ntpd_working_config=/tmp/ntp.conf
+ntpd_sync_status=/tmp/sync_status
 seq=$(seq 0 3)
 
 if [ "POST" = "$REQUEST_METHOD" ]; then
@@ -85,6 +86,7 @@ done; unset i; unset x
 <% ex "echo \$TZ" %>
 <% ex "cat $ntpd_working_config" %>
 <% ex "cat $ntpd_static_config" %>
+<% ex "cat $ntpd_sync_status" %>
 <p id="sync-time-wrapper"><a href="#" id="sync-time">Sync time</a></p>
 </div>
 </div>


### PR DESCRIPTION
Add a file /tmp/sync_status that signals that ntp time is synchronized.

Scripts that depend on synchronized time, for example writing files with correct timestamps, can wait for existence of the file using:

```
#!/bin/sh

# wait for time synchronization:

while [ ! -e "/tmp/sync_status" ]; do
    sleep 1;
done

echo "time synchronized! proceeding..."
```

Added also current sync status in config-time web ui:

![screenshot_time](https://github.com/user-attachments/assets/107cfd05-bcc7-4de2-afaf-fa72a72575a9)
