### PR TITLE
env: jooan a6m: decrease rmem from 22M to 12M (2)

### DIFF
--- a/environment/jooan-a6m-atbm6012bx.uenv.txt
+++ b/environment/jooan-a6m-atbm6012bx.uenv.txt
@@ -14,3 +14,5 @@ gpio_white=60O
 gpio_wlan=6
 wlandev=atbm6012bx
 wlandevopts=atbm_printk_mask=0
+osmem=52M@0x0
+rmem=12M@0x3400000

--- a/environment/jooan-a6m-ssv6355.uenv.txt
+++ b/environment/jooan-a6m-ssv6355.uenv.txt
@@ -13,3 +13,5 @@ gpio_speaker=63o
 gpio_white=60O
 gpio_wlan=6
 wlandev=ssv6x5x
+osmem=52M@0x0
+rmem=12M@0x3400000


### PR DESCRIPTION
(2nd try. ignore the first pull request)
tested 24 hrs, including simultaneous local recording and streaming.

according to T23 calculator:
stream0 = 720p
stream1 = 360p
stream2 = jpeg
buffer = 2M (twice than the recommended buf=1M for 720p)
requires 12M rmem

related #54 