### PR TITLE
fix: allow token-based auth

### DIFF
--- a/overlay/lower/usr/sbin/send2ntfy
+++ b/overlay/lower/usr/sbin/send2ntfy
@@ -62,7 +62,7 @@ if [ -n "$ntfy_delay" ]; then
 	command="$command -H 'Delay: $ntfy_delay'"
 fi
 
-if [ -n "$ntfy_username" ] && [ -n "$ntfy_password" ]; then
+if [ -n "$ntfy_password" ]; then
 	command="$command -u $ntfy_username:$ntfy_password"
 fi
 


### PR DESCRIPTION
There's probably a better way to do this, but ntfy allows us to [use curl's basic auth to authenticate with an access token](https://docs.ntfy.sh/publish/#access-tokens). This means that sometimes, an empty username is acceptable.