### PR TITLE
LSC 3215672: fix blue led at boot

### DIFF
--- a/configs/cameras/lsc_3215672_t23n_sc2331_atbm6012bx/lsc_3215672_t23n_sc2331_atbm6012bx.uenv.txt
+++ b/configs/cameras/lsc_3215672_t23n_sc2331_atbm6012bx/lsc_3215672_t23n_sc2331_atbm6012bx.uenv.txt
@@ -1,4 +1,4 @@
-gpio_default=6i 61o 57O 58O 51o 59i 63o 62o 7O 14O 18O
+gpio_default=6i 61o 57O 58O 51O 59i 63o 62o 7O 14O 18O
 gpio_button=6
 gpio_ir850=61
 gpio_ircut=57O 58O


### PR DESCRIPTION
Related to this https://github.com/themactep/thingino-firmware/issues/951#issuecomment-3700166007
Looks like the blue LED is active low. I don't know why it worked fine before, but the issue appeared around New year.