### PR TITLE
Change Daynight to daemon

### DIFF
--- a/overlay/lower/usr/share/common
+++ b/overlay/lower/usr/share/common
@@ -42,6 +42,7 @@ TZCODE_FILE="/etc/TZ"
 TZJSON_FILE="/usr/share/tz.json.gz"
 TZNAME_FILE="/etc/timezone"
 VBUFFER_FILE="/tmp/vbuffer.mp4"
+DN_MODE_FILE="/tmp/daynightmode"
 WLANAP_MODE_FLAG="/run/wlanap_mode"
 
 DAEMON=${DAEMON:-$0}

--- a/package/thingino-ircut/files/S08daynight
+++ b/package/thingino-ircut/files/S08daynight
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+. /usr/share/common
+
+start() {
+	echo_title "Starting Record service"
+
+	if pidof -o $$ $DAEMON > /dev/null; then
+		echo_error "$DAEMON is already running"
+		exit 1
+	fi
+
+
+	start_daemon
+}
+
+stop() {
+	echo_title "Stopping Daynight daemon"
+
+	find /tmp/ -name "daynight.*" -maxdepth 0 -delete
+
+	stop_daemon
+
+}
+
+case "$1" in
+	start)
+		start
+		;;
+	stop)
+		stop
+		;;
+
+	restart)
+		stop
+		sleep 1
+		start
+		;;
+	*)
+		usage "{start|stop|restart}"
+		;;
+esac
+
+exit 0

--- a/package/thingino-ircut/files/S08daynight
+++ b/package/thingino-ircut/files/S08daynight
@@ -2,24 +2,24 @@
 
 . /usr/share/common
 
+DAEMON="daynight"
+
 start() {
-	echo_title "Starting Record service"
+	echo_title "Starting daynight daemon"
 
 	if pidof -o $$ $DAEMON > /dev/null; then
 		echo_error "$DAEMON is already running"
 		exit 1
 	fi
 
-
-	start_daemon
+	$DAEMON > /dev/null 2>&1 &
 }
 
 stop() {
 	echo_title "Stopping Daynight daemon"
 
-	find /tmp/ -name "daynight.*" -maxdepth 0 -delete
+	find /tmp/ -name "daynight.*" -maxdepth 1 -delete
 
-	stop_daemon
 
 }
 

--- a/package/thingino-ircut/files/daynight
+++ b/package/thingino-ircut/files/daynight
@@ -5,6 +5,7 @@
 singleton $0
 
 MODE_FILE="/tmp/nightmode.txt"
+DN_MODE_FILE="/tmp/dnmode.txt"
 
 [ -f "$MODE_FILE" ] || echo "day" >"$MODE_FILE"
 
@@ -93,7 +94,7 @@ switch_to_night() {
 	echo_info "Switched to night mode"
 
 	if controls_color; then
-		echo_info "switch to monocrome mode"
+		echo_info "switch to monochrome mode"
 		color off &
 	fi
 
@@ -130,16 +131,19 @@ limit_break()
 	echo ""
 }
 
-slimit_break()
+dlimit_break()
 {
-	if [ "$3" -le "$day_night_toggle_limit" ]; then
+	if [ "$3" -lt "$day_night_toggle_limit" ]; then
+		echo_info "was at $3 vs  $day_night_toggle_limit"
 		echo $(limit_break "$1" "$2")
+	else
+		echo_info "prevented excessive switching"
 	fi
 }
 
 get_luminance()
 {
-	value=$(imp-control gettotalgain)
+	local value=$(imp-control gettotalgain)
 	if [ -z "$value" ] || [ "error" = "$value" ]; then
 		echo_error "failed to get luminance"
 		rm "$DN_FLAG"
@@ -160,7 +164,7 @@ toggle_day_night()
 last_value=$(get_luminance)
 light_switch()
 {
-	abs_diff=$(($2 - "$last_value"))
+	local abs_diff=$(($2 - "$last_value"))
 	if [ "$abs_diff" -gt "$day_night_switch" ]; then
 		echo $(toggle_day_night "$1")
 	fi
@@ -168,16 +172,26 @@ light_switch()
 
 check_method()
 {
-	method="dummy"
-	if  [ "$day_night_method" = "none" ]; then
-		method="limit" 
-	elif [ "$day_night_method" = "file" ]; then
-		method="file"
-	else
+	local method="dummy"
+	case "$day_night_method" in
+		limit|none) method="limit" ;;
+		dlimit) method="dlimit" ;;
+		file) method="file" ;;
+		*) echo_info "not implemented yet" ;;
 		# put code here to do time-based scheduling
-	fi
+	esac
 	echo "$method"
 }
+
+light_sleep()
+{
+	local i=0   
+	while [ -f "$DN_FLAG" ] && [ $i -le "$1" ]; do
+  		i=$((i + 1))                                                          
+  		sleep 1  # Sleep for 1 second, then check again
+	done
+}
+
 
 # fail-safe defaults
 [ -z "$day_night_min" ] && day_night_min=500
@@ -212,9 +226,11 @@ while : ; do
 			day) action="day" ;;
 			~ | toggle) action=$(toggle_day_night "$state") ;;
 		esac
-		dn_method="once"
-		day_night_wait=0
-		rm "$DN_FLAG"
+		if [ ! -z "$action" ]; then
+			dn_method="once"
+			rm "$DN_FLAG" 
+			day_night_wait=0
+		fi
 	else 
 		dn_method=$(check_method)
 	fi
@@ -230,11 +246,12 @@ while : ; do
 	echo_info "value: $value"
 
 	if [ "$dn_method" = "file" ]; then
-		file_value=$(cat "$DN_MODE_FILE") ;;
+		dn_method=$(cat "$DN_MODE_FILE")
 	fi
+	echo_info "running in $dn_method mode"
 	case "$dn_method" in
 		limit) 	action=$(limit_break "$state" "$value") ;;
-		slimit) action=$(slimit_break "$state" "$value" "$day_night_toggle_limit") ;;
+		dlimit) action=$(dlimit_break "$state" "$value" "$dn_switch_repeat") ;;
 		switch) action=$(light_switch "$state" "$value") ;;
 		day) action="day";;
 		night) action="night";;
@@ -243,10 +260,11 @@ while : ; do
 
 	if [ ! -z "$action" ]; then
 		if [ "$action" = "$state" ]; then
+			echo_info "already in state $state; skipping"
 			dn_switch_repeat=$((dn_switch_repeat - 1))
 		else
 			dn_switch_repeat=$((dn_switch_repeat + 1))
-			echo_info "pre-action state: $state"
+			echo_info "switching from $state to $action ($dn_switch_repeat in a row)"
 			case "$action" in
 				night) switch_to_night ;;
 				day) switch_to_day ;;
@@ -256,7 +274,8 @@ while : ; do
 		dn_switch_repeat=$((dn_switch_repeat - 1))
 	fi
 
-	sleep "$day_night_wait"
+	echo_info "waiting $day_night_wait"
+	light_sleep "$day_night_wait"
 
 done
 

--- a/package/thingino-ircut/files/daynight
+++ b/package/thingino-ircut/files/daynight
@@ -5,6 +5,8 @@
 singleton $0
 
 MODE_FILE="/tmp/nightmode.txt"
+DN_MODE_FILE="/tmp/daynightmode"
+
 [ -f "$MODE_FILE" ] || echo "day" >"$MODE_FILE"
 
 controls_color() {
@@ -119,6 +121,65 @@ switch_to_night() {
 	echo "night" >"$MODE_FILE"
 }
 
+function limit_break()
+{
+	if [ "$2" -gt "$day_night_max" ] && [ "night" != "$1" ]; then
+		echo "night"
+	elif [ "$2" -lt "$day_night_min" ] && [ "day" != "$1" ]; then
+		echo "day"
+	fi
+	echo ""
+}
+
+function slimit_break()
+{
+	if [ "$3" -le "$day_night_toggle_limit" ]; then
+		echo $(limit_break "$1" "$2")
+	fi
+}
+
+function get_luminence()
+{
+	value=$(imp-control gettotalgain)
+	if [ -z "$value" ] || [ "error" = "$value" ]; then
+		echo_error "failed to get luminance"
+		rm "$DN_FLAG"
+		exit 1
+	fi
+	echo "$value"
+}
+
+function toggle_day_night()
+{
+	if [ "$1" = "day" ]; then
+		echo "night"
+	else
+		echo="day"
+	fi
+}
+
+last_value=$(get_luminence)
+function light_switch()
+{
+	abs_diff=$(expr "$2" - "$last_value") 
+	if [ "$abs_diff" -gt "$day_night_switch" ]; then
+		echo $(toggle_day_night "$1")
+	fi
+}
+
+function check_sched()
+{
+	mode="dummy"
+	if  ["$day_night_sched" = "none" ]; then
+		mode="limit" 
+	elif ["$day_night_sched" = "file"]; then
+		mode=$(cat "$DN_MODE_FILE")
+	else
+		#put code here to do time-based scheduling
+	fi
+	echo "$mode"
+}
+
 # fail-safe defaults
 [ -z "$day_night_min" ] && day_night_min=500
 [ -z "$day_night_max" ] && day_night_max=15000
@@ -127,63 +188,73 @@ switch_to_night() {
 [ -z "$day_night_ir850" ] && day_night_ir850="true"
 [ -z "$day_night_ir940" ] && day_night_ir940="true"
 [ -z "$day_night_white" ] && day_night_white="true"
+[ -z "$day_night_wait" ] && day_night_wait=60
+[ -z "$day_night_switch" ] && day_night_switch=1000
+[ -z "$day_night_toggle_limit" ] && day_night_toggle_limit=3
+[ -z "$day_night_sched" ] && day_night_sched="none"
 
-# determine luminance of the scene
-value=$(imp-control gettotalgain)
-if [ -z "$value" ] || [ "error" = "$value" ]; then
-	echo_error "failed to get luminance"
-	exit 1
-fi
 
-reversed=1
-state=$(cat "$MODE_FILE" 2>/dev/null)
 
-case "$1" in
-	night)
-		switch_to_night
-		;;
-	day)
-		switch_to_day
-		;;
-	~ | toggle)
-		if [ "day" = "$state" ]; then
-			switch_to_night
+DN_FLAG="/tmp/daynight.$$"
+touch "$DN_FLAG"
+dn_switch_repeat=0
+
+while : ; do
+	[ -f $DN_FLAG ] || break
+
+	# determine luminance of the scene
+	value=$(get_luminance)
+	state=$(cat "$MODE_FILE" 2>/dev/null)
+
+	#if we were given a parameter then we will only run once and do the parameter
+	if [! -z "$1" ]; then 
+		case "$1" in
+			night) action="night" ;;
+			day) action="day" ;;
+			~ | toggle) action=$(toggle_day_night "$state") ;;
+		esac
+		dn_mode="once"
+		rm "$DN_FLAG"
+	else 
+		dn_mode=$(check_sched)
+	fi
+
+	echo_info "day_night_min: $day_night_min"
+	echo_info "day_night_max: $day_night_max"
+	echo_info "state: $state"
+	if [ "day" = "$state" ]; then
+		echo_info "active range: 0-$day_night_max"
+	else
+		echo_info "active range: $day_night_min-Infinity"
+	fi
+	echo_info "value: $value"
+
+	case "$dn_mode" in
+		limit) 	action=$(limit_break "$state" "$value") ;;
+		slimit) action=$(slimit_break "$state" $value" "$dn_switch_repeat") ;;
+		switch) action=$(ligth_switch "$state" $value") ;;
+		dummy) action="";;
+	esac
+
+	if [! -z "$action"]; then
+		if [ "$action" = "$state" ]; then
+			dn_switch_repeat=$((dn_switch_repeat - 1))
 		else
-			switch_to_day
+			dn_switch_repeat=$((dn_switch_repeat + 1))
+			echo_info "new state: $state"
+			case "$action" in
+				night) switch_to_night ;;
+				day) switch_to_day ;;
+			esac
 		fi
-		;;
-	\? | read | status)
-		echo $state
-		;;
-	*)
-		echo_info "day_night_min: $day_night_min"
-		echo_info "day_night_max: $day_night_max"
-		echo_info "state: $state"
-		if [ "day" = "$state" ]; then
-			echo_info "active range: 0-$day_night_max"
-		else
-			echo_info "active range: $day_night_min-Infinity"
-		fi
-		echo_info "value: $value"
+	else
+		dn_switch_repeat=$((dn_switch_repeat - 1))
+	fi
 
-		if [ "$reversed" -eq 0 ]; then
-			if [ "$value" -lt "$day_night_min" ] && [ "day" != "$state" ]; then
-				switch_to_day
-			elif [ "$value" -gt "$day_night_max" ] && [ "night" != "$state" ]; then
-				switch_to_night
-			else
-				echo_info "within limits"
-			fi
-		else
-			if [ "$value" -gt "$day_night_max" ] && [ "night" != "$state" ]; then
-				switch_to_night
-			elif [ "$value" -lt "$day_night_min" ] && [ "day" != "$state" ]; then
-				switch_to_day
-			else
-				echo_info "within limits"
-			fi
-		fi
-		;;
+	sleep "$dn_wait"
+
 esac
+
+done
 
 exit 0

--- a/package/thingino-ircut/files/daynight
+++ b/package/thingino-ircut/files/daynight
@@ -228,11 +228,15 @@ while : ; do
 	fi
 	echo_info "value: $value"
 
+	if [ "$dn_method" = "file"]; then
+		file_value=$(cat "$DN_MODE_FILE") ;;
+	fi
 	case "$dn_method" in
 		limit) 	action=$(limit_break "$state" "$value") ;;
 		slimit) action=$(slimit_break "$state" "$value" "$day_night_toggle_limit") ;;
 		switch) action=$(light_switch "$state" "$value") ;;
-		file) action=$(cat "$DN_MODE_FILE") ;;
+		day) action="day";;
+		night) action="night";;
 		dummy) action="";;
 	esac
 

--- a/package/thingino-ircut/files/daynight
+++ b/package/thingino-ircut/files/daynight
@@ -231,7 +231,7 @@ while : ; do
 	case "$dn_mode" in
 		limit) 	action=$(limit_break "$state" "$value") ;;
 		slimit) action=$(slimit_break "$state" $value" "$dn_switch_repeat") ;;
-		switch) action=$(ligth_switch "$state" $value") ;;
+		switch) action=$(light_switch "$state" $value") ;;
 		dummy) action="";;
 	esac
 

--- a/package/thingino-ircut/files/daynight
+++ b/package/thingino-ircut/files/daynight
@@ -169,9 +169,9 @@ function light_switch()
 function check_sched()
 {
 	mode="dummy"
-	if  ["$day_night_sched" = "none" ]; then
+	if  [ "$day_night_sched" = "none" ]; then
 		mode="limit" 
-	elif ["$day_night_sched" = "file"]; then
+	elif [ "$day_night_sched" = "file" ]; then
 		mode=$(cat "$DN_MODE_FILE")
 	else
 		#put code here to do time-based scheduling

--- a/package/thingino-ircut/files/daynight
+++ b/package/thingino-ircut/files/daynight
@@ -166,17 +166,17 @@ function light_switch()
 	fi
 }
 
-function check_sched()
+function check_method()
 {
-	mode="dummy"
-	if  [ "$day_night_sched" = "none" ]; then
-		mode="limit" 
-	elif [ "$day_night_sched" = "file" ]; then
-		mode=$(cat "$DN_MODE_FILE")
+	method="dummy"
+	if  [ "$day_night_method" = "none" ]; then
+		method="limit" 
+	elif [ "$day_night_method" = "file" ]; then
+		method="file"
 	else
 		#put code here to do time-based scheduling
 	fi
-	echo "$mode"
+	echo "$method"
 }
 
 # fail-safe defaults
@@ -190,7 +190,7 @@ function check_sched()
 [ -z "$day_night_wait" ] && day_night_wait=60
 [ -z "$day_night_switch" ] && day_night_switch=1000
 [ -z "$day_night_toggle_limit" ] && day_night_toggle_limit=3
-[ -z "$day_night_sched" ] && day_night_sched="none"
+[ -z "$day_night_method" ] && day_night_method="none"
 
 
 
@@ -212,10 +212,10 @@ while : ; do
 			day) action="day" ;;
 			~ | toggle) action=$(toggle_day_night "$state") ;;
 		esac
-		dn_mode="once"
+		dn_method="once"
 		rm "$DN_FLAG"
 	else 
-		dn_mode=$(check_sched)
+		dn_method=$(check_method)
 	fi
 
 	echo_info "day_night_min: $day_night_min"
@@ -228,10 +228,11 @@ while : ; do
 	fi
 	echo_info "value: $value"
 
-	case "$dn_mode" in
+	case "$dn_method" in
 		limit) 	action=$(limit_break "$state" "$value") ;;
 		slimit) action=$(slimit_break "$state" $value" "$dn_switch_repeat") ;;
 		switch) action=$(light_switch "$state" $value") ;;
+		file) action=$(cat "$DN_MODE_FILE") ;;
 		dummy) action="";;
 	esac
 

--- a/package/thingino-ircut/files/daynight
+++ b/package/thingino-ircut/files/daynight
@@ -213,6 +213,7 @@ while : ; do
 			~ | toggle) action=$(toggle_day_night "$state") ;;
 		esac
 		dn_method="once"
+		day_night_wait=0
 		rm "$DN_FLAG"
 	else 
 		dn_method=$(check_method)
@@ -228,7 +229,7 @@ while : ; do
 	fi
 	echo_info "value: $value"
 
-	if [ "$dn_method" = "file"]; then
+	if [ "$dn_method" = "file" ]; then
 		file_value=$(cat "$DN_MODE_FILE") ;;
 	fi
 	case "$dn_method" in
@@ -240,7 +241,7 @@ while : ; do
 		dummy) action="";;
 	esac
 
-	if [ ! -z "$action"]; then
+	if [ ! -z "$action" ]; then
 		if [ "$action" = "$state" ]; then
 			dn_switch_repeat=$((dn_switch_repeat - 1))
 		else

--- a/package/thingino-ircut/files/daynight
+++ b/package/thingino-ircut/files/daynight
@@ -120,7 +120,7 @@ switch_to_night() {
 	echo "night" >"$MODE_FILE"
 }
 
-function limit_break()
+limit_break()
 {
 	if [ "$2" -gt "$day_night_max" ] && [ "night" != "$1" ]; then
 		echo "night"
@@ -130,14 +130,14 @@ function limit_break()
 	echo ""
 }
 
-function slimit_break()
+slimit_break()
 {
 	if [ "$3" -le "$day_night_toggle_limit" ]; then
 		echo $(limit_break "$1" "$2")
 	fi
 }
 
-function get_luminence()
+get_luminance()
 {
 	value=$(imp-control gettotalgain)
 	if [ -z "$value" ] || [ "error" = "$value" ]; then
@@ -148,25 +148,25 @@ function get_luminence()
 	echo "$value"
 }
 
-function toggle_day_night()
+toggle_day_night()
 {
 	if [ "$1" = "day" ]; then
 		echo "night"
 	else
-		echo="day"
+		echo "day"
 	fi
 }
 
-last_value=$(get_luminence)
-function light_switch()
+last_value=$(get_luminance)
+light_switch()
 {
-	abs_diff=$(expr "$2" - "$last_value") 
+	abs_diff=$(($2 - "$last_value"))
 	if [ "$abs_diff" -gt "$day_night_switch" ]; then
 		echo $(toggle_day_night "$1")
 	fi
 }
 
-function check_method()
+check_method()
 {
 	method="dummy"
 	if  [ "$day_night_method" = "none" ]; then
@@ -174,7 +174,7 @@ function check_method()
 	elif [ "$day_night_method" = "file" ]; then
 		method="file"
 	else
-		#put code here to do time-based scheduling
+		# put code here to do time-based scheduling
 	fi
 	echo "$method"
 }
@@ -199,14 +199,14 @@ touch "$DN_FLAG"
 dn_switch_repeat=0
 
 while : ; do
-	[ -f $DN_FLAG ] || break
+	[ -f "$DN_FLAG" ] || break
 
 	# determine luminance of the scene
 	value=$(get_luminance)
 	state=$(cat "$MODE_FILE" 2>/dev/null)
 
 	#if we were given a parameter then we will only run once and do the parameter
-	if [! -z "$1" ]; then 
+	if [ ! -z "$1" ]; then 
 		case "$1" in
 			night) action="night" ;;
 			day) action="day" ;;
@@ -230,18 +230,18 @@ while : ; do
 
 	case "$dn_method" in
 		limit) 	action=$(limit_break "$state" "$value") ;;
-		slimit) action=$(slimit_break "$state" $value" "$dn_switch_repeat") ;;
-		switch) action=$(light_switch "$state" $value") ;;
+		slimit) action=$(slimit_break "$state" "$value" "$day_night_toggle_limit") ;;
+		switch) action=$(light_switch "$state" "$value") ;;
 		file) action=$(cat "$DN_MODE_FILE") ;;
 		dummy) action="";;
 	esac
 
-	if [! -z "$action"]; then
+	if [ ! -z "$action"]; then
 		if [ "$action" = "$state" ]; then
 			dn_switch_repeat=$((dn_switch_repeat - 1))
 		else
 			dn_switch_repeat=$((dn_switch_repeat + 1))
-			echo_info "new state: $state"
+			echo_info "pre-action state: $state"
 			case "$action" in
 				night) switch_to_night ;;
 				day) switch_to_day ;;
@@ -251,9 +251,7 @@ while : ; do
 		dn_switch_repeat=$((dn_switch_repeat - 1))
 	fi
 
-	sleep "$dn_wait"
-
-esac
+	sleep "$day_night_wait"
 
 done
 

--- a/package/thingino-ircut/files/daynight
+++ b/package/thingino-ircut/files/daynight
@@ -5,7 +5,6 @@
 singleton $0
 
 MODE_FILE="/tmp/nightmode.txt"
-DN_MODE_FILE="/tmp/daynightmode"
 
 [ -f "$MODE_FILE" ] || echo "day" >"$MODE_FILE"
 

--- a/package/thingino-ircut/files/dusk2dawn
+++ b/package/thingino-ircut/files/dusk2dawn
@@ -84,9 +84,9 @@ sed -i "/$SS_MARK/,+1d" $tmpfile
 	echo "# run dusk2dawn nightly at 0:00"
 	echo "0 0 * * * dusk2dawn"
 	echo "$SS_MARK"
-	echo "$(time_for_cron "$sr_time") * * * daynight day"
+	echo "$(time_for_cron "$sr_time") * * * echo "day" > "$DN_MODE_FILE"
 	echo "$SR_MARK"
-	echo "$(time_for_cron "$ss_time") * * * daynight night"
+	echo "$(time_for_cron "$ss_time") * * * echo "night" > "$DN_MODE_FILE"
 } >> $tmpfile
 cp $tmpfile $CRONTABS
 

--- a/package/thingino-ircut/thingino-ircut.mk
+++ b/package/thingino-ircut/thingino-ircut.mk
@@ -4,6 +4,7 @@ THINGINO_IRCUT_SITE = $(BR2_EXTERNAL)/package/thingino-ircut
 define THINGINO_IRCUT_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0755 $(@D)/files/S06ircut $(TARGET_DIR)/etc/init.d/S06ircut
 	$(INSTALL) -D -m 0755 $(@D)/files/S07dusk2dawn $(TARGET_DIR)/etc/init.d/S07dusk2dawn
+	$(INSTALL) -D -m 0755 $(@D)/files/S08daynight $(TARGET_DIR)/etc/init.d/S08daynight
 	$(INSTALL) -D -m 0755 $(@D)/files/daynight $(TARGET_DIR)/usr/sbin/daynight
 	$(INSTALL) -D -m 0755 $(@D)/files/irled $(TARGET_DIR)/usr/sbin/irled
 	$(INSTALL) -D -m 0755 $(@D)/files/ircut $(TARGET_DIR)/usr/sbin/ircut

--- a/package/thingino-webui/files/www/x/config-daynight.cgi
+++ b/package/thingino-webui/files/www/x/config-daynight.cgi
@@ -13,17 +13,17 @@ defaults() {
 	default_for day_night_ir850 "false"
 	default_for day_night_ir940 "false"
 	default_for day_night_white "false"
-	default_for dusk2dawn_offset_sr "0"
-	default_for dusk2dawn_offset_ss "0"
-	default_for day_night_interval "60"
+	default_for day_night_wait2 "60"
 	default_for day_night_method "none"
 	default_for day_night_toggle_limit "3"
+	default_for dusk2dawn_offset_sr "0"
+	default_for dusk2dawn_offset_ss "0"
 }
 
 if [ "POST" = "$REQUEST_METHOD" ]; then
 	error=""
 
-	read_from_post "day_night" "color enabled interval ir850 ir940 ircut max min white"
+	read_from_post "day_night" "color enabled wait2 method toggle_limit ir850 ir940 ircut max min white"
 	read_from_post "dusk2dawn" "enabled lat lng offset_sr offset_ss"
 
 	defaults

--- a/package/thingino-webui/files/www/x/config-daynight.cgi
+++ b/package/thingino-webui/files/www/x/config-daynight.cgi
@@ -17,7 +17,7 @@ defaults() {
 	default_for dusk2dawn_offset_sr "0"
 	default_for dusk2dawn_offset_ss "0"
 	default_for day_night_interval "60"
-	default_for day_night_sched "none"
+	default_for day_night_method "none"
 }
 
 if [ "POST" = "$REQUEST_METHOD" ]; then
@@ -86,8 +86,7 @@ name="day_night_interval" value="<%= $day_night_iternal %>" pattern="[0-9]{1,}" 
 class="form-control text-end" data-min="10" data-max="3600" data-step="10"> seconds</p>
 
 <h3>Daemon Check Method</h3>
-<p>Daemon Evaluation Method:
-<% field_select "day_night_sched" "Theme" "none,file,limit,dlimit,switch" %>
+<% field_select "day_night_method" "Daemon Evaluation Method" "none,file,limit,dlimit,switch" %>
 
 <h5>Day/Night Mode Toggles</h5>
 <% field_checkbox "day_night_color" "Change color mode" %>

--- a/package/thingino-webui/files/www/x/config-daynight.cgi
+++ b/package/thingino-webui/files/www/x/config-daynight.cgi
@@ -17,6 +17,7 @@ defaults() {
 	default_for dusk2dawn_offset_ss "0"
 	default_for day_night_interval "60"
 	default_for day_night_method "none"
+	default_for day_night_toggle_limit "3"
 }
 
 if [ "POST" = "$REQUEST_METHOD" ]; then
@@ -42,7 +43,7 @@ if [ "POST" = "$REQUEST_METHOD" ]; then
 
 		if [ "true" = "$dusk2dawn_enabled" ]; then
 			dusk2dawn > /dev/null
-			day_night_sched="file" # use file method when using dusk2dawn
+			day_night_method="file" # use file method when using dusk2dawn
 		fi
 
 		save2config "
@@ -55,8 +56,9 @@ day_night_ircut=\"$day_night_ircut\"
 day_night_max=\"$day_night_max\"
 day_night_min=\"$day_night_min\"
 day_night_white=\"$day_night_white\"
-day_night_sched=\"$day_night_sched\"
+day_night_method=\"$day_night_method\"
 dusk2dawn_enabled=\"$dusk2dawn_enabled\"
+day_night_toggle_limit=\"3\"
 dusk2dawn_lat=\"$dusk2dawn_lat\"
 dusk2dawn_lng=\"$dusk2dawn_lng\"
 dusk2dawn_offset_sr=\"$dusk2dawn_offset_sr\"

--- a/package/thingino-webui/files/www/x/config-daynight.cgi
+++ b/package/thingino-webui/files/www/x/config-daynight.cgi
@@ -13,9 +13,9 @@ defaults() {
 	default_for day_night_ir850 "false"
 	default_for day_night_ir940 "false"
 	default_for day_night_white "false"
-	default_for day_night_wait2 "60"
-	default_for day_night_method "none"
-	default_for day_night_toggle_limit "3"
+        default_for day_night_wait "60"    
+        default_for day_night_method "limit"  
+        default_for day_night_toggle_limit "3"
 	default_for dusk2dawn_offset_sr "0"
 	default_for dusk2dawn_offset_ss "0"
 }
@@ -23,7 +23,7 @@ defaults() {
 if [ "POST" = "$REQUEST_METHOD" ]; then
 	error=""
 
-	read_from_post "day_night" "color enabled wait2 method toggle_limit ir850 ir940 ircut max min white"
+	read_from_post "day_night" "color enabled method wait toggle_limit ir850 ir940 ircut max min white"
 	read_from_post "dusk2dawn" "enabled lat lng offset_sr offset_ss"
 
 	defaults
@@ -56,6 +56,7 @@ day_night_ircut=\"$day_night_ircut\"
 day_night_max=\"$day_night_max\"
 day_night_min=\"$day_night_min\"
 day_night_white=\"$day_night_white\"
+day_night_wait=\"$day_night_wait\"   
 day_night_method=\"$day_night_method\"
 dusk2dawn_enabled=\"$dusk2dawn_enabled\"
 day_night_toggle_limit=\"3\"
@@ -65,6 +66,7 @@ dusk2dawn_offset_sr=\"$dusk2dawn_offset_sr\"
 dusk2dawn_offset_ss=\"$dusk2dawn_offset_ss\"
 "
 
+		/etc/init.d/S08daynight restart
 		redirect_to $SCRIPT_NAME "success" "Data updated."
 	else
 		redirect_to $SCRIPT_NAME "danger" "Error: $error"
@@ -82,8 +84,8 @@ defaults
 
 <div class="col mb-3">
 <h3>Daemon Test Frequency</h3>
-<p>Have Daemon Check every <input type="text" id="day_night_interval"
-name="day_night_interval" value="<%= $day_night_iterval %>" pattern="[0-9]{1,}" title="numeric value"
+<p>Have Daemon Check every <input type="text" id="day_night_wait"
+name="day_night_wait" value="<%= "$day_night_wait" %>" pattern="[0-9]{1,}" title="numeric value"
 class="form-control text-end" data-min="10" data-max="3600" data-step="10"> seconds</p>
 
 <h3>Daemon Check Method</h3>
@@ -103,7 +105,7 @@ class="form-control text-end" data-min="10" data-max="3600" data-step="10"> seco
 <% field_number "day_night_min" "Switch to Day mode when gain drops below" %>
 <% field_number "day_night_max" "Switch to Night mode when gain raises above" %>
 
-<h3>"Plimit" Method</h3>
+<h3>Dlimit Method</h3>
 <% field_number "day_night_toggle_limit" "Limit on the number of successive toggles before cooling off." %>
 </div>
 

--- a/package/thingino-webui/files/www/x/config-daynight.cgi
+++ b/package/thingino-webui/files/www/x/config-daynight.cgi
@@ -77,11 +77,7 @@ defaults
 <form action="<%= $SCRIPT_NAME %>" method="post" class="mb-3">
 <div class="row row-cols-1 row-cols-md-2 row-cols-xxl-4 mb-4">
 
-<div class="col">
-<h3 class="alert alert-warning text-center">Gain <span class="gain"></span></h3>
-<% field_number "day_night_min" "Switch to Day mode when gain drops below" %>
-<% field_number "day_night_max" "Switch to Night mode when gain raises above" %>
-</div>
+
 
 <div class="col mb-3">
 <h3>Daemon Test Frequency</h3>
@@ -93,12 +89,22 @@ class="form-control text-end" data-min="10" data-max="3600" data-step="10"> seco
 <p>Daemon Evaluation Method:
 <% field_select "day_night_sched" "Theme" "none,file,limit,dlimit,switch" %>
 
-<h5>Actions to perform</h5>
+<h5>Day/Night Mode Toggles</h5>
 <% field_checkbox "day_night_color" "Change color mode" %>
 <% [ -z "$gpio_ircut" ] || field_checkbox "day_night_ircut" "Flip IR cut filter" %>
 <% [ -z "$gpio_ir850" ] || field_checkbox "day_night_ir850" "Toggle IR 850 nm" %>
 <% [ -z "$gpio_ir940" ] || field_checkbox "day_night_ir940" "Toggle IR 940 nm" %>
 <% [ -z "$gpio_white" ] || field_checkbox "day_night_white" "Toggle white light" %>
+</div>
+
+<div class="col">
+<h3>Limit Method Values</h3>
+<h5 class="alert alert-warning text-center">Gain <span class="gain"></span></h3>
+<% field_number "day_night_min" "Switch to Day mode when gain drops below" %>
+<% field_number "day_night_max" "Switch to Night mode when gain raises above" %>
+
+<h3>"Plimit" Method</h3>
+<% field_number "day_night_toggle_limit" "Limit on the number of successive toggles before cooling off." %>
 </div>
 
 <div class="col">
@@ -117,10 +123,12 @@ class="form-control text-end" data-min="10" data-max="3600" data-step="10"> seco
 
 <div class="col">
 <div class="alert alert-info">
-<p>The day/night mode is controlled by the brightness of the scene.
-Changes in illumination affect the gain required to normalise a darkened image - the darker the scene, the higher the gain value.
+<p>The day/night daemon controls whether the camera is in night or day mode.
+<ul><li>The "limit" method uses changes in thethe gain required to normalise a darkened image - the darker the scene, the higher the gain value.
 The current gain value is displayed at the top of each page next to the sun emoji.
-Switching between modes is triggered by changes in the gain beyond the threshold values.</p>
+It switches between modes is triggered by changes in the gain beyond the threshold values.</li>
+<li>The "dlimit" method avoids flipping back and forth rapidly by ticking up a counter when changes occur and cooling off between changes.</li>
+<li>The "file" method uses the file `/tmp/daynightmode` to set day or night.</ul></p>
 <% wiki_page "Configuration:-Night-Mode" %>
 </div>
 </div>

--- a/package/thingino-webui/files/www/x/config-daynight.cgi
+++ b/package/thingino-webui/files/www/x/config-daynight.cgi
@@ -6,7 +6,6 @@ page_title="Day/Night Mode Control"
 DAYNIGHT_APP="daynight"
 
 defaults() {
-	default_for day_night_interval "1"
 	default_for day_night_max "15000"
 	default_for day_night_min "5000"
 	default_for day_night_color "false"
@@ -82,7 +81,7 @@ defaults
 <div class="col mb-3">
 <h3>Daemon Test Frequency</h3>
 <p>Have Daemon Check every <input type="text" id="day_night_interval"
-name="day_night_interval" value="<%= $day_night_iternal %>" pattern="[0-9]{1,}" title="numeric value"
+name="day_night_interval" value="<%= $day_night_iterval %>" pattern="[0-9]{1,}" title="numeric value"
 class="form-control text-end" data-min="10" data-max="3600" data-step="10"> seconds</p>
 
 <h3>Daemon Check Method</h3>


### PR DESCRIPTION
Basically, rewrote some of the code related to the daynight management to make it work as a daemon.

This allows:
1. Intervals to be set at the second level instead of minute
2. Multiple methods for determining the whether to switch day night:
- previous behavior where high luminance / low luminance directly triggered made default and called "limit"
- "dlimit" same as limit but tries to prevent rapid switching by setting a max repeat count before cooling down
- "switch"  - here the idea would be to change only if there's a big luminence change over the interval regardless of the ranges
- "file" determine state based on a file.
3. removes a buggyness associated with reading out of the crontab file to figure out the current interval (at least in my case, the basic idea is that from 8pm until 6am I just forced it to do night mode to avoid rapid switching before and only used daynight during the day time hours).

Also cleaned up the config html page by reorganizing things a bit more logically to what they do.

I switched dusk2dawn to use the file method for directing the daemon.

Hopefully there's something useful in this.