### PR TITLE
Prevent the possible multiple recording instances from starting

### DIFF
--- a/package/prudynt-t/files/S96record
+++ b/package/prudynt-t/files/S96record
@@ -6,31 +6,74 @@ WEBUI_CONF=/etc/webui/record.conf
 
 . /etc/init.d/rc.common
 
+LOCK_FILE="/tmp/record.lock"
+
 read_config() {
 	sed -nE "s/^.*$1:\s*\"?([^\"]+)\"?;.*$/\1/p" /etc/prudynt.cfg | head -1
 }
 
 start() {
-	starting
-	pidof $DAEMON > /dev/null && quit "$DAEMON is already running"
+    starting
 
-	is_streamer_disabled && quit "Streamer disabled"
-	is_streamer_running || quit "Streamer is not running"
-	[ -f $WEBUI_CONF ] || quit "Not configured"
-	. $WEBUI_CONF
-	[ "true" = "$record_enabled" ] || quit "Disabled in $WEBUI_CONF"
-	[ -d "$record_mount" ] || quit "Storage is not mounted"
-	record_path=$(dirname "$record_mount/$(date +"$record_filename")")
-	[ -d "$record_path" ] || mkdir -p $record_path
-	[ -w "$record_path" ] || quit "No access to $record_path"
-	start_daemon_with_pid
+    # Check if the lock file exists and the process is running
+    if [ -f "$LOCK_FILE" ]; then
+        existing_pid=$(cat "$LOCK_FILE")
+        if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
+            quit "Another instance of the record script is already running (PID: $existing_pid)."
+        else
+            echo "Stale lock file found. Cleaning up."
+            rm -f /tmp/record.*
+        fi
+    fi
+
+    # Write current PID to the lock file
+    echo $$ > "$LOCK_FILE"
+
+    pidof $DAEMON > /dev/null && quit "$DAEMON is already running"
+
+    is_streamer_disabled && quit "Streamer disabled"
+    is_streamer_running || quit "Streamer is not running"
+    [ -f $WEBUI_CONF ] || quit "Not configured"
+    . $WEBUI_CONF
+    [ "true" = "$record_enabled" ] || quit "Disabled in $WEBUI_CONF"
+    [ -d "$record_mount" ] || quit "Storage is not mounted"
+    record_path=$(dirname "$record_mount/$(date +"$record_filename")")
+    [ -d "$record_path" ] || mkdir -p $record_path
+    [ -w "$record_path" ] || quit "No access to $record_path"
+
+    # Start the daemon and capture its PID
+    start_daemon_with_pid
+    daemon_pid=$(cat "$PIDFILE")
+
+    # Verify if the PID was successfully captured
+    if [ -n "$daemon_pid" ] && kill -0 "$daemon_pid" 2>/dev/null; then
+        echo "$daemon_pid" > "$LOCK_FILE"
+    else
+        echo "Failed to start daemon or capture PID."
+        exit 1
+    fi
 }
 
+
 stop() {
-	stopping
-	is_streamer_disabled && quit "Streamer disabled"
-	find /tmp/ -name "record.*" -maxdepth 0 -exec rm {} \;
-	stop_daemon_with_pid
+    stopping
+
+    # Check if the lock file exists
+    if [ ! -f "$LOCK_FILE" ]; then
+        echo "No lock file found. The process may not be running."
+        return 0
+    fi
+
+    # Retrieve the PID from the lock file
+    pid=$(cat "$LOCK_FILE")
+
+    # Check if the PID is valid and belongs to the running script
+    if kill -0 "$pid" 2>/dev/null; then
+        echo "Stopping process with PID $pid.  Process will end after next recording interval concludes."
+        kill "$pid"
+    else
+        echo "No valid process found for PID $pid. Cleaning up."
+    fi
 }
 
 case "$1" in

--- a/package/prudynt-t/files/record
+++ b/package/prudynt-t/files/record
@@ -4,6 +4,8 @@
 
 RECORD_FLAG="/tmp/record.$$"
 
+trap 'rm -f /tmp/record.*; exit' INT TERM EXIT
+
 get_free_space() {
 	available_space=$(df -k "$record_mount" | sed 1d | tr -d '\n' | awk 'END{print $4}') # in KiB
 	echo "Space available: $available_space KiB"


### PR DESCRIPTION
Latest build earlier and after restarting device, I notice the fstab entry I have to mount the smb share must not work until after network comes up, so I have to manually run `mount -a`  which lead to me discovering somehow I had 3 record processes running and it was corrupting the recordings.    Reducing down to 1 fixed it, and here is a fix to prevent it from even being possible.

```
root@ing-wyze-c3-acb2 ~# /etc/init.d/S96record start
Starting record: OK
root@ing-wyze-c3-acb2 ~# /etc/init.d/S96record start
Starting record: Another instance of the record script is already running (PID: 31839).
root@ing-wyze-c3-acb2 ~# /etc/init.d/S96record stop
Stopping record: Stopping process with PID 31839.  Process will end after next recording interval concludes.
root@ing-wyze-c3-acb2 ~# /etc/init.d/S96record start
Starting record: Another instance of the record script is already running (PID: 31839).
root@ing-wyze-c3-acb2 ~# ls /tmp/
alloc_manager_info   continuous_mem_info  isp_tuning_func      notify.log           onvif.log            record.lock          snapshot.jpg         vbuffer.tmp          wsd.log
colormode.txt        ircutmode.txt        nightmode.txt        ntp.conf             record.31839         resolv.conf          vbuffer.mov          webui.log
root@ing-wyze-c3-acb2 ~# ps | grep record
 2296 root      1876 S    grep record
31839 root      1904 S    {record} /bin/sh /sbin/record
root@ing-wyze-c3-acb2 ~# ps | grep record
 4315 root      1876 S    grep record
root@ing-wyze-c3-acb2 ~# ls /tmp/
alloc_manager_info   continuous_mem_info  isp_tuning_func      notify.log           onvif.log            snapshot.jpg         vbuffer.tmp          wsd.log
colormode.txt        ircutmode.txt        nightmode.txt        ntp.conf             resolv.conf          vbuffer.mov          webui.log
root@ing-wyze-c3-acb2 ~# /etc/init.d/S96record start
Starting record: OK

```