### PR TITLE
Aobo A12: configure gpios

### DIFF
--- a/configs/cameras/aobocam_a12_t23dl_jxh63p_txw901u/aobocam_a12_t23dl_jxh63p_txw901u.uenv.txt
+++ b/configs/cameras/aobocam_a12_t23dl_jxh63p_txw901u/aobocam_a12_t23dl_jxh63p_txw901u.uenv.txt
@@ -1,9 +1,9 @@
 gpio_button=62
 gpio_button_2=63
-gpio_ircut=
 gpio_default=18O 49o 51O 52i 53o 54O 57i 58i 59i 61O 62i 63i 91i 92i
+gpio_ir940=53
+gpio_ircut=-1
+gpio_led_b=51o
 gpio_led_g=54o
 gpio_led_r=49O
-gpio_led_b=51o
 gpio_mmc_cd=52
-gpio_ir940=53

--- a/configs/cameras/aobocam_a12_t23dl_jxh63p_txw901u/aobocam_a12_t23dl_jxh63p_txw901u.uenv.txt
+++ b/configs/cameras/aobocam_a12_t23dl_jxh63p_txw901u/aobocam_a12_t23dl_jxh63p_txw901u.uenv.txt
@@ -1,8 +1,9 @@
 gpio_button=62
 gpio_button_2=63
-gpio_ircut=-1
+gpio_ircut=
 gpio_default=49o 51O 54O
 gpio_led_g=54o
 gpio_led_r=49O
 gpio_led_b=51o
 gpio_mmc_cd=52
+gpio_ir940=53

--- a/configs/cameras/aobocam_a12_t23dl_jxh63p_txw901u/aobocam_a12_t23dl_jxh63p_txw901u.uenv.txt
+++ b/configs/cameras/aobocam_a12_t23dl_jxh63p_txw901u/aobocam_a12_t23dl_jxh63p_txw901u.uenv.txt
@@ -1,7 +1,7 @@
 gpio_button=62
 gpio_button_2=63
 gpio_ircut=
-gpio_default=49o 51O 54O
+gpio_default=18O 49o 51O 52i 53o 54O 57i 58i 59i 61O 62i 63i 91i 92i
 gpio_led_g=54o
 gpio_led_r=49O
 gpio_led_b=51o


### PR DESCRIPTION
This is the full gpio mapping extracted from the factory firmware:
```
GPIOs 0-31, GPIO A:
 gpio-18  (jxh63p_reset        ) out hi

GPIOs 32-63, GPIO B:
 gpio-49  (sysfs               ) out hi
 gpio-51  (sysfs               ) out lo
 gpio-52  (mmc_detect          ) in  lo
 gpio-53  (sysfs               ) out lo
 gpio-54  (sysfs               ) out hi
 gpio-57  (sda                 ) in  lo
 gpio-58  (scl                 ) in  lo
 gpio-59  (sysfs               ) in  hi
 gpio-61  (sysfs               ) out hi
 gpio-62  (sysfs               ) in  hi
 gpio-63  (sysfs               ) in  lo

GPIOs 64-95, GPIO C:
 gpio-91  (sda                 ) in  lo
 gpio-92  (scl                 ) in  lo
 ```
 
 Let me know if any of them are useful and should be also added to the camera env config.