### PR TITLE
record: ISO8601 and Windows compliant filenames no colons

### DIFF
--- a/package/thingino-webui/files/var/www/x/config-record.cgi
+++ b/package/thingino-webui/files/var/www/x/config-record.cgi
@@ -22,7 +22,7 @@ include $config_file
 [ -z "$record_loop" ] && record_loop="true"
 [ -z "$record_videoformat" ] && record_videoformat="mp4"
 if [ -z "$record_filename" ] || [ "/" = "${record_filename:0-1}" ]; then
-	record_filename="thingino/%Y-%m-%d/%H:%M:%S"
+	record_filename="thingino/%Y-%m-%d/%Y-%m-%dT%H-%M-%S"
 fi
 
 if [ "POST" = "$REQUEST_METHOD" ]; then


### PR DESCRIPTION
Make recording filenames ISO8601 and Windows compliant (remove colons)

Description:

This pull request updates the filename format for recordings to ensure compliance with both ISO8601 standards and Windows file naming restrictions, specifically by removing colons (":") from the timestamp and using a full date-time format.

Changes:

* Updated the record_filename format in package/thingino-webui/files/var/www/x/config-record.cgi:

`Original format: thingino/%Y-%m-%d/%H:%M:%S`

`New format: thingino/%Y-%m-%d/%Y-%m-%dT%H-%M-%S`

* The new format includes the full date in the filename, so if a file is moved out of its date directory, it will retain the complete timestamp information.

Rationale:

* Ensures compatibility with Windows, which does not support colons in filenames.
* Allows for a full ISO8601 timestamp (with minor adjustments for file system compatibility), making it easier to identify files by date and time even outside of their original directory.