### PR TITLE
automount: mount sdcard with noatime

### DIFF
--- a/overlay/lower/usr/lib/mdev/automount
+++ b/overlay/lower/usr/lib/mdev/automount
@@ -60,7 +60,7 @@ do_mount() {
 
 #	do_fsck || return 1
 
-	if mount -t auto -o sync "$devicenode" "$mountpoint"; then
+	if mount -t auto -o noatime,sync "$devicenode" "$mountpoint"; then
 		log "Mounted $devicenode to $mountpoint mountpoint."
 	else
 		log "Failed to mount $devicenode to $mountpoint mountpoint."


### PR DESCRIPTION
```
# mount | grep mmc

before:
/dev/mmcblk0p1 on /mnt/mmcblk0p1 type exfat (rw,sync,relatime,fmask=0000,dmask=0000,allow_utime=0022,namecase=0,errors=remount-ro)

after:
/dev/mmcblk0p1 on /mnt/mmcblk0p1 type exfat (rw,sync,noatime,fmask=0000,dmask=0000,allow_utime=0022,namecase=0,errors=remount-ro)
```