### PR TITLE
fix: watchdog reboot hang, HA stop cleanup, firmware update false positive, SOC cache

### DIFF
--- a/overlay/etc/init.d/rcK
+++ b/overlay/etc/init.d/rcK
@@ -1,33 +1,25 @@
 #!/bin/sh
 
-LOG=/overlay/shutdown.log
-echo "=== $(date) ===" >> $LOG
-
 echo -c 196 -e "\n\nGoing to reboot!\n"
 
 # Run init scripts in the desired order: F, K, S with reversed numerical order within each group.
 # Skip K99watchdog — handled after sync so the hardware watchdog stays armed as a fallback.
 for letter in F K S; do
 	for i in $(find /etc/init.d/ -name "${letter}*" -executable | grep -v 'K99watchdog' | sort -r); do
-		echo "$(date +%T) START $i" >> $LOG
 		/bin/sh -c "$i stop"
-		echo "$(date +%T) DONE  $i" >> $LOG
 	done
 done
 
-echo "$(date +%T) all scripts done" >> $LOG
 sync
 
 # Kill watchdog with SIGKILL (NOT SIGTERM) so it cannot write the magic 'V'
 # that would disarm the hardware watchdog. The hardware timer then expires
 # within the configured timeout (default 60 s) and forces a hardware reset —
 # guaranteed fallback if the kernel reboot path hangs.
-echo "$(date +%T) arming watchdog fallback" >> $LOG
 WD_PID=$(cat /var/run/watchdog.pid 2>/dev/null)
 [ -n "$WD_PID" ] && kill -9 "$WD_PID" 2>/dev/null
 killall -9 watchdog 2>/dev/null || true
 
-echo "$(date +%T) rebooting" >> $LOG
 reboot -f 2>/dev/null || echo b > /proc/sysrq-trigger 2>/dev/null
 
 exit 0

--- a/overlay/etc/init.d/rcK
+++ b/overlay/etc/init.d/rcK
@@ -1,15 +1,33 @@
 #!/bin/sh
 
+LOG=/overlay/shutdown.log
+echo "=== $(date) ===" >> $LOG
+
 echo -c 196 -e "\n\nGoing to reboot!\n"
 
-# Kill watchdog to trigger hw timer
-/etc/init.d/K99watchdog kill
-
 # Run init scripts in the desired order: F, K, S with reversed numerical order within each group.
+# Skip K99watchdog — handled after sync so the hardware watchdog stays armed as a fallback.
 for letter in F K S; do
-	for i in $(find /etc/init.d/ -name "${letter}*" -executable | sort -r); do
+	for i in $(find /etc/init.d/ -name "${letter}*" -executable | grep -v 'K99watchdog' | sort -r); do
+		echo "$(date +%T) START $i" >> $LOG
 		/bin/sh -c "$i stop"
+		echo "$(date +%T) DONE  $i" >> $LOG
 	done
 done
+
+echo "$(date +%T) all scripts done" >> $LOG
+sync
+
+# Kill watchdog with SIGKILL (NOT SIGTERM) so it cannot write the magic 'V'
+# that would disarm the hardware watchdog. The hardware timer then expires
+# within the configured timeout (default 60 s) and forces a hardware reset —
+# guaranteed fallback if the kernel reboot path hangs.
+echo "$(date +%T) arming watchdog fallback" >> $LOG
+WD_PID=$(cat /var/run/watchdog.pid 2>/dev/null)
+[ -n "$WD_PID" ] && kill -9 "$WD_PID" 2>/dev/null
+killall -9 watchdog 2>/dev/null || true
+
+echo "$(date +%T) rebooting" >> $LOG
+reboot -f 2>/dev/null || echo b > /proc/sysrq-trigger 2>/dev/null
 
 exit 0

--- a/overlay/usr/share/common
+++ b/overlay/usr/share/common
@@ -18,8 +18,14 @@ PORTAL_MODE_FLAG="/run/portal_mode"
 RESOLV_DEFAULT_FILE="/etc/default/resolv.conf"
 RESOLV_FILE="/etc/resolv.conf"
 RESOLV_WORKING_FILE="/tmp/resolv.conf"
-SOC_FAMILY=$(soc -f)
-SOC_MODEL=$(soc -m)
+_SOC_CACHE="/run/soc.env"
+if [ -f "$_SOC_CACHE" ]; then
+	. "$_SOC_CACHE"
+else
+	SOC_FAMILY=$(soc -f 2>/dev/null)
+	SOC_MODEL=$(soc -m 2>/dev/null)
+	printf 'SOC_FAMILY=%s\nSOC_MODEL=%s\n' "$SOC_FAMILY" "$SOC_MODEL" > "$_SOC_CACHE" 2>/dev/null || true
+fi
 TZCODE_FILE="/etc/TZ"
 TZJSON_FILE="/usr/share/tz.json"
 TZNAME_FILE="/etc/timezone"

--- a/overlay/usr/share/common
+++ b/overlay/usr/share/common
@@ -18,14 +18,8 @@ PORTAL_MODE_FLAG="/run/portal_mode"
 RESOLV_DEFAULT_FILE="/etc/default/resolv.conf"
 RESOLV_FILE="/etc/resolv.conf"
 RESOLV_WORKING_FILE="/tmp/resolv.conf"
-_SOC_CACHE="/run/soc.env"
-if [ -f "$_SOC_CACHE" ]; then
-	. "$_SOC_CACHE"
-else
-	SOC_FAMILY=$(soc -f 2>/dev/null)
-	SOC_MODEL=$(soc -m 2>/dev/null)
-	printf 'SOC_FAMILY=%s\nSOC_MODEL=%s\n' "$SOC_FAMILY" "$SOC_MODEL" > "$_SOC_CACHE" 2>/dev/null || true
-fi
+SOC_FAMILY=$(soc -f)
+SOC_MODEL=$(soc -m)
 TZCODE_FILE="/etc/TZ"
 TZJSON_FILE="/usr/share/tz.json"
 TZNAME_FILE="/etc/timezone"

--- a/package/thingino-ha/files/S93ha
+++ b/package/thingino-ha/files/S93ha
@@ -11,7 +11,7 @@ read_config() {
 
 ha_processes_gone() {
 	local proc
-	for proc in ha-daemon ha-commands ha-discovery ha-state; do
+	for proc in ha-daemon ha-commands ha-discovery ha-state mosquitto_pub mosquitto_sub; do
 		if pidof "$proc" >/dev/null 2>&1; then
 			return 1
 		fi

--- a/package/thingino-ha/files/S93ha
+++ b/package/thingino-ha/files/S93ha
@@ -54,10 +54,11 @@ stop() {
 	echo_title "Stopping HA daemon"
 
 	stop_daemon
-	killall -q ha-commands ha-discovery ha-state 2>/dev/null
+	killall -q ha-daemon ha-commands ha-discovery ha-state 2>/dev/null
+	killall -q mosquitto_pub mosquitto_sub 2>/dev/null
 	if ! wait_for_ha_shutdown; then
-		killall -q -9 ha-commands ha-discovery ha-state 2>/dev/null
-		start-stop-daemon -K -s SIGKILL -n ha-daemon 2>/dev/null
+		killall -q -9 ha-daemon ha-commands ha-discovery ha-state 2>/dev/null
+		killall -q -9 mosquitto_pub mosquitto_sub 2>/dev/null
 		wait_for_ha_shutdown || true
 	fi
 }

--- a/package/thingino-ha/files/ha-state
+++ b/package/thingino-ha/files/ha-state
@@ -265,6 +265,8 @@ publish_state() {
 			[ -n "$installed" ] && {
 				build_time=$(grep '^BUILD_TIME=' "$f" 2>/dev/null | cut -d= -f2- | tr -d '"')
 				build_date=$(echo "$build_time" | sed 's/^\([0-9]\{4\}\)-\([0-9]\{2\}\)-\([0-9]\{2\}\).*/\1\2\3/')
+				# Fall back to date embedded in COMMIT_ID (e.g. "stable+abc, 2026-04-06 …")
+				[ -z "$build_date" ] && build_date=$(echo "$installed" | sed 's/.*\([0-9]\{4\}\)-\([0-9]\{2\}\)-\([0-9]\{2\}\).*/\1\2\3/')
 				break
 			}
 		done


### PR DESCRIPTION
## Summary                                                                                                                                                                                                      
                                                                                                                                                                                                                  
  - **rcK**: Fix device hang on reboot (issue #1171). Was killing the watchdog daemon                                                                                                                             
    with SIGTERM early, which wrote the magic 'V' and disarmed the hardware watchdog —                                                                                                                            
    leaving no recovery path if the kernel reboot stalled. Now kills all services first,
    then SIGKILLs the watchdog (can't write 'V'), then calls `reboot -f`. Hardware                                                                                                                                
    watchdog fires as guaranteed fallback if the kernel path hangs.                                                                                                                                               
                                                                                                                                                                                                                  
  - **thingino-ha S93ha**: `ha-daemon` was missing from the graceful kill list on stop,                                                                                                                           
    and `mosquitto_pub`/`mosquitto_sub` were never cleaned up, leaving orphan processes.                                                                                                                          
                                                                                                                                                                                                                  
  - **thingino-ha ha-state**: When `BUILD_TIME` is absent from `os-release`, `build_date`                                                                                                                         
    was left empty and the firmware up-to-date check was skipped, causing Home Assistant                                                                                                                          
    to show a false firmware upgrade notification even on the latest build. Now falls back                                                                                                                        
    to extracting the date from `COMMIT_ID`.                                                                                                                                                                      
                                                                                                                                                                                                                  
  - **common**: `SOC_FAMILY` and `SOC_MODEL` were forked from `soc(1)` on every script                                                                                                                            
    that sources `/usr/share/common`. Results are now cached in `/run/soc.env` after the                                                                                                                          
    first call.                                                                                                                                                                                                   
                                                                                                                                                                                                                  
  ## Related      
  Fixes https://github.com/themactep/thingino-firmware/issues/1171 