### PR TITLE
Fix broken config of IR850 and white led for tplink tapo c200

### DIFF
--- a/configs/cameras/tplink_tapo_c200_t23n_sc2336p_rtl8188ftv/thingino-camera.json
+++ b/configs/cameras/tplink_tapo_c200_t23n_sc2336p_rtl8188ftv/thingino-camera.json
@@ -2,10 +2,8 @@
   "gpio": {
     "button_reset": 40,
     "ir850": {
-      "pin": {
-        "pin": 49,
-        "active_low": true
-      },
+      "pin": 49,
+      "active_low": true,
       "pwm_channel": 0
     },
     "ircut": 999,
@@ -23,10 +21,8 @@
       "active_low": true
     },
     "white": {
-      "pin": {
-        "pin": 50,
-        "active_low": true
-      },
+      "pin": 50,
+      "active_low": true,
       "pwm_channel": 1
     },
     "wlan": 51


### PR DESCRIPTION
The json structure does not fit for `/sbin/light`. Therefore the logic of IR850 is inverted and UI does not show the IR850 pin in settings dialog but `[object]` in the input field. By fixing the json both problems are gone.