### PR TITLE
Make connection destination for Websocket with SSL (WSS) use port 8090, which helps in supporting both http and https

### DIFF
--- a/package/thingino-webui/files/www/x/config-streamer.cgi
+++ b/package/thingino-webui/files/www/x/config-streamer.cgi
@@ -333,7 +333,10 @@ const osd_params = ['enabled', 'font_color', 'font_path', 'font_size', 'font_str
 	'logo_enabled', 'time_enabled', 'time_format', 'uptime_enabled', 'user_text_enabled'];
 
 let sts;
-let ws = new WebSocket('//' + document.location.hostname + ':8089?token=<%= $ws_token %>');
+
+const wsPort = location.protocol === "https:" ? 8090 : 8089;
+let ws = new WebSocket('//' + location.hostname + ':' + wsPort + '?token=<%= $ws_token %>');
+
 ws.onopen = () => {
 	console.log('WebSocket connection opened');
 	const stream_rq = '{' +

--- a/package/thingino-webui/files/www/x/preview.cgi
+++ b/package/thingino-webui/files/www/x/preview.cgi
@@ -121,7 +121,9 @@ function updatePreview(data) {
 	ws.send('{"action":{"capture":null}}');
 }
 
-let ws = new WebSocket(`//${document.location.hostname}:8089?token=<%= $ws_token %>`);
+const wsPort = location.protocol === "https:" ? 8090 : 8089;
+let ws = new WebSocket(`//${document.location.hostname}:${wsPort}?token=<%= $ws_token %>`);
+
 ws.onopen = () => {
 	console.log('WebSocket connection opened');
 	ws.binaryType = 'arraybuffer';

--- a/package/thingino-webui/files/www/x/service-motion.cgi
+++ b/package/thingino-webui/files/www/x/service-motion.cgi
@@ -33,7 +33,9 @@ which sends alerts through the selected and preconfigured notification methods.<
 const motion_params = ['enabled', 'sensitivity', 'cooldown_time'];
 const send2_targets = ['email', 'ftp', 'mqtt', 'telegram', 'webhook', 'yadisk'];
 
-let ws = new WebSocket('//' + document.location.hostname + ':8089?token=<%= $ws_token %>');
+const wsPort = location.protocol === "https:" ? 8090 : 8089;
+let ws = new WebSocket('//' + document.location.hostname + ':' + wsPort + '?token=<%= $ws_token %>');
+
 ws.onopen = () => {
 	console.log('WebSocket connection opened');
 	const payload = '{"motion":{' + motion_params.map((x) => `"${x}":null`).join() + '}}';


### PR DESCRIPTION
The way it currently works, in the CGI webpages, the port to seek websocket is hardcoded to the value 8089. This value works because prudynt uses that port for providing unencrypted websocket connection, which is used for the camera preview.

This, however, causes an issue in camera preview when getting SSL to work by wrapping the http stream with a reverse proxy. The problem is that now port 8089 is expecting to provide WSS connection instead of WS, which breaks the stream.

This PR provides a simple (perhaps temporary) solution to this problem. If any of the CGI files that use websocket detect that the webpage is using SSL protocol, it uses port 8090 instead of 8089.

This solution was tested with stunnel (being the reverse proxy), and it works.

To test it:

1. Add `BR2_PACKAGE_STUNNEL=y` to local.fragment
2. Compile your camera firmware
3. Push the firmware to the camera
4. Issue your certificate, and concatenate your CA certificate, server private key and signed certificate and place that file in /etc/stunnel.conf
5. Edit /etc/stunnel/stunnel.conf to this:
```
[https]
accept  = 443
connect = 80
cert = /etc/stunnel.pem

[ws]
accept  = 8090
connect = 8089
cert = /etc/stunnel.pem
```
6. Run `stunnel`. Now the reverse proxy works. If everything is alright, it usually doesn't write anything in the terminal's stdout/stderr.
7. You can check with `netstat -plunt` that port 443 is occupied.
8. Visit the https link to your camera's hostname, like `https://hostname.local`.
9. Profit!