### PR TITLE
timelapse: Use ISO-style datetime format for default filename

### DIFF
--- a/package/thingino-webui/files/var/www/x/plugin-timelapse.cgi
+++ b/package/thingino-webui/files/var/www/x/plugin-timelapse.cgi
@@ -18,7 +18,7 @@ if [ "POST" = "$REQUEST_METHOD" ]; then
 
 	# defaults
 	[ -z "$timelapse_enabled"  ] && timelapse_enabled="false"
-	[ -z "$timelapse_filename" ] && timelapse_filename="%Y%m%d%H%M.jpg"
+	[ -z "$timelapse_filename" ] && timelapse_filename="%Y%m%dT%H%M.jpg"
 	[ -z "$timelapse_interval" ] && timelapse_interval=1
 
 	# normalize


### PR DESCRIPTION
Change the default timelapse filename pattern to include a 'T' separator
between date and time components (%Y%m%dT%H%M.jpg instead of
%Y%m%d%H%M.jpg), aligning with ISO 8601 datetime format.

The 'T' separator improves readability and makes it easier to parse - it's easier for users to quickly
parse "20240105T1430.jpg" into "2024-01-05 14:30" mentally than when
looking at the unbroken "202401051430.jpg", and makes it easier to parse with standard libraries.