### PR TITLE
Remove breaks from bash case

### DIFF
--- a/scripts/binpadder.sh
+++ b/scripts/binpadder.sh
@@ -22,15 +22,12 @@ echo "UNIT: $unit"
 case "$unit" in
 	b | B | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 0)
 		final_size=$2
-		break
 		;;
 	k | K)
 		final_size=$((${2::-1} * 1024))
-		break
 		;;
 	m | M)
 		final_size=$((${2::-1} * 1024 * 1024))
-		break
 		;;
 	*)
 		echo "$unit - Unknown unit"


### PR DESCRIPTION
There is no such thing. :)

```
./binpadder.sh: line 33: break: only meaningful in a `for', `while', or `until' loop
```