### PR TITLE
Format bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,33 +7,43 @@ assignees: ''
 
 ---
 
-**Describe the bug**
+## Describe the bug
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+## Reproduction steps
 Steps to reproduce the behavior:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
 4. See error
 
-**Expected behavior**
+## Expected behavior
 A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+## Screenshots and logs
+If applicable, add screenshots or logs to help explain your problem.
 
-**Camera model and hardware**
-SoC, sensor, Wi-Fif module
+<!-- To put long logs in a collapsible block: -->
+<!-- Remove the line you are reading now, but not the blank lines below (breaks formatting)
+<details><summary>Logs</summary>
 
-**Thingino firmware**
+```
+(Paste logs here)
+```
+
+</details><!-- -->
+
+## Camera model and hardware
+SoC, sensor, Wi-Fi module
+
+## Thingino firmware
 Branch, build date and ID (run `ver`, copy line that looks like `master+84b4193, 2026-03-14`)
 
-**Client software**
+## Client software
 If applicable, OS version, browser, phone or NVR model.
 
-**Additional context**
+## Additional context
 Add any other context about the problem here.
 
-**Diagnostics**
-Run `thingino-diag -u` in console, or go to Infomration -> Diagnostic Info in Web UI and generate the a report with upload to Thingino server, post the output URL below.
+## Diagnostics
+Run `thingino-diag -u` in console, or go to Information -> Diagnostic Info in Web UI and generate the a report with upload to Thingino server, and post the output URL below.


### PR DESCRIPTION
Uses `## Headers` instead of `**bold**` to separate sections, and adds a comment for collapsible logs.

Before:
**Describe the bug**

After:
## Describe the bug

Collapsing log example:
<!-- To put long logs in a collapsible block: -->
<details><summary>Logs</summary>

```
Logs, logs, logs
```
</details><!-- -->