### PR TITLE
Update onvif_simple_server to the last commit

### DIFF
--- a/package/onvif-simple-server/0002-change-config-file-and-dir-names.patch
+++ b/package/onvif-simple-server/0002-change-config-file-and-dir-names.patch
@@ -22,7 +22,7 @@ diff --git a/onvif_simple_server.c b/onvif_simple_server.c
 index 21a490e..3eed477 100644
 --- a/onvif_simple_server.c
 +++ b/onvif_simple_server.c
-@@ -36,9 +36,9 @@
+@@ -37,9 +37,9 @@
  #include "utils.h"
  #include "log.h"
  

--- a/package/onvif-simple-server/files/onvif.conf
+++ b/package/onvif-simple-server/files/onvif.conf
@@ -7,10 +7,16 @@ serial_num=000000000
 ifs=wlan0
 port=80
 scope=onvif://www.onvif.org/Profile/Streaming
+scope=onvif://www.onvif.org/Profile/T
+scope=onvif://www.onvif.org/hardware
+scope=onvif://www.onvif.org/name
 user=thingino
 password=thingino
+
 #Advanced options
+adv_enable_media2=1
 adv_fault_if_unknown=0
+adv_fault_if_set=0
 adv_synology_nvr=0
 
 #Profile 0
@@ -20,6 +26,8 @@ height=1080
 url=rtsp://%s/ch0
 snapurl=http://%s/image.jpg
 type=H264
+audio_decoder=AAC
+audio_encoder=NONE
 
 #Profile 1
 name=Profile_1
@@ -28,6 +36,8 @@ height=360
 url=rtsp://%s/ch1
 snapurl=http://%s/onvif/image.cgi?width=640&height=360
 type=H264
+audio_decoder=AAC
+audio_encoder=NONE
 
 #PTZ
 ptz=1

--- a/package/onvif-simple-server/onvif-simple-server.mk
+++ b/package/onvif-simple-server/onvif-simple-server.mk
@@ -42,6 +42,8 @@ define ONVIF_SIMPLE_SERVER_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 0644 -t $(TARGET_DIR)/var/www/onvif/generic_files $(@D)/generic_files/*
 	$(INSTALL) -m 0755 -d $(TARGET_DIR)/var/www/onvif/media_service_files
 	$(INSTALL) -m 0644 -t $(TARGET_DIR)/var/www/onvif/media_service_files $(@D)/media_service_files/*
+	$(INSTALL) -m 0755 -d $(TARGET_DIR)/var/www/onvif/media2_service_files
+	$(INSTALL) -m 0644 -t $(TARGET_DIR)/var/www/onvif/media2_service_files $(@D)/media2_service_files/*
 	$(INSTALL) -m 0755 -d $(TARGET_DIR)/var/www/onvif/notify_files
 	$(INSTALL) -m 0644 -t $(TARGET_DIR)/var/www/onvif/notify_files $(@D)/notify_files/*
 	$(INSTALL) -m 0755 -d $(TARGET_DIR)/var/www/onvif/ptz_service_files
@@ -52,6 +54,7 @@ define ONVIF_SIMPLE_SERVER_INSTALL_TARGET_CMDS
 	ln -sf /usr/sbin/onvif_simple_server $(TARGET_DIR)/var/www/onvif/device_service
 	ln -sf /usr/sbin/onvif_simple_server $(TARGET_DIR)/var/www/onvif/events_service
 	ln -sf /usr/sbin/onvif_simple_server $(TARGET_DIR)/var/www/onvif/media_service
+	ln -sf /usr/sbin/onvif_simple_server $(TARGET_DIR)/var/www/onvif/media2_service
 	ln -sf /usr/sbin/onvif_simple_server $(TARGET_DIR)/var/www/onvif/ptz_service
 endef
 


### PR DESCRIPTION
The last update of onvif_simple_server implements media2 methods.
And onvif.conf needs to be changed to contain new parameters.
