### PR TITLE
Add day/night mode gain thresholds to Howell QJ05T

### DIFF
--- a/environment/howell-qj05t.uenv.txt
+++ b/environment/howell-qj05t.uenv.txt
@@ -1,5 +1,7 @@
 day_night_color=true
 day_night_ircut=true
+day_night_max=5000
+day_night_min=2500
 enable_updates=true
 gpio_button=60
 gpio_default=25o 26o 77o 60i


### PR DESCRIPTION
According to my tests, these thresholds makes sense for this camera.