### PR TITLE
scripts/rootfs_script.sh: guard libc compat symlinks for merged-/usr

### DIFF
--- a/scripts/rootfs_script.sh
+++ b/scripts/rootfs_script.sh
@@ -87,18 +87,36 @@ rm -f ${TARGET_DIR}/usr/bin/ldd
 echo '#!/bin/sh
 LD_TRACE_LOADED_OBJECTS=1 exec "$@"' > ${TARGET_DIR}/usr/bin/ldd && chmod +x ${TARGET_DIR}/usr/bin/ldd
 
+# Resolve the real on-disk lib directory: with merged-usr rootfs, /lib is a
+# symlink to /usr/lib. Operate on /usr/lib directly so we never accidentally
+# convert the symlink to a real directory or create broken literal-glob
+# symlinks when the pattern fails to expand.
+if [ -L "${TARGET_DIR}/lib" ] || [ ! -d "${TARGET_DIR}/lib" ]; then
+	LIB_DIR="${TARGET_DIR}/usr/lib"
+else
+	LIB_DIR="${TARGET_DIR}/lib"
+fi
+
 if grep -q "^BR2_TOOLCHAIN_USES_MUSL=y" $BR2_CONFIG >/dev/null; then
-	ln -srf ${TARGET_DIR}/lib/libc.so ${TARGET_DIR}/lib/ld-uClibc.so.0
+	if [ -e "${LIB_DIR}/libc.so" ]; then
+		ln -srf "${LIB_DIR}/libc.so" "${LIB_DIR}/ld-uClibc.so.0"
+	fi
 fi
 
 if grep -q "^BR2_TOOLCHAIN_USES_UCLIBC=y" $BR2_CONFIG >/dev/null; then
-	ln -srf ${TARGET_DIR}/lib/libuClibc*.so ${TARGET_DIR}/lib/libpthread.so.0
-	ln -srf ${TARGET_DIR}/lib/libuClibc*.so ${TARGET_DIR}/lib/libdl.so.0
-	ln -srf ${TARGET_DIR}/lib/libuClibc*.so ${TARGET_DIR}/lib/libm.so.0
+	for libuclibc in "${LIB_DIR}"/libuClibc-*.so; do
+		[ -e "$libuclibc" ] || continue
+		ln -srf "$libuclibc" "${LIB_DIR}/libpthread.so.0"
+		ln -srf "$libuclibc" "${LIB_DIR}/libdl.so.0"
+		ln -srf "$libuclibc" "${LIB_DIR}/libm.so.0"
+		break
+	done
 fi
 
 if grep -q "^BR2_TOOLCHAIN_USES_GLIBC=y" $BR2_CONFIG >/dev/null; then
-	ln -srf ${TARGET_DIR}/lib/libc.so.6 ${TARGET_DIR}/lib/libpthread.so.0
+	if [ -e "${LIB_DIR}/libc.so.6" ]; then
+		ln -srf "${LIB_DIR}/libc.so.6" "${LIB_DIR}/libpthread.so.0"
+	fi
 fi
 
 #


### PR DESCRIPTION
## Summary
- Follow-up to c47716296 (`package: install into /usr paths for merged-/usr`). That commit stopped the wifi packages from corrupting the `/lib -> usr/lib` symlink, but `scripts/rootfs_script.sh` still contains an unguarded libc compat-symlink block that can silently write broken symlinks on any merged-usr build.
- Specifically, the post-build script runs:

  ```sh
  ln -srf ${TARGET_DIR}/lib/libuClibc*.so ${TARGET_DIR}/lib/libpthread.so.0
  ln -srf ${TARGET_DIR}/lib/libuClibc*.so ${TARGET_DIR}/lib/libdl.so.0
  ln -srf ${TARGET_DIR}/lib/libuClibc*.so ${TARGET_DIR}/lib/libm.so.0
  ```

  Bash doesn't fail an unmatched glob — it passes the literal pattern through. So on any build where `libuClibc-*.so` doesn't sit directly in `${TARGET_DIR}/lib/` (e.g. the merged-usr layout where it lives in `${TARGET_DIR}/usr/lib/` and is reachable only through the `/lib -> usr/lib` symlink), `ln` is invoked with the literal string `libuClibc*.so` as the source and writes a symlink like `libdl.so.0 -> libuClibc*.so` into the rootfs. I have observed exactly this in broken builds: an otherwise-empty `/lib/` containing three dangling symlinks with a literal asterisk in the target.
- The musl and glibc branches have the same problem in a milder form: unconditional `ln -srf` with no check that the source file exists.

## Fix

Rewrite the block to:

- Resolve `LIB_DIR` to `${TARGET_DIR}/usr/lib` when `/lib` is a symlink (or doesn't exist), and to `${TARGET_DIR}/lib` otherwise, so it always operates on the directory that actually contains the shared objects.
- Guard each `ln` with a `[ -e ]` source-existence check.
- Iterate the uClibc glob with a `for` loop + `[ -e \$libuclibc ] || continue` so an unmatched pattern is cleanly skipped rather than fed to `ln` as a literal.

No behavior change on builds where libc already lives in `/lib` with the expected files present. Broken symlinks with literal glob characters can no longer be written under any circumstances.

## Test plan

- [ ] Build any camera with `BR2_TOOLCHAIN_USES_UCLIBC=y` and `BR2_ROOTFS_MERGED_USR=y` (e.g. `wyze_cam3_t31x_gc2053_rtl8189ftv`) and verify `unsquashfs -ll images/rootfs.squashfs | grep -F '*'` returns no matches.
- [ ] Verify `target/usr/lib/libdl.so.0`, `libm.so.0`, `libpthread.so.0` are symlinks pointing to a real `libuClibc-*.so` that exists.
- [ ] Build a musl config and verify `target/usr/lib/ld-uClibc.so.0` is present and resolves.
- [ ] Spot-check that a build where `/lib` is still a real directory (non-merged-usr config, if any remain) still gets its libc compat symlinks created in `/lib`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)