### PR TITLE
Update S41portal - remove AP timeout

### DIFF
--- a/package/thingino-portal/files/S41portal
+++ b/package/thingino-portal/files/S41portal
@@ -14,10 +14,6 @@ elif [ "$(fw_printenv -n wlandev)" = "wq9001" ]; then
 	sed -i 's/wlan0/wlan1/g' /etc/udhcpd-portal.conf
 fi
 
-timeout() {
-	sleep 600 && $0 stop
-}
-
 case "$1" in
 	start)
 		starting
@@ -47,8 +43,6 @@ case "$1" in
 
 		start-stop-daemon -S -x /sbin/wpa_supplicant -- -i $net_dev -B -c /etc/wpa-portal_ap.conf 2>&1 | log
 		check_result
-
-		timeout &
 		;;
 	stop)
 		stopping


### PR DESCRIPTION
For very remote camera locations with no SD card (where you cannot create uenv.txt), it is better to have AP online indefinitely (as opposite to 10minutes timeout until now) after full upgrade.  Then you dont need to be extremly fast to connect from wireless client to AP after camera full upgrade. 

Security considerations are minor compared to usability benefit.
