### PR TITLE
ntpd: move sync status to /run, cleanup

### DIFF
--- a/overlay/lower/etc/ntpd_callback
+++ b/overlay/lower/etc/ntpd_callback
@@ -1,6 +1,14 @@
 #!/bin/sh
-# This script is called internally by ntpq when time synchronization updated, dont run it yourself
+# usage: ntpd -S ntpd_callback
 
-SYNC_STATUS="/tmp/sync_status"
+# /run/sync_success is created when time is synchronized
+# /run/sync_status contains current ntpd status, even if not sync yet
 
-echo -e "$1\nfreq_drift_ppm=$freq_drift_ppm\noffset=$offset\nstratum=$stratum\npoll_interval=$poll_interval" > $SYNC_STATUS
+export action="$1"
+export timestamp="$(date -Iseconds)"
+
+env | \
+grep -E '^(action|freq_drift_ppm|offset|poll_interval|stratum|timestamp)=' | \
+sort > /run/sync_status
+
+[ "$action" = "step" ] || [ "$action" = "stratum" ] && touch /run/sync_success

--- a/package/thingino-webui/files/var/www/x/config-time.cgi
+++ b/package/thingino-webui/files/var/www/x/config-time.cgi
@@ -9,7 +9,7 @@ config_file="$ui_config_dir/$plugin.conf"
 
 ntpd_static_config=/etc/default/ntp.conf
 ntpd_working_config=/tmp/ntp.conf
-ntpd_sync_status=/tmp/sync_status
+ntpd_sync_status=/run/sync_status
 seq=$(seq 0 3)
 
 if [ "POST" = "$REQUEST_METHOD" ]; then


### PR DESCRIPTION
ntpd fixes and cleanup:
* move to /run/sync_status
* create /run/sync_success only when time is synchronized successfully, ignoring ntpd periodic messages which can appear even if not synced yet.
* document script usage
* normalize all content in /run/sync_status to the key=value format, including ntpd action field

Sample:

$ cat /run/sync_status
action=periodic
freq_drift_ppm=-2
offset=0.002793
poll_interval=4096
stratum=3
timestamp=2024-10-25T04:38:05

fixes #274 