### PR TITLE
Fix wpa_supplicant not up when the camera have both wired ethernet and wifi

### DIFF
--- a/package/thingino-sysupgrade/files/sysupgrade
+++ b/package/thingino-sysupgrade/files/sysupgrade
@@ -299,7 +299,7 @@ stop_services() {
 	echo_c 112 "\nStop services"
 	for i in $(find /etc/init.d/ -name "[KS]*" -executable | sort -nr); do
 		case "$(basename $i)" in
-			K99watchdog | S31prudynt | S36wireless | S38wpa_supplicant | S40network | S41ifplugd | S42wireguard | S42wifiap | S30dropbear | S50dropbear | S97sysupgrade)
+			K99watchdog | S31prudynt | S36wireless | S40network | S40wpa_supplicant | S41ifplugd | S42wireguard | S42wifiap | S30dropbear | S50dropbear | S97sysupgrade)
 				continue
 				;;
 			S50httpd | S90httpd)

--- a/package/wifi/files/S40wpa_supplicant.in
+++ b/package/wifi/files/S40wpa_supplicant.in
@@ -20,6 +20,12 @@ iface_exists() {
 	fi
 }
 
+is_gateway_reachable() {
+        [ -z "$iface" ] && return 1
+        ping -c 1 -W 1 -I $iface $(ip -4 route | grep $iface | grep default | awk '{print $3}') > /dev/null 2>&1 || \
+        ping -6 -c 1 -W 1 -I $iface $(ip -6 route | grep $iface | grep default | awk '{print $3}') > /dev/null 2>&1
+}
+
 ts() {
 	date -u +"%F %T"
 }
@@ -266,7 +272,7 @@ start() {
 	fi
 
 	# Wired interface is present
-	if iface_exists "eth0"; then
+	if iface=eth0 is_gateway_reachable; then
 		echo "Wired interface found" >&2
 		exit 1
 	fi

--- a/package/wifi/wifi.mk
+++ b/package/wifi/wifi.mk
@@ -159,8 +159,8 @@ define WIFI_INSTALL_TARGET_CMDS
 	# WPA supplicant script
 	sed -e 's,@WLAN_STA_NETDEV@,$(WIFI_STA_NETDEV),g' \
 		-e 's,@WLAN_AP_NETDEV@,$(WIFI_AP_NETDEV),g' \
-		$(WIFI_PKGDIR)/files/S38wpa_supplicant.in > $(TARGET_DIR)/etc/init.d/S38wpa_supplicant
-	chmod 0755 $(TARGET_DIR)/etc/init.d/S38wpa_supplicant
+		$(WIFI_PKGDIR)/files/S40wpa_supplicant.in > $(TARGET_DIR)/etc/init.d/S40wpa_supplicant
+	chmod 0755 $(TARGET_DIR)/etc/init.d/S40wpa_supplicant
 
 	# Network interface config
 	$(INSTALL) -D -m 0644 $(WIFI_PKGDIR)/files/wlan0 \


### PR DESCRIPTION
When a camera have both wired ethernet and wifi :
 
 in /etc/init.d/S38wpa_supplicant 
there is :
    # Wired interface is present
    if iface_exists "eth0"; then
        echo_error "Wired interface found"
        exit 1
    fi

The  iface_exists "eth0" is true whether the eth0 is connected or not.

So we need to dectet weather eth0 is working after " ifup -v -a" in S40network, I renamed S38wpa_supplicant to S40wpa_supplicant and added is_gateway_reachable() 

I have tested it's functional in the stable branch on h3c c2041 with wired ethernet connected or not, it works as expected. I also tested to compine it without wired ethernet, it also works fine.