### PR TITLE
wlan: fix temperature regexp

### DIFF
--- a/package/wifi/files/wlan
+++ b/package/wifi/files/wlan
@@ -112,7 +112,7 @@ temp() {
 			echo "SSV not supported yet."
 			;;
 		atbm*)
-			iwpriv wlan0 common get_tjroom | sed -n 's/.*stempC:\([0-9]*\).*/\1/p'
+			iwpriv wlan0 common get_tjroom | sed -n 's/.*stempC:\(-\?[0-9]\+\).*/\1/p'
 			;;
 		rtl*|818*|87*|88*)
 			echo "Realtek not supported yet."


### PR DESCRIPTION
two fixes:

1. stempC = Signed temp C = temperature can be negative. accept optional "-" prefix in number regexp for negative numbers.

2. temperature value should contain at least 1 digit. zero digits is invalid value.