### PR TITLE
TP-Link Tapo C500 EU/2.0 rotate image by default.

### DIFF
--- a/configs/cameras/tplink_tapo_c500_t23n_sc2336p_atbm6012bx/prudynt-override.json
+++ b/configs/cameras/tplink_tapo_c500_t23n_sc2336p_atbm6012bx/prudynt-override.json
@@ -1,0 +1,6 @@
+{
+    "image": {
+        "hflip": true,
+        "vflip": true
+    }
+}


### PR DESCRIPTION
Rotate the image to the correct orientation by default.