### PR TITLE
cameras: fix sd card power for dekco_t23n_sc3332p_ws73v100

### DIFF
--- a/configs/cameras-exp/dekco_t23n_sc3332p_ws73v100/dekco_t23n_sc3332p_ws73v100.uenv.txt
+++ b/configs/cameras-exp/dekco_t23n_sc3332p_ws73v100/dekco_t23n_sc3332p_ws73v100.uenv.txt
@@ -4,6 +4,7 @@ gpio_ircut=59 60
 gpio_led_b=57
 gpio_led_g=58
 gpio_mmc_cd=59
+gpio_mmc_power=50o
 gpio_speaker=42o
 gpio_white=60
 gpio_wlan=6O

--- a/configs/cameras-exp/dekco_t23n_sc3332p_ws73v100/thingino-camera.json
+++ b/configs/cameras-exp/dekco_t23n_sc3332p_ws73v100/thingino-camera.json
@@ -5,6 +5,10 @@
     "ircut": "59 60",
     "led_b": 57,
     "mmc_cd": 59,
+    "mmc_power": {
+      "pin": 50,
+      "active_low": true
+    },
     "white": 60,
     "wlan": 6
   }


### PR DESCRIPTION
This PR fixes missing power on VCC pin of the sd card slot on dekco_t23n_sc3332p_ws73v100.
It is achieved by pulling low pin 50, which enables 3.3V power regulator.