### PR TITLE
wifi: rename adhoc to ap

### DIFF
--- a/package/thingino-webui/files/var/www/x/_common.cgi
+++ b/package/thingino-webui/files/var/www/x/_common.cgi
@@ -344,7 +344,7 @@ html_theme() {
 	esac
 }
 
-is_adhoc() {
+is_ap() {
 	[ "true" = "$wlanap_enabled" ]
 }
 

--- a/package/thingino-webui/files/var/www/x/_header.cgi
+++ b/package/thingino-webui/files/var/www/x/_header.cgi
@@ -90,7 +90,7 @@ Pragma: no-cache
 <div class="col col-12 col-md-12 col-lg-3 col-xl-4 text-end"><a href="/x/config-time.cgi" id="time-now" class="link-underline link-underline-opacity-0 link-underline-opacity-75-hover"></a></div>
 </div>
 
-<% if !is_adhoc && [ -z "$network_gateway" ]; then %>
+<% if !is_ap && [ -z "$network_gateway" ]; then %>
 <div class="alert alert-warning">
 <p class="mb-0">No Internet connection. Please <a href="config-network.cgi">check your network settings</a>.</p>
 </div>


### PR DESCRIPTION
Wifi adhoc mode is a decentralized mesh protocol (IBSS).
This is not the correct term here.
Replace with Wifi AP term, which is the correct description of the WiFi mode.