### PR TITLE
webui: show wifi connection statistics

### DIFF
--- a/package/thingino-webui/files/var/www/x/config-wlan.cgi
+++ b/package/thingino-webui/files/var/www/x/config-wlan.cgi
@@ -55,6 +55,7 @@ wlan_mac="$(get wlanmac)"
 </div>
 <div class="col">
 <% ex "fw_printenv | grep wlan | sort" %>
+<% ex "iwpriv wlan0 common get_ap_info" %>
 </div>
 </div>
 <% button_submit %>

--- a/package/thingino-webui/files/var/www/x/config-wlan.cgi
+++ b/package/thingino-webui/files/var/www/x/config-wlan.cgi
@@ -55,7 +55,7 @@ wlan_mac="$(get wlanmac)"
 </div>
 <div class="col">
 <% ex "fw_printenv | grep wlan | sort" %>
-<% ex "iwpriv wlan0 common get_ap_info" %>
+<% ex "wlan info" %>
 </div>
 </div>
 <% button_submit %>


### PR DESCRIPTION
Show wifi connection status, connection quality (rssi, phy rates), and connection statistics in the wifi config web page.
This works for at least 50% of the thingino devices (Altobeam), maybe more (can't test all devices).
Perfect is the enemy of the good enough, yada yada, patches welcome

Sample below
```
# iwpriv wlan0 common get_ap_info
wlan0     common:
ssid=Home
rssi=-26
mac:00:11:22:aa:bb:cc
tx_pkt=614363
tx_suc_pkt=608973
rx_pkt=537659
tx_rate=650
rx_rate=650
idle=957
throughput=8507131 Byte/s
```