### PR TITLE
fix: system restart network

### DIFF
--- a/overlay/lower/etc/init.d/S40network
+++ b/overlay/lower/etc/init.d/S40network
@@ -16,9 +16,9 @@ case "$1" in
 		;;
 
 	reload | restart)
-		stop
+		"$0" stop
 		sleep 1
-		start
+		"$0" start
 		;;
 
 	*)


### PR DESCRIPTION
Prior to this, running `system restart network` would fail due to no `start` or `stop` function definition in the file


```
root@wyze-v3-front-porch ~# service restart network
/etc/init.d/S40network: line 19: stop: not found
/etc/init.d/S40network: line 21: start: not found
```

This partially reverts 081920f80e6f7d0c35437dd7c0f752ec2c857ced 