### PR TITLE
Fix MQTT topic_photo and topic_video config reading

### DIFF
--- a/package/prudynt-t/files/send2mqtt
+++ b/package/prudynt-t/files/send2mqtt
@@ -55,6 +55,8 @@ read_config() {
 	send_photo=$(get_value send_photo)
 	send_video=$(get_value send_video)
 	topic=$(get_value topic)
+	topic_photo=$(get_value topic_photo)
+	topic_video=$(get_value topic_video)
 	username=$(get_value username)
 }
 


### PR DESCRIPTION
The send2mqtt script was missing topic_photo and topic_video in the read_config() function, causing the error 'MQTT topic for sending snapshot is not set' even when configured.

Added topic_photo and topic_video to read_config().