### PR TITLE
Improved Motion Guard Stability

### DIFF
--- a/overlay/lower/usr/sbin/send2telegram
+++ b/overlay/lower/usr/sbin/send2telegram
@@ -119,6 +119,7 @@ if [ "true" = "$telegram_attach_video" ] && [ "true" = "$telegram_attach_photo" 
 		n=$((n + 1))
 		if [ "$n" -ge 10 ]; then
 			echo_error "Give up after $n attempts."
+			remove_tempfiles
 			exit 1
 		fi
 		sleep 1
@@ -161,6 +162,7 @@ fi
 echo_command "$command"
 if ! sh -c "$command" >/dev/null; then
 	echo_error "Failed to send message to Telegram"
+	remove_tempfiles
 	exit 1
 fi
 

--- a/package/thingino-webui/files/www/x/service-motion.cgi
+++ b/package/thingino-webui/files/www/x/service-motion.cgi
@@ -9,7 +9,7 @@ page_title="Motion Guard"
 <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3">
 <div class="col">
 <% field_range "motion_sensitivity" "Sensitivity" "1,8,1" %>
-<% field_range "motion_cooldown_time" "Delay between alerts, sec." "5,30,1" %>
+<% field_range "motion_cooldown_time" "Delay between alerts, sec." "5,60,1" %>
 </div>
 <div class="col">
 <% field_checkbox "motion_send2email" "Send to email address" "<a href=\"tool-send2email.cgi\">Configure sending to email</a>" %>


### PR DESCRIPTION
I stopped a memory leak which resulted in degraded performance and crashes from send2telegram program. The lack of removal of temporary files from abnormal exits in other send2[X] programs can also cause crashes, I didn't fix them as I couldn't test them for stability improvements.

For some reason increasing the cooldown time between the motion alarms stopped my remaining crashes. I couldn't figure out the exact cause behind it, but changing the cooldown range on the GUI could help other users who experience similar issues.