### PR TITLE
fix(daynightd): correct 'thershold_high' typo that dropped POSTed high threshold

### DIFF
--- a/package/thingino-daynightd/files/config-daynightd.cgi
+++ b/package/thingino-daynightd/files/config-daynightd.cgi
@@ -42,7 +42,7 @@ if [ "POST" = "$REQUEST_METHOD" ]; then
 
   enabled="$POST_enabled"
   threshold_low="$POST_threshold_low"
-  thershold_high="$POST_threshold_high"
+  threshold_high="$POST_threshold_high"
   hysteresis_factor="$POST_hysteresis_factor"
   controls_color="$POST_controls_color"
   controls_ir850="$POST_controls_ir850"


### PR DESCRIPTION
Fixes #1175.

Not cosmetic — real defect. In `package/thingino-daynightd/files/config-daynightd.cgi:45` the assignment

```sh
thershold_high="$POST_threshold_high"
```

uses a misspelled local `thershold_high` while the later validation / save path reads `$threshold_high` (lines 56, 65). Net effect: the night-mode threshold POSTed from the UI is silently dropped — validation can't see it and `set_value threshold_high` stays at whatever was previously stored.

```diff
- thershold_high="$POST_threshold_high"
+ threshold_high="$POST_threshold_high"
```

Single-character fix in the variable name. Matches the already-correct low threshold line above.