### PR TITLE
Fix error output in telegrambot

### DIFF
--- a/overlay/lower/usr/sbin/telegrambot
+++ b/overlay/lower/usr/sbin/telegrambot
@@ -258,9 +258,9 @@ while :; do
 			for i in $(seq 0 9); do
 				[ "/$(eval echo \$telegrambot_command_$i)" = "$bot_command" ] || continue
 				script="$(eval echo \$telegrambot_script_$i | sed "s/\$chat_id/$chat_id/")"
-				message=$(eval $script)
+				message=$(eval $script 2>&1)
 				if [ $? -ne 0 ]; then
-					message="Execution failed! Please review the command:\n$script\n\nOutput:\n$result"
+					message="Execution failed! Please review the command:\n$script\n\nOutput:\n$message"
 				fi
 				break
 			done


### PR DESCRIPTION
This fixes two things:
1. The $result variable does not exist in the script, so it is always evaluated into an empty string.
2. The $message variable is set to the stdout of the command, ignoring stderr. This once again causes $message to be empty if an error occurs.

This can be tested by opening the web UI and adding a bot command that will always fail (like `ls /abc`), and then sending that command to the bot on Telegram.

Hope this helps!