### PR TITLE
Record sync

### DIFF
--- a/package/prudynt-t/files/record
+++ b/package/prudynt-t/files/record
@@ -32,6 +32,15 @@ read_config() {
 	[ -z "$_" ] || echo "$2"
 }
 
+fix_duration() {
+    if [ "$1" -eq 60 ]; then
+        echo $(expr "$1" - $(date +%S))
+    else
+        echo "$1"
+    fi
+    #to do - handle cases different than 60 second durations
+}
+
 # "default"
 read_fps() {
 	logcat | grep "fps" | head -1 | awk -F '[=,]' '{print $2}'
@@ -77,10 +86,18 @@ Where params are:
 
 pidof -o $$ record > /dev/null && die "is already running"
 
-CONFIG_FILE="/etc/web.conf"
+CONFIG_FILE="/etc/webui/record.conf"
 [ -f "$CONFIG_FILE" ] && . $CONFIG_FILE
 
 RECORD_FLAG="/tmp/record.$$"
+
+RECORD_WEBUI_CONF=/etc/webui/record.conf
+if [ -f $RECORD_WEBUI_CONF ]; then
+	cat $RECORD_WEBUI_CONF
+	. $RECORD_WEBUI_CONF
+else
+	[ "${#1}" -eq 0 ] && die "Config file $RECORD_WEBUI_CONF not found"
+fi
 
 while getopts "c:d:f:h:m:n:p:s:t:u:v:w:xz:" flag; do
 	case "$flag" in
@@ -178,12 +195,16 @@ while :; do
 		done
 	fi
 
+
+
 	record_file="$record_storage/$(date +"$record_filename").$record_videofmt"
 	create_directory_for "$record_file"
 
-	log "openRTSP -u $rtsp_username $rtsp_password -w $stream_width -h $stream_height -f $stream_fps -d $record_duration $vformat -b 1048576 -t rtsp://[::1]/$stream_endpoint > $record_file"
+	real_duration=$(fix_duration $record_duration)
+
+	log "openRTSP -u $rtsp_username $rtsp_password -w $stream_width -h $stream_height -f $stream_fps -d $real_duration $vformat -b 1048576 -t rtsp://[::1]/$stream_endpoint > $record_file"
 	openRTSP -u $rtsp_username $rtsp_password -w $stream_width -h $stream_height -f $stream_fps \
-		-d $record_duration $vformat -b 1048576 -t rtsp://[::1]/$stream_endpoint > "$record_file" 2> /dev/null
+		-d $real_duration $vformat -b 1048576 -t rtsp://[::1]/$stream_endpoint > "$record_file" 2> /dev/null
 
 	[ "true" = "$one_time" ] && rm $RECORD_FLAG
 done

--- a/package/prudynt-t/files/record
+++ b/package/prudynt-t/files/record
@@ -19,10 +19,14 @@ hesitate() {
 fix_duration() {
     if [ "$1" -eq 60 ]; then
         echo $(expr "$1" - $(date +%S))
+    elif [ $(expr "$1" % 60) -eq 0 ]; then
+        m_inc=$(expr "$1" / 60)
+        mpart=$(expr "$m_inc" - $(expr $(date +%M) % "$m_inc"))
+        echo $(expr "$mpart" "*" 60)
     else
         echo "$1"
     fi
-    #to do - handle cases different than 60 second durations
+    #to do - handle cases different than 60 second durations or videos longer than an hour
 }
 
 get_free_space() {

--- a/package/prudynt-t/files/record
+++ b/package/prudynt-t/files/record
@@ -193,7 +193,7 @@ while :; do
 	real_duration=$(fix_duration $record_duration)
 
 	log "openRTSP -u $rtsp_username $rtsp_password -w $stream_width -h $stream_height -f $stream_fps -d $real_duration $vformat -b 1048576 -t rtsp://[::1]/$stream_endpoint > $record_file"
-	openRTSP -u $rtsp_username $rtsp_password -w $stream_width -h $stream_height -f $stream_fps \
+	timeout $((real_duration + 5)) openRTSP -u $rtsp_username $rtsp_password -w $stream_width -h $stream_height -f $stream_fps \
 		-d $real_duration $vformat -b 1048576 -t rtsp://[::1]/$stream_endpoint > "$record_file" 2> /dev/null
 
 

--- a/package/prudynt-t/files/record
+++ b/package/prudynt-t/files/record
@@ -16,6 +16,15 @@ hesitate() {
 	exit 0
 }
 
+fix_duration() {
+    if [ "$1" -eq 60 ]; then
+        echo $(expr "$1" - $(date +%S))
+    else
+        echo "$1"
+    fi
+    #to do - handle cases different than 60 second durations
+}
+
 get_free_space() {
 	available_space=$(df -k "$record_mount" | sed 1d | tr -d '\n' | awk 'END{print $4}') # in KiB
 	log "Space available: $available_space KiB"
@@ -30,15 +39,6 @@ get_occupied_space() {
 read_config() {
 	sed -nE "s/^.*$1\s*[:=]\s*\"?([^\"]+)\"?;.*$/\1/p" /etc/prudynt.cfg | head -1
 	[ -z "$_" ] || echo "$2"
-}
-
-fix_duration() {
-    if [ "$1" -eq 60 ]; then
-        echo $(expr "$1" - $(date +%S))
-    else
-        echo "$1"
-    fi
-    #to do - handle cases different than 60 second durations
 }
 
 # "default"
@@ -86,18 +86,10 @@ Where params are:
 
 pidof -o $$ record > /dev/null && die "is already running"
 
-CONFIG_FILE="/etc/webui/record.conf"
+CONFIG_FILE="/etc/web.conf"
 [ -f "$CONFIG_FILE" ] && . $CONFIG_FILE
 
 RECORD_FLAG="/tmp/record.$$"
-
-RECORD_WEBUI_CONF=/etc/webui/record.conf
-if [ -f $RECORD_WEBUI_CONF ]; then
-	cat $RECORD_WEBUI_CONF
-	. $RECORD_WEBUI_CONF
-else
-	[ "${#1}" -eq 0 ] && die "Config file $RECORD_WEBUI_CONF not found"
-fi
 
 while getopts "c:d:f:h:m:n:p:s:t:u:v:w:xz:" flag; do
 	case "$flag" in
@@ -195,8 +187,6 @@ while :; do
 		done
 	fi
 
-
-
 	record_file="$record_storage/$(date +"$record_filename").$record_videofmt"
 	create_directory_for "$record_file"
 
@@ -205,6 +195,8 @@ while :; do
 	log "openRTSP -u $rtsp_username $rtsp_password -w $stream_width -h $stream_height -f $stream_fps -d $real_duration $vformat -b 1048576 -t rtsp://[::1]/$stream_endpoint > $record_file"
 	openRTSP -u $rtsp_username $rtsp_password -w $stream_width -h $stream_height -f $stream_fps \
 		-d $real_duration $vformat -b 1048576 -t rtsp://[::1]/$stream_endpoint > "$record_file" 2> /dev/null
+
+
 
 	[ "true" = "$one_time" ] && rm $RECORD_FLAG
 done


### PR DESCRIPTION
for record of 60 seconds, line up the recordings to the zero second mark by adjusting the length.
for recordings  val % 60 upto 3600 correct the bound to the nearest by reducing length of the current video


add a timeout to openRTSP to avoid runaway that exceeds expected run length
