### PR TITLE
Remove unused PTZ variables from init

### DIFF
--- a/package/thingino-onvif/files/S96onvif_discovery
+++ b/package/thingino-onvif/files/S96onvif_discovery
@@ -44,8 +44,6 @@ start() {
 		jct $tmpfile set ptz.enable 1
 		jct $tmpfile set ptz.max_step_x "$steps_pan"
 		jct $tmpfile set ptz.max_step_y "$steps_tilt"
-		jct $tmpfile set ptz.move_right "$MOTORS_BIN -d h -x $steps_pan"
-		jct $tmpfile set ptz.move_down "$MOTORS_BIN -d h -y $steps_tilt"
 	fi
 	jct $ONVIF_CONFIG import $tmpfile
 	rm -f $tmpfile


### PR DESCRIPTION
This is to go with the ONVIF fixes from https://github.com/themactep/thingino-onvif/pull/2.
The directional move commands are no longer used after being migrated to more general move_x, move_y and move_both.
Therefore, these init lines are no longer required.