### PR TITLE
Add cork to motion

### DIFF
--- a/overlay/lower/usr/bin/motors
+++ b/overlay/lower/usr/bin/motors
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+. /sbin/common-motion
+
+touch_motion_cork
+motors.bin "$@"

--- a/overlay/lower/usr/sbin/color
+++ b/overlay/lower/usr/sbin/color
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+. /sbin/common-motion
+
 # set parameters from cli, if empty
 [ -z "$mode" ] && mode=$1
 
@@ -8,12 +11,14 @@ MODE_FILE=/tmp/colormode.txt
 # NB! ISP mode is set backwards: 0 - color, 1 - monochrome
 
 switch_to_color() {
+	touch_motion_cork
 	imp-control ispmode 0
 	echo "Switched to full-color mode"
 	echo 1 > $MODE_FILE
 }
 
 switch_to_monochrome() {
+	touch_motion_cork
 	imp-control ispmode 1
 	echo "Switched to monochrome mode"
 	echo 0 > $MODE_FILE

--- a/overlay/lower/usr/sbin/common-motion
+++ b/overlay/lower/usr/sbin/common-motion
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+MOTION_CORK=/run/motion.cork
+MOTION_CORK_TIMEOUT=1
+
+touch_motion_cork() {
+	touch $MOTION_CORK
+}
+
+motion_cork_age() {
+	NOW=$(date +"%s")
+	AGE=$(stat -c "%Y" $MOTION_CORK)
+	echo $((NOW-AGE))
+}

--- a/overlay/lower/usr/sbin/ircut
+++ b/overlay/lower/usr/sbin/ircut
@@ -54,6 +54,7 @@ report_ir_filter() {
 }
 
 ir_filter_off() {
+	touch_motion_cork
 	gpio set "$pin1" "$pin1_off" > /dev/null
 	if [ -n "$pin2" ]; then
 		gpio set "$pin2" "$pin2_on" > /dev/null
@@ -64,6 +65,7 @@ ir_filter_off() {
 }
 
 ir_filter_on() {
+	touch_motion_cork
 	gpio set "$pin1" "$pin1_on" > /dev/null
 	if [ -n "$pin2" ]; then
 		gpio set "$pin2" "$pin2_off" > /dev/null

--- a/overlay/lower/usr/sbin/irled
+++ b/overlay/lower/usr/sbin/irled
@@ -41,14 +41,17 @@ pin=${pin:0:(-1)}
 
 case "$mode" in
 	0 | off)
+		touch_motion_cork
 		echo "gpio set $pin $pin_off > /dev/null" >&2
 		gpio set $pin $pin_off > /dev/null
 		;;
 	1 | on)
+		touch_motion_cork
 		echo "gpio set $pin $pin_on > /dev/null" >&2
 		gpio set $pin $pin_on > /dev/null
 		;;
 	~ | toggle)
+		touch_motion_cork
 		echo "gpio toggle $pin > /dev/null" >&2
 		gpio toggle $pin > /dev/null
 		;;

--- a/overlay/lower/usr/sbin/motion
+++ b/overlay/lower/usr/sbin/motion
@@ -2,6 +2,7 @@
 
 plugin="motion"
 
+. /sbin/common-motion
 . /sbin/common-plugins
 singleton
 
@@ -13,6 +14,10 @@ MOTION_STOP_FILE="/run/motors.pid"
 
 start() {
 	[ -f $MOTION_STOP_FILE ] && exit 0
+
+	if [ -f $MOTION_CORK ]; then
+		[ "$(motion_cork_age)" -gt "$MOTION_CORK_TIMEOUT" ] || exit 0
+	fi
 
 	touch $MOTION_ALARM
 

--- a/package/motors/motors.mk
+++ b/package/motors/motors.mk
@@ -21,7 +21,7 @@ define MOTORS_INSTALL_TARGET_CMDS
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/etc/init.d
 	$(INSTALL) -m 755 -t $(TARGET_DIR)/etc/init.d/ $(MOTORS_PKGDIR)/files/S09motor
 
-	$(INSTALL) -m 755 -D $(@D)/motors $(TARGET_DIR)/usr/bin/motors
+	$(INSTALL) -m 755 -D $(@D)/motors $(TARGET_DIR)/usr/bin/motors.bin
 	$(INSTALL) -m 755 -D $(@D)/motors-daemon $(TARGET_DIR)/usr/bin/motors-daemon
 
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/usr/sbin/


### PR DESCRIPTION
This is my rendition of fixing https://github.com/themactep/thingino-firmware/issues/324

There seem to be a lot of ways for the user to inflict image changes that will fire off the motion sensor.  This patch attempts cork all those paths off by having them touch a common motion.cork file.

The motion script will sniff the cork to see if it's older than the timeout value before proceeding.

