### PR TITLE
Wansview A1: add --send-raw probe, SDIO sleep, password sanitization

### DIFF
--- a/package/atbm6461-tools/files/atbm6461-tool.c
+++ b/package/atbm6461-tools/files/atbm6461-tool.c
@@ -66,6 +66,7 @@ static void usage(const char *prog)
 	printf("  --set_detect_range=[threshold]\n");
 	printf("  --set_pir_type=[type]\n");
 	printf("  --set_rtc_mode=[mode]\n");
+	printf("  --send-raw=[cmd_id]        probe a raw RTOS command ID\n");
 	printf("  --upgrade_fw [=<file_path>]\n");
 }
 
@@ -344,6 +345,29 @@ static int handle_option(int argc, char **argv, int *index)
 		if (take_arg(argc, argv, index, &value) < 0)
 			return upgrade_firmware(NULL);
 		return upgrade_firmware(value);
+	}
+
+	if (strcmp(name, "send-raw") == 0) {
+		int cmd_id;
+		unsigned char buf[256];
+		int out_len;
+		int ret, i;
+
+		if (take_arg(argc, argv, index, &value) < 0) {
+			puts("send-raw requires a command ID");
+			return -1;
+		}
+		cmd_id = atoi(value);
+		memset(buf, 0, sizeof(buf));
+		out_len = sizeof(buf);
+		ret = rtos_cmd_send(cmd_id, NULL, 0, buf, &out_len,
+				    RTOS_TIMEOUT_SHORT_MS);
+		printf("id=%d ret=%d out_len=%d hex=",
+		       cmd_id, ret, out_len);
+		for (i = 0; i < out_len && i < 16; i++)
+			printf("%02x", buf[i]);
+		putchar('\n');
+		return ret >= 0 ? 0 : 1;
 	}
 
 	return -2;

--- a/package/wifi/files/S38wpa_supplicant.in
+++ b/package/wifi/files/S38wpa_supplicant.in
@@ -279,10 +279,12 @@ start() {
 						echo "mcu_test not found; ATBM6461 client connection cannot start" >&2
 						exit 1
 					fi
-					echo "Bring $IFACE up"
-					ip link set $IFACE up
-					echo "Connecting via mcu_test: $wifi_ssid"
-					if ! mcu_test --wifi_connect="${wifi_ssid}:${wifi_pass}"; then
+				echo "Bring $IFACE up"
+				ip link set $IFACE up
+				echo "Waiting for SDIO link to stabilize..."
+				sleep 3
+				echo "Connecting via mcu_test: $wifi_ssid"
+				if ! mcu_test --wifi_connect="${wifi_ssid}:${wifi_pass}"; then
 						echo "WARNING: mcu_test WiFi command failed"
 					fi
 					echo "Waiting for MCU WiFi connection..."

--- a/package/wifi/files/S38wpa_supplicant.in
+++ b/package/wifi/files/S38wpa_supplicant.in
@@ -287,28 +287,28 @@ start() {
 				if ! mcu_test --wifi_connect="${wifi_ssid}:${wifi_pass}"; then
 						echo "WARNING: mcu_test WiFi command failed"
 					fi
-					echo "Waiting for MCU WiFi connection..."
-					i=0
-					hex_ip=""
-					while [ "$i" -lt 30 ]; do
-						hex_ip=$(dmesg | grep 'hostevent.*ipaddr' | tail -1 | sed 's/.*ipaddr \([0-9a-f]*\).*/\1/')
-						[ -n "$hex_ip" ] && break
-						i=$((i + 1))
-						sleep 1
-					done
-					if [ -n "$hex_ip" ] && [ ${#hex_ip} -eq 8 ] && [ "$hex_ip" != "00000000" ]; then
-						ip_addr=$(printf '%d.%d.%d.%d' 0x${hex_ip:6:2} 0x${hex_ip:4:2} 0x${hex_ip:2:2} 0x${hex_ip:0:2})
-						gateway=$(echo "$ip_addr" | sed 's/\.[0-9]*$/.1/')
-						echo "MCU DHCP IP: $ip_addr"
-						ip addr add ${ip_addr}/24 dev $IFACE 2>/dev/null || true
-						ip route add default via $gateway dev $IFACE 2>/dev/null || true
-						echo "nameserver $gateway" > /tmp/resolv.conf
-						sed -i 's/iface wlan0 inet dhcp/iface wlan0 inet manual/' /etc/network/interfaces.d/wlan0
-					else
-						echo "WARNING: Could not get IP from MCU DHCP"
-						ip link show $IFACE
-						iwconfig $IFACE 2>/dev/null || true
-					fi
+				echo "Waiting for MCU WiFi connection..."
+				i=0
+				hex_ip=""
+				while [ "$i" -lt 30 ]; do
+					hex_ip=$(dmesg | grep 'hostevent.*ipaddr' | tail -1 | sed 's/.*ipaddr \([0-9a-f]*\).*/\1/')
+					[ -n "$hex_ip" ] && break
+					i=$((i + 1))
+					sleep 1
+				done
+				if [ -n "$hex_ip" ] && [ ${#hex_ip} -eq 8 ] && [ "$hex_ip" != "00000000" ]; then
+					ip_addr=$(printf '%d.%d.%d.%d' 0x${hex_ip:6:2} 0x${hex_ip:4:2} 0x${hex_ip:2:2} 0x${hex_ip:0:2})
+					gateway=$(echo "$ip_addr" | sed 's/\.[0-9]*$/.1/')
+					echo "MCU DHCP IP: $ip_addr"
+					ip addr add ${ip_addr}/24 dev $IFACE 2>/dev/null || true
+					ip route add default via $gateway dev $IFACE 2>/dev/null || true
+					echo "nameserver $gateway" > /tmp/resolv.conf
+					sed -i 's/iface wlan0 inet dhcp/iface wlan0 inet manual/' /etc/network/interfaces.d/wlan0
+				else
+					echo "WARNING: Could not get IP from MCU DHCP"
+					ip link show $IFACE
+					iwconfig $IFACE 2>/dev/null || true
+				fi
 				else
 					echo "Missing SSID or password for mcu_test"
 				fi

--- a/package/wifi/files/wlan.in
+++ b/package/wifi/files/wlan.in
@@ -149,6 +149,7 @@ configure() {
 	@if WIFI_ATBM6461@
 	# ATBM6461 uses mcu_test for WiFi connection via MCU, not wpa_supplicant.
 	# Store plain text credentials for mcu_test to read at boot.
+	password=$(printf '%s' "$password" | tr -d '\r\n\t')
 	{
 		echo "# created on $(date +%c)"
 		echo "ctrl_interface=/run/wpa_supplicant"


### PR DESCRIPTION
Follow-up to PR #1256 (merged).

Three post-merge fixes:

- **atbm6461-tool: add `--send-raw=<id>`** — raw RTOS command probe for discovering undocumented MCU commands. Sends a command ID with no payload, prints retcode and hex output.

- **S38wpa_supplicant: 3-sec SDIO stabilization sleep** — added `sleep 3` between `ip link set wlan0 up` and `mcu_test --wifi_connect` to give the ATBM6461 SDIO link time to stabilize before initiating the WiFi connection. Prevents occasional 4-way handshake failures caused by MCU auto-connect preceding the host command.

- **wlan.in: password sanitization** — strips carriage return, newline, and tab characters from passwords before storing to wpa_supplicant.conf. Fixes malformed config files caused by serial terminal line endings (`\r`) being embedded in the password field.