### PR TITLE
Always send mqtt message, but snapshot only if enabled & configured

### DIFF
--- a/overlay/lower/usr/sbin/send2mqtt
+++ b/overlay/lower/usr/sbin/send2mqtt
@@ -66,17 +66,26 @@ if [ -n "$mqtt_password" ]; then
 	command="$command -P $mqtt_password"
 fi
 
-if [ "true" = "$mqtt_send_snap" ]; then
-	attachment=$(mktemp -u).jpg
-	cp -f "$SNAPSHOT_FILE" "$attachment"
-	command="$command -t $mqtt_snap_topic -f \"$attachment\""
-else
-	command="$command -t $mqtt_topic -m \"$mqtt_message\""
+mqtt_failed=0
+send_command="$command -t $mqtt_topic -m \"$mqtt_message\""
+if ! sh -c "$send_command"; then
+        echo_error "Failed to send MQTT message"
+        mqtt_failed=1
 fi
 
-if ! sh -c "$command"; then
-	echo_error "Failed to send MQTT message"
-	exit 1
+if [ "true" = "$mqtt_send_snap" ]; then
+        attachment=$(mktemp -u).jpg
+        cp -f "$SNAPSHOT_FILE" "$attachment"
+        send_command="$command -t $mqtt_snap_topic -f \"$attachment\""
+
+        if ! sh -c "$send_command"; then
+                echo_error "Failed to send snapshot via MQTT"
+                mqtt_failed=1
+        fi
+fi
+
+if [ $mqtt_failed -eq 1 ]; then
+        exit 1
 fi
 
 [ -f "$attachment" ] && rm "$attachment"


### PR DESCRIPTION
Previously if snapshot was enabled, mqtt_message was not sent to mqtt_topic. 

Now, it always pubs to the mqtt_topic, but optionally and additionally pubs to the mqtt_snap_topic.  

This change allows for monitoring subs that don't want snap, they can monitor the text-only pubs.  For example, I log the motion triggers via text string, but don't need to get the snapshots for logging on all devices, they are already in frigate/NVR/etc.  It generally makes automation triggers easier having the option of snaphot or message text available and then just subscribing to the appropriate topic

mqtt_message & mqtt_topic were already required parameters to the script so I wouldn't expect this to be a breaking change for anything.  It shouldn't be much additional overhead, assuming mqtt_message configured is reasonable.  Since they are already choosing to send a snapshot image, sending the message text as well should be negligible.