### PR TITLE
Fix typo in sysupgrade

### DIFF
--- a/overlay/lower/usr/sbin/sysupgrade
+++ b/overlay/lower/usr/sbin/sysupgrade
@@ -299,7 +299,7 @@ esac
 if [ "true" = "$bootloader_only" ]; then
 	[ "mtd5" = "$mtd_dev" ] || die "Userland image does not have a bootloader!"
 	extract_bootloader "$fw_file"
-	flascp -v $fw_file /dev/mtd0
+	flashcp -v $fw_file /dev/mtd0
 	exit 0
 fi
 


### PR DESCRIPTION
current version of the script has a typo and fails to complete:

```
root@wyze-v3-kitchen ~# sysupgrade -p -b
Run as /sbin/sysupgrade -p -b
Updating self
############################################################################################################################################################################################################################################################################# 100.0%############################################################################################################################################################################################################################################################################# 100.0%Re-running script from /tmp/sysupgrade
Run as /tmp/sysupgrade/sysupgrade -p -b
Upgrading from GitHub
Downloading firmware from:
https://github.com/themactep/thingino-firmware/releases/latest/download/thingino-wyze_c3_t31x_rtl.bin
############################################################################################################################################################################################################################################################################# 100.0%Downloading checksum from:
https://github.com/themactep/thingino-firmware/releases/latest/download/thingino-wyze_c3_t31x_rtl-update.bin.sha256sum
############################################################################################################################################################################################################################################################################# 100.0%Verifying downloaded file
thingino-wyze_c3_t31x_rtl-update.bin: OK
'thingino-wyze_c3_t31x_rtl-update.bin' -> '/tmp/sysupgrade/fw.bin'
/tmp/sysupgrade/sysupgrade: line 302: flascp: not found
```