### PR TITLE
disable two-way audio for low-memory devices

### DIFF
--- a/package/prudynt-t/prudynt-t.mk
+++ b/package/prudynt-t/prudynt-t.mk
@@ -147,7 +147,7 @@ define PRUDYNT_T_INSTALL_TARGET_CMDS
 
 	# Adjust buffer settings for low-memory devices
 	if [ "$(SOC_RAM)" -le "64" ]; then \
-		$(HOST_DIR)/bin/jq '.stream0.buffers = 1 | .stream1.buffers = 1' \
+		$(HOST_DIR)/bin/jq '.stream0.buffers = 1 | .stream1.buffers = 1 | .audio.output_enabled = false' \
 			$(STAGING_DIR)/prudynt.json > $(STAGING_DIR)/prudynt.json.tmp && \
 		mv $(STAGING_DIR)/prudynt.json.tmp $(STAGING_DIR)/prudynt.json; \
 	fi


### PR DESCRIPTION
Constant CPU load on T23:

```
Mem: 34228K used, 3284K free, 716K shrd, 3920K buff, 13960K cached
CPU: 24.7% usr 49.3% sys  0.0% nic  0.0% idle  0.0% io  0.0% irq 25.9% sirq
Load average: 2.97 3.09 3.50 2/85 20561
  PID  PPID USER     STAT   VSZ %VSZ CPU %CPU COMMAND
20507     1 root     S    44780119.1   0 92.9 /bin/prudynt --
```