### PR TITLE
sysupgrade: Correct help. Given file/URL must be argument 1.

### DIFF
--- a/package/thingino-sysupgrade/files/sysupgrade
+++ b/package/thingino-sysupgrade/files/sysupgrade
@@ -282,7 +282,7 @@ flush_memory() {
 }
 
 show_help() {
-	echo -e "Usage: $0 [-x] [-f|-p|<file>|<URL>]
+	echo -e "Usage: $0 [<file>|<URL>] [-f|-p] [-b] [-d] [-x]
 Where:
   -f      full upgrade with a binary from GitHub
   -p      partial upgrade with a binary from GitHub


### PR DESCRIPTION
The help for sysupgrade implied different usage order than is required. The file/URL must be the first argument, not the last, as implied.