### PR TITLE
Fixed Homing on boot

### DIFF
--- a/package/thingino-motors/files/S09motor
+++ b/package/thingino-motors/files/S09motor
@@ -31,7 +31,7 @@ set_motors_speed() {
 }
 
 position_motors() {
-	local x y motor_pos_0
+	local x y
 
 	if [ -n "$motor_pos_0" ]; then
 		x=$(echo $motor_pos_0 | cut -d, -f1)


### PR DESCRIPTION
Fixed Homing On Boot by making motor_pos_0 NOT local in position_motors()

#590 