### PR TITLE
Added GPIO definition to enable wired Ethernet for Jooan W3-U

### DIFF
--- a/configs/cameras/jooan_w3u_t23n_sc2336p_eth+atbm6132u/thingino-camera.json
+++ b/configs/cameras/jooan_w3u_t23n_sc2336p_eth+atbm6132u/thingino-camera.json
@@ -11,6 +11,11 @@
     "wlan": {
       "pin": 6,
       "toggle": true
-    }
+    },
+    "eth": {
+      "pin": 64,
+      "active_low": false,
+      "toggle": true
+    }    
   }
 }


### PR DESCRIPTION
This pull request contains a modification to the thingino-camera.json file for the Jooan W3-U, defining GPIO pin 64 for wired Ethernet. This GPIO pin needs to be toggled (low-to-high) to enable the interface. Otherwise a link can't be established.

An additional extension to the defconfig to make the SD card work within Thingino is in preparation, but had to be withdrawn for the time being because although the card is now recognized and can be formatted, mounting it fails.