### PR TITLE
gitignore: add buildroot-dl cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /.vscode
 /build.log
 /buildroot-*/
+/buildroot-dl-cache\.zip*
 /configs/local.*
 /local.mk
 /output*/


### PR DESCRIPTION
The `download-cache` option in the user menu downloads the cache zip in the checkout root, add it to gitignore to avoid accidentally polluting the working set.