### PR TITLE
tapo c200: fix homing

### DIFF
--- a/configs/cameras/tplink_tapo_c200_t23n_sc2336p_rtl8188ftv/tplink_tapo_c200_t23n_sc2336p_rtl8188ftv.uenv.txt
+++ b/configs/cameras/tplink_tapo_c200_t23n_sc2336p_rtl8188ftv/tplink_tapo_c200_t23n_sc2336p_rtl8188ftv.uenv.txt
@@ -13,6 +13,7 @@ gpio_wlan=51
 motor=spi
 motor_maxstep_h=7850
 motor_maxstep_v=2730
+motor_pos_0=3925,512
 motor_speed=430
 pwm_ch_ir850=0
 pwm_ch_white=1

--- a/package/thingino-motors/files/S09motor
+++ b/package/thingino-motors/files/S09motor
@@ -138,9 +138,7 @@ start() {
 		echo_info "Homing disabled"
 	else
 		home_motors
-		if [ -z "$motor" ]; then
-			position_motors
-		fi
+		position_motors
 	fi
 }
 


### PR DESCRIPTION
these changes are somehow related related to this PR https://github.com/themactep/thingino-firmware/pull/816
I reverted the change in S09motor from a previous commit and set the initial position in uenv.