### PR TITLE
Add day/night mode gain thresholds to Howell QJ05T (again)

### DIFF
--- a/configs/cameras/howell_qj05t_t20l_sc2235_eth+rtl8188ftv/howell_qj05t_t20l_sc2235_eth+rtl8188ftv.config
+++ b/configs/cameras/howell_qj05t_t20l_sc2235_eth+rtl8188ftv/howell_qj05t_t20l_sc2235_eth+rtl8188ftv.config
@@ -1,1 +1,3 @@
 wlan_module="8188fu"
+day_night_max="5000"
+day_night_min="2500"


### PR DESCRIPTION
They got mistakenly removed by https://github.com/themactep/thingino-firmware/commit/428cfa83e3d492392feffcb6f7994f1ad7e90448#diff-c638bdb18a6b866ba2d9e3ed725a7f9b67f529257117c6256db122d3830c33a1.