### PR TITLE
Add Date email header to send2email

### DIFF
--- a/package/prudynt-t/files/send2email
+++ b/package/prudynt-t/files/send2email
@@ -118,9 +118,11 @@ else
 	command="$command --url smtp://$host:$port"
 fi
 
+email_date=$(date -uR)
 email_body=${body//"/\\"}
 command="$command -H 'From: \"$from_name\" <$from_address>'"
 command="$command -H 'To: \"$to_name\" <$to_address>'"
+command="$command -H 'Date: $email_date'"
 command="$command -H 'Subject: $subject'"
 command="$command -F '=(;type=multipart/mixed'"
 command="$command -F \"=${body};type=text/plain\""


### PR DESCRIPTION
This prevents email clients (i. e. Thunderbird) from often showing the received date instead of the actual send date.

Using -u to generate in UTC timezone to not leak the timezone the camera is in.

Also rspamd otherwise increases the SPAM score because of MISSING_DATE(1).