### PR TITLE
scripts: improve dep check for rpm-based systems

### DIFF
--- a/scripts/dep_check.sh
+++ b/scripts/dep_check.sh
@@ -111,7 +111,7 @@ if [ -f /etc/os-release ]; then
 				rhel|centos|fedora)
 					echo "RedHat-based"
 					pkg_manager="rpm"
-					pkg_check_command="rpm -q"
+					pkg_check_command="rpm -q --whatprovides"
 					pkg_install_cmd="dnf install -y"
 					packages="gcc make bc bison cpio cmake curl file flex gawk git nano ncurses-devel rsync unzip uboot-tools wget newt dialog"
 					;;


### PR DESCRIPTION
`rpm -q` will fail if the package is provided by another package (for example, on recent Fedora versions `wget` is actually provided by `wget2-wget`. Use `rpm -q --whatprovides` instead which works properly in this case.