### PR TITLE
Docker Build: silence --format nags in master

### DIFF
--- a/Makefile.docker
+++ b/Makefile.docker
@@ -32,7 +32,7 @@ CONTAINER_RUN_EXEC := $(CONTAINER_RUN) -i $(CONTAINER_RUN_OPTS)
 
 .PHONY: docker-build
 docker-build:
-	@if ! $(CONTAINER_ENGINE) images | grep -q "$(DOCKER_IMAGE).*$(DOCKER_TAG)"; then \
+	@if ! $(CONTAINER_ENGINE) images --format=table | grep -q "$(DOCKER_IMAGE).*$(DOCKER_TAG)"; then \
 		echo "Building Docker image: $(DOCKER_IMAGE):$(DOCKER_TAG)"; \
 		$(CONTAINER_ENGINE) build --network=host \
 			--build-arg USER_ID=$(USER_ID) \

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -78,7 +78,7 @@ fi
 DOCKER_IMAGE="thingino-builder"
 DOCKER_TAG="latest"
 
-if ! $CONTAINER_ENGINE images | grep -q "$DOCKER_IMAGE.*$DOCKER_TAG"; then
+if ! $CONTAINER_ENGINE images --format=table | grep -q "$DOCKER_IMAGE.*$DOCKER_TAG"; then
     print_info "Building container image..."
     make -f Makefile.docker docker-build CONTAINER_ENGINE="$CONTAINER_ENGINE"
     print_success "Container image built"


### PR DESCRIPTION
Silences `WARNING: This output is designed for human readability. For machine-readable output, please use --format.` in `master` branch.