### PR TITLE
Reorganize /sbin/record to improve functionality

### DIFF
--- a/package/prudynt-t/files/rarchive
+++ b/package/prudynt-t/files/rarchive
@@ -1,0 +1,75 @@
+#!/bin/sh
+. /sbin/record.common
+
+pidof -o $$ rarchive > /dev/null && rm /tmp/rarchive.* 
+
+CONFIG_FILE="/etc/web.conf"                                               
+[ -f "$CONFIG_FILE" ] && . $CONFIG_FILE
+
+RECORD_FLAG="/tmp/rarchive.$$"
+
+record_mount=${record_mount%/}
+record_device_path=${record_device_path%/}
+
+[ -z "$record_mount"     ] && hesitate "Mountpoint record_mount is not set"
+mountpoint -q "$record_mount" || hesitate "Mountpoint $record_mount is not mounted"
+[ -w "$record_mount"     ] || hesitate "Mountpoint $record_mount is not writable"
+[ -z "$record_duration"  ] && record_duration=10
+[ -z "$record_filename"  ] && record_filename="%hostname/%Y/%m/%d/%H-%M-%S"
+
+touch $RECORD_FLAG
+
+stream_align_minutes="true"
+record_storage="$record_mount/$record_device_path"
+if [ ! -d "$record_storage" ]; then
+	log "Creating $record_storage"
+	mkdir -p "$record_storage" || die "Cannot create directory $record_storage"
+fi
+[ -w "$record_storage" ] || die "Cannot write to $record_storage"
+
+record_limit_kb=$((record_limit * 1024 * 1024)) # GiB to KiB
+required_space=$((100 * record_duration)) # KiB
+
+check_so=0
+
+while :; do
+	[ -f $RECORD_FLAG ] || break
+	get_free_space
+	if [ "$available_space" -le "$required_space" ]; then
+		log "Space required: $required_space KiB"
+		log "Not enough space: $required_space > $available_space"
+		while [ "$available_space" -le "$required_space" ]; do
+			remove_oldest_file_in "$record_storage"
+			get_free_space
+			has_files "$record_storage" || die "$record_mount is empty yet no space!"
+		done
+	fi
+
+if [ "$check_so" -le 0 ]; then
+    if [ "$record_limit_kb" -gt 0 ]; then       
+        log "Space limit: $record_limit_kb KiB"
+        get_occupied_space                                                                   
+        if [ "$((occupied_space + (required_space * 100)))" -lt "$record_limit_kb" ]; then
+   		log "lots of space - skipping check for 60 runs"
+	         check_so=60
+        fi                                               
+        while [ "$((occupied_space + required_space))" -gt "$record_limit_kb" ]; do
+            log "Occupied space $occupied_space KiB exceeds limit $record_limit_kb KiB"
+            remove_oldest_file_in "$record_storage"                            
+            get_occupied_space                      
+            has_files "$record_storage" || die "$record_mount is empty yet no space!"
+        done                                                      
+    fi                                         
+else                                 
+  check_so=$((check_so - 1))
+
+fi
+                                          
+  sleep  $((record_duration))                         
+done
+
+log "Cannot find recording flag $RECORD_FLAG"
+[ -n "$LEDD_FLAG" ] && [ -f "$LEDD_FLAG" ] && rm $LEDD_FLAG
+log "Exit"
+
+exit 0

--- a/package/prudynt-t/files/record
+++ b/package/prudynt-t/files/record
@@ -1,99 +1,13 @@
 #!/bin/sh
-
-die() { echo -e "\e[38;5;160m$@\e[0m" >&2; exit 1; }
-log() { echo "$1" >&2; }
-
-create_directory_for() {
-	dir="$(dirname "$1")"
-	[ -d "$dir" ] || mkdir -p "$dir"
-	[ -d "$dir" ] || die "Cannot create directory $dir"
-	[ -w "$dir" ] || die "Cannot write to $dir"
-}
-
-hesitate() {
-	echo "$1" >&2
-	sleep 5
-	exit 0
-}
-
-fix_duration() {
-    if [ "$1" -eq 60 ]; then
-        echo $(expr "$1" - $(date +%S))
-    elif [ $(expr "$1" % 60) -eq 0 ]; then
-        m_inc=$(expr "$1" / 60)
-        mpart=$(expr "$m_inc" - $(expr $(date +%M) % "$m_inc"))
-        echo $(expr "$mpart" "*" 60)
-    else
-        echo "$1"
-    fi
-    #to do - handle cases different than 60 second durations or videos longer than an hour
-}
-
-get_free_space() {
-	available_space=$(df -k "$record_mount" | sed 1d | tr -d '\n' | awk 'END{print $4}') # in KiB
-	log "Space available: $available_space KiB"
-}
-
-get_occupied_space() {
-        occupied_space=$(du -s "$record_storage" | awk '{print $1}') # in KiB
-	log "Space occupied: $occupied_space KiB"
-}
-
-# "parameter" "default"
-read_config() {
-	sed -nE "s/^.*$1\s*[:=]\s*\"?([^\"]+)\"?;.*$/\1/p" /etc/prudynt.cfg | head -1
-	[ -z "$_" ] || echo "$2"
-}
-
-# "default"
-read_fps() {
-	logcat | grep "fps" | head -1 | awk -F '[=,]' '{print $2}'
-	[ -z "$_" ] || echo "$1"
-}
-
-# "parameter" "default"
-read_size() {
-	logcat | grep "VBMCreatePool()-${stream_number}: w=" | head -1 | awk -F '[= ]' "{print \$$1}"
-	[ -z "$_" ] || echo "$2"
-}
-
-# "path"
-remove_oldest_file_in() {
-	oldest_file="$(find "$1" -type f -exec ls -ltr {} + | head -n1 | awk '{print $9}')"
-	oldest_file_dir="$(dirname $oldest_file)"
-	rm -v "$oldest_file"
-	[ -z "$(ls -A1 "$oldest_file_dir")" ] && rm -rv "$oldest_file_dir"
-}
-
-has_files() {
-	[ "$(find "$1" -type f | wc -l)" -gt 0 ]
-}
-
-show_help() {
-	log "Usage: $0 [<params>]
-Where params are:
-	-u <string>  RTSP username
-	-p <string>  RTSP password
-	-c <int>     RTSP stream number
-	-h <int>     Frame height
-	-w <int>     Frame width
-	-f <int>     Frames per second
-	-t <int>     Duration in seconds
-	-v <str>     Record video format
-	-m <path>    Mount point for storing files
-	-s <path>    Subdirectory for the device
-	-n <string>  File name template (supports strftime format)
-	-d <int>     Maximum disk usage, GiB
-	-x           One-time run
-"
-}
+. /sbin/record.common
 
 pidof -o $$ record > /dev/null && die "is already running"
 
-CONFIG_FILE="/etc/web.conf"
-[ -f "$CONFIG_FILE" ] && . $CONFIG_FILE
 
 RECORD_FLAG="/tmp/record.$$"
+
+CONFIG_FILE="/etc/web.conf"                                                        
+[ -f "$CONFIG_FILE" ] && . $CONFIG_FILE
 
 while getopts "c:d:f:h:m:n:p:s:t:u:v:w:xz:" flag; do
 	case "$flag" in
@@ -113,7 +27,7 @@ while getopts "c:d:f:h:m:n:p:s:t:u:v:w:xz:" flag; do
 		*) show_help && exit ;;
 	esac
 done
-shift "$((OPTIND - 1))"
+
 
 record_mount=${record_mount%/}
 record_device_path=${record_device_path%/}
@@ -132,6 +46,8 @@ stream_endpoint="ch$stream_number"
 [ -z "$stream_fps"       ] && stream_fps=$(read_fps "25")
 [ -z "$stream_height"    ] && stream_height=$(read_size "7" "1080")
 [ -z "$stream_width"     ] && stream_width=$(read_size "5" "1920")
+[ -z "$align_minutes" ] && align_minutes="true"                                    
+
 
 log "
 stream_number: $stream_number
@@ -154,7 +70,10 @@ case "$record_videofmt" in
 	  *) die "Unknown video format $record_videofmt"
 esac
 
+
+
 touch $RECORD_FLAG
+
 
 record_storage="$record_mount/$record_device_path"
 if [ ! -d "$record_storage" ]; then
@@ -166,41 +85,51 @@ fi
 record_limit_kb=$((record_limit * 1024 * 1024)) # GiB to KiB
 required_space=$((100 * record_duration)) # KiB
 
+if [ -z "$one_time" ]; then
+  /sbin/rarchive p="$$"  & 
+  archive_pid=$!
+  log "Spun up rarchive $archive_pid"
+
+
+# Set a trap to call cleanup when the script exits
+trap cleanup EXIT
+
+else
+        get_free_space                                                             
+        if [ "$available_space" -le "$required_space" ]; then                      
+                log "Space required: $required_space KiB"                                        
+                log "Not enough space: $required_space > $available_space"                       
+                while [ "$available_space" -le "$required_space" ]; do                           
+                        remove_oldest_file_in "$record_storage"                                  
+                        get_free_space                                                           
+                        has_files "$record_storage" || die "$record_mount is empty yet no space!"                                                                                               
+                done                                                                                  
+        fi      
+
+  if [ "$record_limit_kb" -gt 0 ]; then                                                        
+        log "Space limit: $record_limit_kb KiB"                                                  
+        get_occupied_space                                                                       
+        while [ "$((occupied_space + required_space))" -gt "$record_limit_kb" ]; do              
+            log "Occupied space $occupied_space KiB exceeds limit $record_limit_kb KiB"          
+            remove_oldest_file_in "$record_storage"                                              
+            get_occupied_space                                                                   
+            has_files "$record_storage" || die "$record_mount is empty yet no space!"            
+        done                                                                                     
+    fi         
+fi
+
 while :; do
 	[ -f $RECORD_FLAG ] || break
-
-	get_free_space
-	if [ "$available_space" -le "$required_space" ]; then
-		log "Space required: $required_space KiB"
-		log "Not enough space: $required_space > $available_space"
-		while [ "$available_space" -le "$required_space" ]; do
-			remove_oldest_file_in "$record_storage"
-			get_free_space
-			has_files "$record_storage" || die "$record_mount is empty yet no space!"
-		done
-	fi
-
-	if [ "$record_limit_kb" -gt 0 ]; then
-		log "Space limit: $record_limit_kb KiB"
-		get_occupied_space
-		while [ "$((occupied_space + required_space))" -gt "$record_limit_kb" ]; do
-			log "Occupied space $occupied_space KiB exceeds limit $record_limit_kb KiB"
-			remove_oldest_file_in "$record_storage"
-			get_occupied_space
-			has_files "$record_storage" || die "$record_mount is empty yet no space!"
-		done
-	fi
 
 	record_file="$record_storage/$(date +"$record_filename").$record_videofmt"
 	create_directory_for "$record_file"
 
-	real_duration=$(fix_duration $record_duration)
-
-	log "openRTSP -u $rtsp_username $rtsp_password -w $stream_width -h $stream_height -f $stream_fps -d $real_duration $vformat -b 1048576 -t rtsp://[::1]/$stream_endpoint > $record_file"
-	timeout $((real_duration + 5)) openRTSP -u $rtsp_username $rtsp_password -w $stream_width -h $stream_height -f $stream_fps \
-		-d $real_duration $vformat -b 1048576 -t rtsp://[::1]/$stream_endpoint > "$record_file" 2> /dev/null
-
-
+        real_duration=$(fix_duration $record_duration)                                               
+                                          
+        log "openRTSP -u $rtsp_username $rtsp_password  -w $stream_width -h $stream_height -f $stream_fps -d $real_duration $vformat -b 1048576 -t rtsp://[::1]/$stream_endpoint > $record_file"
+        openRTSP -u $rtsp_username $rtsp_password  -w $stream_width -h $stream_height -f $stream_fps \
+                -d $real_duration $vformat -b 1048576 -t rtsp://[::1]/$stream_endpoint > "$record_file" 2> /dev/null
+                                                   
 
 	[ "true" = "$one_time" ] && rm $RECORD_FLAG
 done
@@ -208,5 +137,7 @@ done
 log "Cannot find recording flag $RECORD_FLAG"
 [ -n "$LEDD_FLAG" ] && [ -f "$LEDD_FLAG" ] && rm $LEDD_FLAG
 log "Exit"
+
+rm "/tmp/rarchive.$archive_pid"
 
 exit 0

--- a/package/prudynt-t/files/record.common
+++ b/package/prudynt-t/files/record.common
@@ -1,0 +1,121 @@
+#!/bin/sh
+
+die() { echo -e "\e[38;5;160m$@\e[0m" >&2; exit 1; }
+log() { echo $(cat /proc/uptime) "$1" >&2; }
+
+# Function to clean up the subprocess                                                                 
+cleanup() {                                                                                                         
+    if [ -n "$archive_pid" ] && kill -0 "$archive_pid" 2>/dev/null; then
+        echo "Parent exiting, killing subprocess $archive_pid..."                  
+        kill -TERM "$archive_pid"                                          
+    fi                                                                             
+}    
+
+create_directory_for() {
+	dir="$(dirname "$1")"
+	[ -d "$dir" ] || mkdir -p "$dir"
+	[ -d "$dir" ] || die "Cannot create directory $dir"
+	[ -w "$dir" ] || die "Cannot write to $dir"
+}
+
+hesitate() {
+	echo "$1" >&2
+	sleep 5
+	exit 0
+}
+
+get_free_space() {
+	available_space=$(df -k "$record_mount" | sed 1d | tr -d '\n' | awk 'END{print $4}') # in KiB
+	log "Space available: $available_space KiB"
+}
+
+get_occupied_space() {
+        occupied_space=$(du -s "$record_storage" | awk '{print $1}') # in KiB
+	log "Space occupied: $occupied_space KiB"
+}
+
+# "parameter" "default"
+read_config() {
+	sed -nE "s/^.*$1\s*[:=]\s*\"?([^\"]+)\"?;.*$/\1/p" /etc/prudynt.cfg | head -1
+	[ -z "$_" ] || echo "$2"
+}
+
+fix_duration() {
+    if [ -z "$align_minutes" ]; then
+    	echo "$1"
+    elif [ "$1" -eq 60 ]; then
+        echo $(expr "$1" - $(date +%S))
+    elif [ $(expr "$1" % 60) -eq 0 ]; then
+        m_inc=$(expr "$1" / 60)
+        mpart=$(expr "$m_inc" - $(expr $(date +%M) % "$m_inc"))
+        echo $(expr "$mpart" "*" 60)
+    else
+        echo "$1"
+    fi
+    #to do - handle cases different than 60 second durations
+}
+
+# "default"
+read_fps() {
+	logcat | grep "fps" | head -1 | awk -F '[=,]' '{print $2}'
+	[ -z "$_" ] || echo "$1"
+}
+
+# "parameter" "default"
+read_size() {
+	logcat | grep "VBMCreatePool()-${stream_number}: w=" | head -1 | awk -F '[= ]' "{print \$$1}"
+	[ -z "$_" ] || echo "$2"
+}
+
+# "path"
+#!/bin/ash
+
+remove_oldest_file_in() {
+    [ -z "$del_count" ] && del_count=10
+
+    log "started removing old files started"
+    # Find oldest files, limited to del_count
+    oldest_files=$(find "$1" -type f -exec ls -ltr {} + | head -n"$del_count" | awk '{print $9}')
+
+    # Check if any files were found
+    if [ -z "$oldest_files" ]; then
+        echo "No files found to delete in $1" >&2
+        return 1
+    fi
+
+    echo "$oldest_files" | while IFS= read -r oldest_file; do
+        if [ -n "$oldest_file" ]; then
+            oldest_file_dir=$(dirname "$oldest_file")
+            rm -v "$oldest_file"
+            # Remove directory if empty
+            if [ -z "$(ls -A "$oldest_file_dir" 2>/dev/null)" ]; then
+                rm -rv "$oldest_file_dir"
+            fi
+        fi
+    done
+
+    log "remove_oldest_file_in finished "
+}
+
+has_files() {
+	[ "$(find "$1" -type f | wc -l)" -gt 0 ]
+}
+
+show_help() {
+	log "Usage: $0 [<params>]
+Where params are:
+	-u <string>  RTSP username
+	-p <string>  RTSP password
+	-c <int>     RTSP stream number
+	-h <int>     Frame height
+	-w <int>     Frame width
+	-f <int>     Frames per second
+	-t <int>     Duration in seconds
+	-v <str>     Record video format
+	-m <path>    Mount point for storing files
+	-s <path>    Subdirectory for the device
+	-n <string>  File name template (supports strftime format)
+	-d <int>     Maximum disk usage, GiB
+	-x           One-time run
+"
+}

--- a/package/prudynt-t/files/record.common
+++ b/package/prudynt-t/files/record.common
@@ -68,7 +68,6 @@ read_size() {
 }
 
 # "path"
-#!/bin/ash
 
 remove_oldest_file_in() {
     [ -z "$del_count" ] && del_count=10


### PR DESCRIPTION
the `/sbin/record` loop was covering both:
1. video recording
2. file management to delete old files to clear up space

These two loops were actually not cooperating well when run in series since several of the operations are time-consuming on the file side.

Solution: Split into two daemons -- one that is recording and one that is deleting files / checking for space

Among the time consuming file operations there were two:
1. the check occupied space could take up to 0.2 seconds on an SD card
2. the `remove_oldest_file_in` function takes upwards of a second to run due to the inefficient $(find "$1" -type f -exec ls -ltr {} + | head -n1 | awk '{print $9}')

For 1, do a sanity check where if there's > 100x as much space as expected, delay the check for 60 seconds
For 2, add a variable `del_count` that could be tweaked on the interface level to reduce the frequency of the file deletions.


Still todo are:
(1) expose align_minutes to web interface so users can pick whether or not they want this behavior
(2) allow users to select the greediness of removing old files (presumably just let them pick a number?)

```
remove_oldest_file_in() {
    [ -z "$del_count" ] && del_count=10

    log "started removing old files started"
    # Find oldest files, limited to del_count
    oldest_files=$(find "$1" -type f -exec ls -ltr {} + | head -n"$del_count" | awk '{print $9}')

    # Check if any files were found
    if [ -z "$oldest_files" ]; then
        echo "No files found to delete in $1" >&2
        return 1
    fi

    echo "$oldest_files" | while IFS= read -r oldest_file; do
        if [ -n "$oldest_file" ]; then
            oldest_file_dir=$(dirname "$oldest_file")
            rm -v "$oldest_file"
            # Remove directory if empty
            if [ -z "$(ls -A "$oldest_file_dir" 2>/dev/null)" ]; then
                rm -rv "$oldest_file_dir"
            fi
        fi
    done

    log "remove_oldest_file_in finished "
}

```



