### PR TITLE
[thingino-esphome] Fix for the action: media_player.play_media handling issue.

### DIFF
--- a/package/thingino-esphome/plugins/thingino_media_player/thingino_media_player.c
+++ b/package/thingino-esphome/plugins/thingino_media_player/thingino_media_player.c
@@ -1228,9 +1228,9 @@ int media_player_handle_message(esphome_plugin_context_t *ctx,
         switch (cmd_msg.command) {
             case MEDIA_PLAYER_COMMAND_PLAY:
                 pthread_mutex_lock(&g_player_ctx.lock);
-                g_player_ctx.state = MEDIA_PLAYER_STATE_PAUSED;
+                g_player_ctx.state = MEDIA_PLAYER_STATE_PLAYING;
                 pthread_mutex_unlock(&g_player_ctx.lock);
-                report_media_player_state(MEDIA_PLAYER_STATE_PAUSED, g_player_ctx.volume, g_player_ctx.muted);
+                report_media_player_state(MEDIA_PLAYER_STATE_PLAYING, g_player_ctx.volume, g_player_ctx.muted);
                 break;
 
             case MEDIA_PLAYER_COMMAND_PAUSE:


### PR DESCRIPTION
This PR fixes the media playback issue, example for HA:
```yaml
action: media_player.play_media
target:
  entity_id: media_player.cam_thingino_speaker
data:
  media:
    media_content_id: https://tavr.radio.tvstitch.com/KissFM_Deep_HD
    media_content_type: music
```

As you can see from the log, this is not a command for the media_player, and therefore download_and_stream_audio() is never called.

```
[esphome-api] <<< Received UNKNOWN (type=65, payload=118 bytes)
0d 01 00 00 00 30 01 3a 6d 68 74 74 70 3a 2f 2f 78 78 2e 78 78 78 2e 78 78 2e 78 78 3a 38 31 32 33 2f 61 70 69 2f 65 73 70 68 6f 6d 65 2f 66 66 6d 70 65 67 5f 70 72 6f 78 79 2f 61 30 39 31 32 31 63 30 66 61 33 64 30 31 61 31 36 38 34 63 65 36 39 38 65 30 61 33 63 32 62 31 2f 75 4d 73 70 74 35 78 70 79 2d 4d 79 68 43 74 37 4d 42 5a 45 38 41 2e 77 61 76
pb.pos 0x00, tag 0x0d, field_num 1, wire_type 5
pb.pos 0x05, tag 0x30, field_num 6, wire_type 0
pb.pos 0x07, tag 0x3a, field_num 7, wire_type 2
[plugin-manager] [INFO] [MediaPlayer] Received command: 0
[esphome-api] Message processed, 0 bytes remaining in buffer
```

This is MEDIA_PLAYER_COMMAND_STOP command
```
[esphome-api] <<< Received UNKNOWN (type=65, payload=9 bytes)
0d 01 00 00 00 10 01 18 02
pb.pos 0x00, tag 0x0d, field_num 1, wire_type 5
pb.pos 0x05, tag 0x10, field_num 2, wire_type 0
pb.pos 0x07, tag 0x18, field_num 3, wire_type 0
[plugin-manager] [INFO] [MediaPlayer] Received command: 2
[MediaPlayer] Stopping current playback
```
After fix:
```
[esphome-api] <<< Received UNKNOWN (type=65, payload=118 bytes)
[esphome-api] Message processed, 0 bytes remaining in buffer
[MediaPlayer] Starting playback of http://x.x.x.x:8123/api/esphome/ffmpeg_proxy/a09121c0fa3d01a1684ce698e0a3c2b1/d9QY5-9xxVTaQcxupYYfgA.wav
[MediaPlayer] Connected to IAD audio output socket
[esphome-api] >>> Sent UNKNOWN (type=64, payload=14 bytes, total=17 bytes)

```
