### PR TITLE
fix missing snapshot in sendtox functions

### DIFF
--- a/overlay/lower/usr/share/common
+++ b/overlay/lower/usr/share/common
@@ -409,7 +409,7 @@ cleanup() {
 copy_photo() {
 	check_snapshot
 	local tmpfile="$(mktemp -u).jpg"
-	cp -f "$SNAPSHOT_FILE" "$photo"
+	cp -f "$SNAPSHOT_FILE" "$tmpfile"
 	garbage="$garbage $tmpfile"
 	echo "$tmpfile"
 }


### PR DESCRIPTION
Found a typo which makes every snapshot generation failing due to a wrong filename creation in copy_photo.
same in stable