### PR TITLE
Add missing close curly bracket from initial ws open

### DIFF
--- a/package/thingino-webui/files/var/www/x/plugin-motion.cgi
+++ b/package/thingino-webui/files/var/www/x/plugin-motion.cgi
@@ -47,7 +47,7 @@ const send2_targets = ['email', 'ftp', 'mqtt', 'telegram', 'webhook', 'yadisk'];
 let ws = new WebSocket('ws://' + document.location.hostname + ':8089?token=<%= $ws_token %>');
 ws.onopen = () => {
 	console.log('WebSocket connection opened');
-	const payload = '{"motion":{' + motion_params.map((x) => `"${x}":null`).join() + '}';
+	const payload = '{"motion":{' + motion_params.map((x) => `"${x}":null`).join() + '}}';
 	ws.send(payload);
 }
 ws.onclose = () => { console.log('WebSocket connection closed'); }


### PR DESCRIPTION
During my investigations on how to enable/disable motion detection from my own scripts I noticed a malformed WS communication.  It's only on when the WS is first opened, so it's not very impactful.
