### PR TITLE
fix: resolve macOS/Apple Silicon Docker build failures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ENV LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8
 
 # Create user with matching UID/GID for volume permissions
-RUN groupadd -g ${GROUP_ID} ${USERNAME} && \
+RUN groupadd -g ${GROUP_ID} ${USERNAME} 2>/dev/null || true && \
     useradd -m -u ${USER_ID} -g ${GROUP_ID} -s /bin/bash ${USERNAME} && \
     echo "${USERNAME}:${USERNAME}" | chpasswd && \
     echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -11,6 +11,11 @@ DL_DIR := dl
 # Directories
 WORKSPACE_DIR := $(shell pwd)
 
+# Named volume for build output — avoids macOS APFS hard-link limitations.
+# Buildroot's per-package isolation uses rsync hard-links which fail on bind-mounted
+# APFS volumes. A named Docker volume stays in the Linux VM and supports hard links.
+OUTPUT_VOLUME := thingino-build-output
+
 # Container run command
 ifeq ($(findstring podman,$(CONTAINER_ENGINE)),podman)
 	CONTAINER_RUN := $(CONTAINER_ENGINE) run --rm --userns=keep-id
@@ -20,6 +25,7 @@ endif
 
 CONTAINER_RUN_OPTS := \
 	-v $(WORKSPACE_DIR):/workspace \
+	-v $(OUTPUT_VOLUME):/workspace/output \
 	-v $(shell [ -e ${DL_DIR} ] || mkdir -p ${DL_DIR} && readlink -f ${DL_DIR}):/home/$(USERNAME)/dl \
 	-w /workspace \
 	-e TERM=xterm-256color
@@ -43,6 +49,9 @@ docker-build:
 	else \
 		echo "Docker image $(DOCKER_IMAGE):$(DOCKER_TAG) already exists (use 'make docker-clean' to rebuild)"; \
 	fi
+	@$(CONTAINER_ENGINE) volume create $(OUTPUT_VOLUME) > /dev/null 2>&1 || true
+	@$(CONTAINER_ENGINE) run --rm -v $(OUTPUT_VOLUME):/output debian:trixie \
+		sh -c "chown -R $(USER_ID):$(GROUP_ID) /output && chmod 775 /output" 2>/dev/null || true
 
 .PHONY: docker-shell
 docker-shell: docker-build
@@ -118,6 +127,20 @@ docker-upgrade-ota: docker-build
 	$(eval CAMERA_ARG := $(if $(CAMERA),CAMERA=$(CAMERA)))
 	$(eval GROUP_ARG := $(if $(GROUP),GROUP=$(GROUP)))
 	$(CONTAINER_RUN_INTERACTIVE) $(DOCKER_IMAGE):$(DOCKER_TAG) make upgrade_ota $(IP_ARG) $(CAMERA_ARG) $(GROUP_ARG)
+
+# Copy built firmware images from the named volume to ./images/ on the host.
+# Run this after a successful build: make -f Makefile.docker docker-extract-images
+.PHONY: docker-extract-images
+docker-extract-images:
+	@mkdir -p $(WORKSPACE_DIR)/images
+	@echo "Extracting firmware images from build volume..."
+	@$(CONTAINER_ENGINE) run --rm \
+		-v $(OUTPUT_VOLUME):/output:ro \
+		-v $(WORKSPACE_DIR)/images:/images \
+		debian:trixie \
+		sh -c "find /output -name 'thingino-*.bin' -exec cp -v {} /images/ \;"
+	@echo "Done. Images in ./images/:"
+	@ls -lh $(WORKSPACE_DIR)/images/*.bin 2>/dev/null || echo "  (none found)"
 
 # Allow make targets to be passed through to container
 %:


### PR DESCRIPTION
## Problem

Building on macOS with Docker Desktop fails in two ways:

### 1. `groupadd: GID '20' already exists` (Dockerfile)

macOS passes the host GID (20 = "staff") into the container. That GID already exists in the Debian base image, so `groupadd` exits with code 4 and the entire build layer fails.

```
ERROR [6/8] RUN groupadd -g 20 builder && ...
0.035 groupadd: GID '20' already exists
```

**Fix:** append `2>/dev/null || true` to `groupadd` so the existing group is silently reused.

---

### 2. `rsync: failed to hard-link … Operation not permitted` (Makefile.docker)

Buildroot's per-package isolation uses `rsync --hard-links` to snapshot the staging tree between packages. Hard links across a Docker bind-mount backed by an APFS volume (macOS host) are not supported by the macOS filesystem layer, causing every package build to fail.

```
rsync: failed to hard-link … Operation not permitted (1)
make[1]: *** [...] Error 1
```

**Fix:** mount the build output directory as a **named Docker volume** (`thingino-build-output`) that lives entirely inside the Docker Linux VM, where hard links work normally. The host filesystem is no longer in the rsync path.

A `docker-extract-images` target is also added to copy the finished `thingino-*.bin` files back to `./images/` on the host after a successful build.

## Testing

Tested on macOS 26.3 (Apple Silicon, M4) with Docker Desktop. Both issues are resolved and a full firmware build completes successfully.

## Usage (after this fix)

```bash
# Build (output stays in named Docker volume)
CAMERA=your_camera_name ./docker-build.sh build

# Copy finished firmware to ./images/ on the host
make -f Makefile.docker docker-extract-images
```

Made with [Cursor](https://cursor.com)