### PR TITLE
daynight: read GPIO pins from /etc/thingino.json

### DIFF
--- a/package/prudynt-t/files/daynight
+++ b/package/prudynt-t/files/daynight
@@ -16,12 +16,6 @@ get_value() {
 		echo "true"
 }
 
-get_config_pin() {
-	local type="$1"
-	jct /etc/thingino.json get "gpio.$type.pin" 2>/dev/null || \
-		jct /etc/thingino.json get "gpio.$type" 2>/dev/null
-}
-
 # Load control flags from prudynt config
 load_controls() {
 	if command_present jct && [ -f "$PRUDYNT_CONFIG" ]; then
@@ -49,17 +43,17 @@ switch_to_day() {
 		ircut on &
 	fi
 
-	if [ "true" = "$day_night_ir850" ] && [ -n "$(get_config_pin ir850)" ] && command_present light; then
+	if [ "true" = "$day_night_ir850" ] && command_present light; then
 		echo_info "  turn IR LED 850nm OFF"
 		light ir850 off &
 	fi
 
-	if [ "true" = "$day_night_ir940" ] && [ -n "$(get_config_pin ir940)" ] && command_present light; then
+	if [ "true" = "$day_night_ir940" ] && command_present light; then
 		echo_info "  turn IR LED 940nm OFF"
 		light ir940 off &
 	fi
 
-	if [ "true" = "$day_night_white" ] && [ -n "$(get_config_pin white)" ] && command_present light; then
+	if [ "true" = "$day_night_white" ] && command_present light; then
 		echo_info "  turn White Light OFF"
 		light white off &
 	fi
@@ -84,17 +78,17 @@ switch_to_night() {
 		ircut off &
 	fi
 
-	if [ "true" = "$day_night_ir850" ] && [ -n "$(get_config_pin ir850)" ] && command_present light; then
+	if [ "true" = "$day_night_ir850" ] && command_present light; then
 		echo_info "  turn IR LED 850nm ON"
 		light ir850 on &
 	fi
 
-	if [ "true" = "$day_night_ir940" ] && [ -n "$(get_config_pin ir940)" ] && command_present light; then
+	if [ "true" = "$day_night_ir940" ] && command_present light; then
 		echo_info "  turn IR LED 940nm ON"
 		light ir940 on &
 	fi
 
-	if [ "true" = "$day_night_white" ] && [ -n "$(get_config_pin white)" ] && command_present light; then
+	if [ "true" = "$day_night_white" ] && command_present light; then
 		echo_info "  turn White Light ON"
 		light white on &
 	fi


### PR DESCRIPTION
`/sbin/daynight` should read the GPIO pins from `/etc/thingino.json`, otherwise the corresponding variable are not set and lights are not changed.