### PR TITLE
use the correct Wiki link for the VPN configuration page

### DIFF
--- a/package/thingino-webui/files/var/www/x/config-wireguard.cgi
+++ b/package/thingino-webui/files/var/www/x/config-wireguard.cgi
@@ -55,7 +55,7 @@ fi
 WireGuard is a fast and simple general purpose VPN.</p>
 <p>This interface supports the simple use case of connecting a single tunnel to a peer (server),
 and routing traffic from the camera, to a set of CIDRs (networks) through that server.</p>
-<% wiki_page "WireGuard-VPN" %>
+<% wiki_page "VPN:-Wireguard" %>
 </div>
 </div>
 </div>


### PR DESCRIPTION
The link to the VPN configuration page is wrong. This PR will fix it by sending to the correct page.
See https://discord.com/channels/1086012062649565286/1209383244710027284/1333499657912975360