### PR TITLE
Enhance doorbell_chime.c

### DIFF
--- a/package/wyze-accessory/files/doorbell_chime.c
+++ b/package/wyze-accessory/files/doorbell_chime.c
@@ -1,8 +1,38 @@
 /*
-* Control the Wyze Doorbell V1's wireless chime!
-* Supporting playing various sounds, volume, repeat, and pairing.
-*/
-
+ * doorbell_chime.c – Wyze Doorbell V1 Chime Controller
+ *
+ * This is a superset of the original doorbell_chime and a drop-in
+ * replacement for it.  The two commands end-users will call most are:
+ *
+ *   pair – full 8-step pairing sequence with the CC1310 sub-GHz radio
+ *   play – trigger a sound/volume/repeat on an already-paired chime
+ *
+ * This implementation can also serve as a base for other Wyze sensors
+ * that use the same serial protocol.
+ *
+ * Protocol (TX, host → device): AA 55 53 [LEN] [CMD] [payload] [CHK_HI][CHK_LO]
+ * Protocol (RX, device → host): 55 AA 53 [LEN] [CMD] [payload] [CHK_HI][CHK_LO]
+ *   LEN = payload_len + 1(cmd) + 2(cksum)
+ *
+ * Pairing sequence (reverse-engineered from WyzeSensePy / Wyze protocol):
+ *   1. SUB1G_INIT       TX 0x14 0xFF
+ *   2. DELETE_ALL       TX 0x3F           [optional: -D flag]
+ *   3. START_PAIRING    TX 0x1C 0x01
+ *   4. NOTIFY_SCAN   ← RX 0x20           chime broadcasts MAC when in pairing mode
+ *   5. CHALLENGE        TX 0x21 <MAC8> <CHALLENGE_R[16]>
+ *   6. CHALLENGE_RESP ← RX 0x22
+ *   7. VERIFY_RESULT    TX 0x23 <MAC8> 0xFF 0x04
+ *   8. STOP_PAIRING     TX 0x1C 0x00
+ *
+ * MAC wire format: 8 upper-case ASCII hex chars, no colons.
+ *   Command line "77:AB:62:77" → wire bytes 0x37 0x37 0x41 0x42 0x36 0x32 0x37 0x37
+ *   (each character's ASCII value, not the decoded byte value)
+ *
+ * Build (MIPS / thingino):
+ *   mipsel-linux-gnu-gcc -march=mips32 -O2 -static \
+ *     -fno-builtin -Wall -Wextra doorbell_chime.c -o doorbell_chime
+ */
+ 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -10,394 +40,523 @@
 #include <fcntl.h>
 #include <unistd.h>
 #include <termios.h>
+#include <sys/select.h>
+#include <time.h>
 
-// Define CRTSCTS if not defined
 #ifndef CRTSCTS
 #define CRTSCTS 020000000000
 #endif
 
-// Convert a hexadecimal ASCII character to its ASCII value
-unsigned char hex_char_to_ascii(char c) {
-	return (unsigned char)c;
+#define DEVICE          "/dev/ttyS0"
+#define DEFAULT_VOLUME  5   /* 1–8 typical; device accepts up to ~32 */
+#define DEFAULT_REPEAT  1   /* times to play */
+
+/* 16-byte challenge R (from WyzeSensePy Scan()) */
+static const unsigned char CHALLENGE_R[16] = {
+    'O','k','5','H','P','N','Q','4','l','f','7','7','u','7','5','4'
+};
+
+static int debug_mode = 0;  /* -d / --debug */
+static int do_delete  = 0;  /* -D / --delete: clear pairings before pair */
+
+/* Print only when debug is on */
+#define dbg(fmt, ...) do { if (debug_mode) printf(fmt, ##__VA_ARGS__); } while (0)
+
+/* ──────────────────────────── MAC ──────────────────────────────── */
+
+/*
+ * Parse "XX:XX:XX:XX" → 8 upper-case ASCII hex chars (wire format).
+ * E.g. "00:11:22:33" → {'0','0','1','1','2','2','3','3'}
+ * Returns 0 on success, -1 on invalid input.
+ */
+static int parse_mac(const char *s, unsigned char *mac8)
+{
+    int j = 0;
+    for (; *s && j < 8; s++) {
+        if (*s == ':') continue;
+        if (!isxdigit((unsigned char)*s)) return -1;
+        mac8[j++] = (unsigned char)toupper((unsigned char)*s);
+    }
+    return (j == 8) ? 0 : -1;
 }
 
-// Check if a MAC address is in valid format (XX:XX:XX:XX)
-int is_valid_mac_format(const char *mac) {
-	// Check if the MAC has the correct length and colons in the right positions
-	if (strlen(mac) != 11) {
-		return 0;
-	}
+/* A string containing ':' is treated as a MAC address. */
+static int looks_like_mac(const char *s) { return !!strchr(s, ':'); }
 
-	if (mac[2] != ':' || mac[5] != ':' || mac[8] != ':') {
-		return 0;
-	}
+/* ──────────────────────────── sounds ───────────────────────────── */
 
-	// Check if all other characters are valid hexadecimal digits
-	for (int i = 0; i < 11; i++) {
-		if (i == 2 || i == 5 || i == 8) {
-			continue; // Skip the colon positions
-		}
-		if (!isxdigit(mac[i])) {
-			return 0;
-		}
-	}
+static const struct { const char *name; int id; } SOUNDS[] = {
+    {"SPACE_WAVE",  1}, {"WIND_CHIME", 2}, {"CURIOSITY",   3},
+    {"SURPRISE",    4}, {"CHEERFUL",   5}, {"DOORBELL_1",  6},
+    {"DOORBELL_2",  7}, {"DOORBELL_3", 8}, {"DOORBELL_4",  9},
+    {"BIRD_CHIRP", 10}, {"DOG_BARK_1",11}, {"DOG_BARK_2", 12},
+    {"DOOR_CLOSE", 13}, {"DOOR_OPEN", 14}, {"SIMPLE_1",   15},
+    {"SIMPLE_2",   16}, {"SIMPLE_3",  17}, {"SIMPLE_4",   18},
+    {"INTRUDER",   19},
+};
+#define N_SOUNDS ((int)(sizeof(SOUNDS) / sizeof(SOUNDS[0])))
 
-	return 1;
+/* Returns ID 1-19 for a sound name or decimal integer, -1 on error. */
+static int resolve_sound(const char *arg)
+{
+    for (int i = 0; i < N_SOUNDS; i++)
+        if (!strcmp(arg, SOUNDS[i].name)) return SOUNDS[i].id;
+    char *end;
+    long n = strtol(arg, &end, 10);
+    return (*end == '\0' && n >= 1 && n <= 19) ? (int)n : -1;
 }
 
-// Convert each pair of hexadecimal ASCII characters to their corresponding ASCII values
-void convert_mac_to_ascii(const char *mac, char *mac_ascii) {
-	// First, we should validate the MAC format
-	if (!is_valid_mac_format(mac)) {
-		fprintf(stderr, "Error: Invalid MAC address format. Use XX:XX:XX:XX format.\n");
-		exit(EXIT_FAILURE);
-	}
+/* ──────────────────────────── packet helpers ────────────────────── */
 
-	size_t j = 0;
-	for (size_t i = 0; i < strlen(mac); i++) {
-		if (mac[i] == ':') {
-			continue;
-		}
-		unsigned char high = hex_char_to_ascii(toupper(mac[i]));
-		unsigned char low = hex_char_to_ascii(toupper(mac[i + 1]));
-		j += sprintf(mac_ascii + j, "\\x%02X", high);
-		j += sprintf(mac_ascii + j, "\\x%02X", low);
-		i++;  // Skip the next character, as it is part of the current hex byte
-	}
+static void hex_dump(const char *lbl, const unsigned char *d, int n)
+{
+    if (!debug_mode) return;
+    printf("%s [%d]:", lbl, n);
+    for (int i = 0; i < n; i++) printf(" %02X", d[i]);
+    printf("  |");
+    for (int i = 0; i < n; i++) putchar(isprint(d[i]) ? d[i] : '.');
+    putchar('\n');
 }
 
-// Calculate checksum for the packet
-unsigned short calculate_checksum(const unsigned char *cmd, int length) {
-	unsigned short sum = 0;
-	for (int i = 0; i < length; i++) {
-		sum += cmd[i];
-	}
-	return sum;
+static unsigned short pkt_sum(const unsigned char *d, int n)
+{
+    unsigned short s = 0;
+    while (n--) s += *d++;
+    return s;
 }
 
-// Configure the serial port speed to 115200 baud and set it to raw mode
-int configure_serial_port(int fd) {
-	struct termios tty;
-
-	// Get current serial port settings
-	if (tcgetattr(fd, &tty) != 0) {
-		perror("Error from tcgetattr");
-		return -1;
-	}
-
-	// Set baud rate to 115200
-	cfsetospeed(&tty, B115200);
-	cfsetispeed(&tty, B115200);
-
-	// Set raw mode: Disable input/output processing and set 8N1 (8 data bits, no parity, 1 stop bit)
-	tty.c_cflag |= (CLOCAL | CREAD);  // Enable receiver, local mode
-	tty.c_cflag &= ~CSIZE;
-	tty.c_cflag |= CS8;               // 8 data bits
-	tty.c_cflag &= ~PARENB;           // No parity bit
-	tty.c_cflag &= ~CSTOPB;           // 1 stop bit
-	tty.c_cflag &= ~CRTSCTS;          // No hardware flow control
-
-	tty.c_iflag &= ~(IXON | IXOFF | IXANY); // Disable software flow control
-	tty.c_iflag &= ~(ICRNL | INLCR);        // Disable special handling of newlines
-
-	tty.c_lflag &= ~(ICANON | ECHO | ECHOE | ISIG);  // Disable canonical mode, echo, and signals
-	tty.c_oflag &= ~OPOST;  // Disable output processing
-
-	tty.c_cc[VMIN] = 1;  // Minimum number of characters to read
-	tty.c_cc[VTIME] = 5; // Timeout in deciseconds
-
-	// Apply the settings
-	if (tcsetattr(fd, TCSANOW, &tty) != 0) {
-		perror("Error from tcsetattr");
-		return -1;
-	}
-
-	// Debug output to verify settings
-	printf("Serial port configured to 115200 baud, raw mode.\n");
-
-	return 0;
+/*
+ * Build TX frame into buf: AA 55 53 [LEN=plen+3] [cmd] [payload] [CHK_HI][CHK_LO]
+ * Returns total length.
+ */
+static int build_pkt(unsigned char *buf, unsigned char cmd,
+                     const unsigned char *payload, int plen)
+{
+    int pos = 0;
+    buf[pos++] = 0xAA; buf[pos++] = 0x55; buf[pos++] = 0x53;
+    buf[pos++] = (unsigned char)(plen + 3);
+    buf[pos++] = cmd;
+    if (payload && plen) { memcpy(buf + pos, payload, plen); pos += plen; }
+    unsigned short cs = pkt_sum(buf, pos);
+    buf[pos++] = cs >> 8;
+    buf[pos++] = cs & 0xFF;
+    return pos;
 }
 
-// Map sound names to their corresponding IDs
-int get_sound_id(const char *sound_name) {
-	if (strcmp(sound_name, "SPACE_WAVE") == 0) return 1;
-	if (strcmp(sound_name, "WIND_CHIME") == 0) return 2;
-	if (strcmp(sound_name, "CURIOSITY") == 0) return 3;
-	if (strcmp(sound_name, "SURPRISE") == 0) return 4;
-	if (strcmp(sound_name, "CHEERFUL") == 0) return 5;
-	if (strcmp(sound_name, "DOORBELL_1") == 0) return 6;
-	if (strcmp(sound_name, "DOORBELL_2") == 0) return 7;
-	if (strcmp(sound_name, "DOORBELL_3") == 0) return 8;
-	if (strcmp(sound_name, "DOORBELL_4") == 0) return 9;
-	if (strcmp(sound_name, "BIRD_CHIRP") == 0) return 10;
-	if (strcmp(sound_name, "DOG_BARK_1") == 0) return 11;
-	if (strcmp(sound_name, "DOG_BARK_2") == 0) return 12;
-	if (strcmp(sound_name, "DOOR_CLOSE") == 0) return 13;
-	if (strcmp(sound_name, "DOOR_OPEN") == 0) return 14;
-	if (strcmp(sound_name, "SIMPLE_1") == 0) return 15;
-	if (strcmp(sound_name, "SIMPLE_2") == 0) return 16;
-	if (strcmp(sound_name, "SIMPLE_3") == 0) return 17;
-	if (strcmp(sound_name, "SIMPLE_4") == 0) return 18;
-	if (strcmp(sound_name, "INTRUDER") == 0) return 19;
-	return -1;  // Return -1 if no valid sound name is found
+/* ──────────────────────────── serial ───────────────────────────── */
+
+static int configure_serial(int fd)
+{
+    struct termios tty;
+    if (tcgetattr(fd, &tty)) { perror("tcgetattr"); return -1; }
+    cfsetospeed(&tty, B115200); cfsetispeed(&tty, B115200);
+    tty.c_cflag |=  (CLOCAL | CREAD);
+    tty.c_cflag &= ~CSIZE;  tty.c_cflag |= CS8;
+    tty.c_cflag &= ~(PARENB | CSTOPB | CRTSCTS);
+    tty.c_iflag &= ~(IXON | IXOFF | IXANY | ICRNL | INLCR);
+    tty.c_lflag &= ~(ICANON | ECHO | ECHOE | ISIG);
+    tty.c_oflag &= ~OPOST;
+    tty.c_cc[VMIN] = 0; tty.c_cc[VTIME] = 0;  /* non-blocking reads */
+    if (tcsetattr(fd, TCSANOW, &tty)) { perror("tcsetattr"); return -1; }
+    return 0;
 }
 
-// Check if the string is a number
-int is_number(const char *str) {
-	for (int i = 0; str[i] != '\0'; i++) {
-		if (!isdigit(str[i])) {
-			return 0;
-		}
-	}
-	return 1;
+static int open_serial(void)
+{
+    /* O_RDWR: need to read responses; O_NONBLOCK: use select() for timeouts */
+    int fd = open(DEVICE, O_RDWR | O_NOCTTY | O_NONBLOCK);
+    if (fd < 0) { perror("open " DEVICE); exit(EXIT_FAILURE); }
+    if (configure_serial(fd) < 0) { close(fd); exit(EXIT_FAILURE); }
+    dbg("[+] %s: 115200 8N1 raw\n", DEVICE);
+    return fd;
 }
 
-unsigned char convert_volume_to_value(int volume) {
-	if (volume < 1) volume = 1;
-	if (volume > 32) volume = 32;
-
-	return (unsigned char)(volume);  // Direct mapping from 1-32 to 0x01-0x20, should be enough.
+/* Send a packet; 120 ms settling time after write. */
+static void send_pkt(int fd, const unsigned char *pkt, int n, const char *desc)
+{
+    hex_dump(desc, pkt, n);
+    if (write(fd, pkt, n) != n) perror("write");
+    usleep(120000);
 }
 
-void send_verify_result(const char *mac_ascii, int debug_mode) {
-	unsigned char cmd[20] = {0xAA, 0x55, 0x53, 0x0D, 0x23};  // Header and CMD
-	size_t cmd_len = 5;
-
-	// Convert the MAC address into the command
-	for (size_t i = 0; i < strlen(mac_ascii); i += 4) {
-		unsigned char byte;
-		sscanf(mac_ascii + i + 2, "%02hhX", &byte);  // Convert the hex string to a byte
-		cmd[cmd_len++] = byte;
-	}
-
-	// Add the pairing payload
-	cmd[cmd_len++] = 0xFF;  // Part of the pairing payload
-	cmd[cmd_len++] = 0x04;  // Part of the pairing payload
-
-	// Calculate the checksum
-	unsigned short checksum = calculate_checksum(cmd, cmd_len);
-	cmd[cmd_len++] = (checksum >> 8) & 0xFF;  // Checksum high byte
-	cmd[cmd_len++] = checksum & 0xFF;  // Checksum low byte
-
-	// Print the command in debug mode
-	if (debug_mode) {
-		printf("Debug Mode: Pairing command to be sent to /dev/ttyS0: ");
-		for (size_t i = 0; i < cmd_len; i++) {
-			printf("\\x%02X", cmd[i]);
-		}
-		printf("\n");
-	}
-
-	// Open /dev/ttyS0 for writing
-	int serial_port = open("/dev/ttyS0", O_WRONLY | O_NOCTTY | O_SYNC);
-	if (serial_port < 0) {
-		perror("Error opening /dev/ttyS0");
-		exit(EXIT_FAILURE);
-	}
-
-	// Configure the serial port speed to 115200 baud and set it to raw mode
-	if (configure_serial_port(serial_port) < 0) {
-		close(serial_port);
-		return;
-	}
-
-	// Write the command to the serial port
-	if (write(serial_port, cmd, cmd_len) != cmd_len) {
-		perror("Error writing to /dev/ttyS0");
-	} else {
-		printf("Pairing command sent to /dev/ttyS0\n");
-	}
-
-	// Close the serial port
-	close(serial_port);
+/* Non-blocking read with select() timeout. */
+static int timed_read(int fd, unsigned char *buf, int max, int timeout_sec)
+{
+    fd_set fds; struct timeval tv = { timeout_sec, 0 };
+    FD_ZERO(&fds); FD_SET(fd, &fds);
+    if (select(fd + 1, &fds, NULL, NULL, &tv) <= 0) return 0;
+    int n = (int)read(fd, buf, max);
+    return n > 0 ? n : 0;
 }
 
-// Display detailed help information
-void display_help(const char *program_name) {
-	printf("Wyze Doorbell Chime Controller\n");
-	printf("==============================\n\n");
-	printf("Usage:\n");
-	printf("  %s [-d] [-p] <MAC_ADDRESS> <SOUND_NAME_OR_NUMBER> <VOLUME> [REPEAT]\n", program_name);
-	printf("  %s [-d] -p <MAC_ADDRESS>\n", program_name);
-	printf("  %s -h\n\n", program_name);
+/* ──────────────────────────── RX frame engine ───────────────────── */
 
-	printf("Options:\n");
-	printf("  -h    Display this help message\n");
-	printf("  -d    Debug mode (verbose output)\n");
-	printf("  -p    Pairing mode (pair with a doorbell chime)\n\n");
+static unsigned char _rxbuf[2048];
+static int           _rxlen = 0;
 
-	printf("Arguments:\n");
-	printf("  MAC_ADDRESS         MAC address of the doorbell chime in XX:XX:XX:XX format\n");
-	printf("  SOUND_NAME_OR_NUMBER  Sound to play, either by name or number (1-19)\n");
-	printf("  VOLUME              Volume level (1-8)\n");
-	printf("  REPEAT              Number of times to repeat the sound (1-255, default: 1)\n\n");
-
-	printf("Available Sound Names:\n");
-	printf("  SPACE_WAVE (1)      WIND_CHIME (2)     CURIOSITY (3)\n");
-	printf("  SURPRISE (4)        CHEERFUL (5)       DOORBELL_1 (6)\n");
-	printf("  DOORBELL_2 (7)      DOORBELL_3 (8)     DOORBELL_4 (9)\n");
-	printf("  BIRD_CHIRP (10)     DOG_BARK_1 (11)    DOG_BARK_2 (12)\n");
-	printf("  DOOR_CLOSE (13)     DOOR_OPEN (14)     SIMPLE_1 (15)\n");
-	printf("  SIMPLE_2 (16)       SIMPLE_3 (17)      SIMPLE_4 (18)\n");
-	printf("  INTRUDER (19)\n\n");
-
-	printf("Examples:\n");
-	printf("  %s -p 00:11:22:33   # Pair with chime at MAC 00:11:22:33\n", program_name);
-	printf("  %s 00:11:22:33 DOORBELL_1 5 2   # Play DOORBELL_1 sound at volume 5, repeat 2 times\n", program_name);
-	printf("  %s 00:11:22:33 15 8   # Play SIMPLE_1 sound at maximum volume\n", program_name);
+static void rx_push(const unsigned char *d, int n)
+{
+    if (_rxlen + n > (int)sizeof(_rxbuf)) {
+        int drop = _rxlen + n - (int)sizeof(_rxbuf);
+        memmove(_rxbuf, _rxbuf + drop, _rxlen - drop);
+        _rxlen -= drop;
+    }
+    memcpy(_rxbuf + _rxlen, d, n);
+    _rxlen += n;
 }
 
-int main(int argc, char *argv[]) {
-	int debug_mode = 0;
-	int pairing_mode = 0;
-	int help_mode = 0;
+static void rx_clear(void) { _rxlen = 0; }
 
-	// Check if the -h flag is present (help mode)
-	if (argc > 1 && strcmp(argv[1], "-h") == 0) {
-		display_help(argv[0]);
-		return EXIT_SUCCESS;
-	}
+/*
+ * Scan accumulator for a packet matching 'code'.
+ * RX magic: 55 AA 53
+ *   NOTIFICATION: 55 AA 53 LEN code payload CHK_HI CHK_LO  (LEN < 0x70)
+ *   ACK (7 bytes): 55 AA 53 code 00 CHK_HI CHK_LO
+ * On match, consumes the frame and optionally fills body/body_len.
+ */
+static int scan_for(unsigned char code, unsigned char *body, int *body_len)
+{
+    for (int i = 0; i + 7 <= _rxlen; i++) {
+        if (_rxbuf[i] != 0x55 || _rxbuf[i+1] != 0xAA || _rxbuf[i+2] != 0x53)
+            continue;
 
-	// Check if the -d or -p flag is present
-	while (argc > 1 && (strcmp(argv[1], "-d") == 0 || strcmp(argv[1], "-p") == 0)) {
-		if (strcmp(argv[1], "-d") == 0) {
-			debug_mode = 1;
-		}
-		if (strcmp(argv[1], "-p") == 0) {
-			pairing_mode = 1;
-		}
-		argv++;
-		argc--;
-	}
+        /* NOTIFICATION (length-prefixed) */
+        unsigned char plen = _rxbuf[i+3];
+        if (plen < 0x70) {
+            int tot = plen + 4;
+            if (i + tot <= _rxlen) {
+                unsigned short csc = pkt_sum(_rxbuf + i, tot - 2);
+                unsigned short csr = ((unsigned short)_rxbuf[i+tot-2] << 8) | _rxbuf[i+tot-1];
+                if (csc == csr && _rxbuf[i+4] == code) {
+                    if (body && body_len) {
+                        int bl = tot - 7;
+                        *body_len = (bl > 0 && bl <= 64) ? bl : 0;
+                        if (*body_len) memcpy(body, _rxbuf + i + 5, *body_len);
+                    }
+                    memmove(_rxbuf, _rxbuf + i + tot, _rxlen - i - tot);
+                    _rxlen -= i + tot;
+                    return 1;
+                }
+            }
+        }
 
-	if (pairing_mode && argc != 2) {
-		fprintf(stderr, "Error: Invalid arguments for pairing mode.\n");
-		fprintf(stderr, "Usage: %s [-d] -p <MAC_ADDRESS>\n", argv[0]);
-		fprintf(stderr, "Try '%s -h' for more information.\n", argv[0]);
-		return EXIT_FAILURE;
-	}
+        /* ACK (7-byte fixed frame) */
+        {
+            unsigned short csc = pkt_sum(_rxbuf + i, 5);
+            unsigned short csr = ((unsigned short)_rxbuf[i+5] << 8) | _rxbuf[i+6];
+            if (csc == csr && _rxbuf[i+3] == code) {
+                memmove(_rxbuf, _rxbuf + i + 7, _rxlen - i - 7);
+                _rxlen -= i + 7;
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
 
-	if (!pairing_mode && (argc < 4 || argc > 5)) {
-		// If no arguments were provided at all (just the program name), show a friendlier message
-		if (argc == 1) {
-			fprintf(stderr, "Usage: %s [-d] <MAC_ADDRESS> <SOUND_NAME_OR_NUMBER> <VOLUME> [REPEAT]\n", argv[0]);
-			fprintf(stderr, "Try '%s -h' for more information.\n", argv[0]);
-		} else {
-			fprintf(stderr, "Error: Invalid number of arguments.\n");
-			fprintf(stderr, "Usage: %s [-d] <MAC_ADDRESS> <SOUND_NAME_OR_NUMBER> <VOLUME> [REPEAT]\n", argv[0]);
-			fprintf(stderr, "Try '%s -h' for more information.\n", argv[0]);
-		}
-		return EXIT_FAILURE;
-	}
+/*
+ * Wait up to timeout_sec for a specific response code.
+ * Debug mode: prints wait/got/timeout messages + hex dumps.
+ * Returns 1 on success, 0 on timeout.
+ */
+static int wait_for(int fd, unsigned char code, int timeout_sec,
+                    unsigned char *body, int *body_len, const char *ctx)
+{
+    dbg("[.] Waiting 0x%02X [%s] (%ds)\n", code, ctx, timeout_sec);
+    time_t deadline = time(NULL) + timeout_sec;
+    while (time(NULL) < deadline) {
+        unsigned char tmp[256];
+        int n = timed_read(fd, tmp, sizeof(tmp), 1);
+        if (n > 0) { hex_dump("  ← RX", tmp, n); rx_push(tmp, n); }
+        if (scan_for(code, body, body_len)) {
+            dbg("[+] Got 0x%02X [%s]\n", code, ctx);
+            return 1;
+        }
+    }
+    dbg("[!] Timeout 0x%02X [%s]\n", code, ctx);
+    return 0;
+}
 
-	const char *mac = argv[1];
-	char mac_ascii[50] = {0};  // Enough space for the converted MAC, no segfaults
-	convert_mac_to_ascii(mac, mac_ascii);
+/* ──────────────────────────── protocol primitives ───────────────── */
 
-	// Pairing mode operation
-	if (pairing_mode) {
-		send_verify_result(mac_ascii, debug_mode);
-		return EXIT_SUCCESS;
-	}
+static void do_init(int fd) {
+    unsigned char p[] = {0xFF}, pkt[16];
+    int n = build_pkt(pkt, 0x14, p, 1);
+    send_pkt(fd, pkt, n, "→ SUB1G_INIT (0x14)");
+    wait_for(fd, 0x14, 2, NULL, NULL, "INIT ACK");
+}
 
-	// Open /dev/ttyS0 for writing
-	int serial_port = open("/dev/ttyS0", O_WRONLY | O_NOCTTY | O_SYNC);
-	if (serial_port < 0) {
-		perror("Error opening /dev/ttyS0");
-		return EXIT_FAILURE;
-	}
+static void do_delete_all(int fd) {
+    unsigned char pkt[16];
+    int n = build_pkt(pkt, 0x3F, NULL, 0);
+    send_pkt(fd, pkt, n, "→ DELETE_ALL (0x3F)");
+    wait_for(fd, 0x3F, 2, NULL, NULL, "DELETE ACK");
+}
 
-	// Configure the serial port speed to 115200 baud and set it to raw mode
-	if (configure_serial_port(serial_port) < 0) {
-		close(serial_port);
-		return EXIT_FAILURE;
-	}
+static void do_start_pairing(int fd) {
+    unsigned char p[] = {0x01}, pkt[16];
+    int n = build_pkt(pkt, 0x1C, p, 1);
+    send_pkt(fd, pkt, n, "→ START_PAIRING (0x1C 01)");
+    wait_for(fd, 0x1C, 2, NULL, NULL, "START ACK");
+}
 
-	// Sound command operation (existing functionality)
-	const char *sound_arg = argv[2];
-	const char *volume_arg = argv[3];
-	const char *repeat_arg = (argc == 5) ? argv[4] : "1";  // Default repeat value is 1
+static void do_stop_pairing(int fd) {
+    unsigned char p[] = {0x00}, pkt[16];
+    int n = build_pkt(pkt, 0x1C, p, 1);
+    send_pkt(fd, pkt, n, "→ STOP_PAIRING (0x1C 00)");
+    wait_for(fd, 0x1C, 2, NULL, NULL, "STOP ACK");
+}
 
-	// Get sound ID
-	int sound_id;
-	if (is_number(sound_arg)) {
-		sound_id = atoi(sound_arg);
-		if (sound_id < 0 || sound_id > 19) {
-			fprintf(stderr, "Invalid sound number. Must be between 0 and 19.\n");
-			return EXIT_FAILURE;
-		}
-	} else {
-		sound_id = get_sound_id(sound_arg);
-		if (sound_id == -1) {
-			fprintf(stderr, "Invalid sound name. Use one of the predefined sound names.\n");
-			return EXIT_FAILURE;
-		}
-	}
+static void do_challenge(int fd, const unsigned char *mac8) {
+    unsigned char payload[24], pkt[48];
+    memcpy(payload,     mac8,        8);
+    memcpy(payload + 8, CHALLENGE_R, 16);
+    int n = build_pkt(pkt, 0x21, payload, 24);
+    send_pkt(fd, pkt, n, "→ CHALLENGE (0x21)");
+}
 
-	// Validate and convert volume
-	if (!is_number(volume_arg)) {
-		fprintf(stderr, "Invalid volume. Must be a number between 1 and 8.\n");
-		return EXIT_FAILURE;
-	}
-	int volume = atoi(volume_arg);
-	if (volume < 0 || volume > 10) {
-		fprintf(stderr, "Invalid volume. Must be between 1 and 8.\n");
-		return EXIT_FAILURE;
-	}
-	unsigned char volume_value = convert_volume_to_value(volume);
+static void do_verify(int fd, const unsigned char *mac8) {
+    unsigned char payload[10], pkt[32];
+    memcpy(payload, mac8, 8);
+    payload[8] = 0xFF; payload[9] = 0x04;
+    int n = build_pkt(pkt, 0x23, payload, 10);
+    send_pkt(fd, pkt, n, "→ VERIFY_RESULT (0x23)");
+}
 
-	// Validate and convert repeat count
-	if (!is_number(repeat_arg)) {
-		fprintf(stderr, "Invalid repeat count. Must be a number.\n");
-		return EXIT_FAILURE;
-	}
-	int repeat_count = atoi(repeat_arg);
-	if (repeat_count < 1 || repeat_count > 255) {
-		fprintf(stderr, "Invalid repeat count. Must be between 1 and 255.\n");
-		return EXIT_FAILURE;
-	}
+/* ──────────────────────────── high-level commands ───────────────── */
 
-	// Prepare the command packet (leave space for checksum at the end)
-	unsigned char cmd[20] = {0xAA, 0x55, 0x53, 0x0E, 0x70};  // Header and CMD
-	size_t cmd_len = 5;
+/*
+ * cmd_pair: full 8-step pairing sequence.
+ *   mac8_hint: 8-char ASCII fallback if 0x20 doesn't carry the MAC (may be NULL).
+ *   do_delete:  global; when set, sends DELETE_ALL before START_PAIRING.
+ */
+static void cmd_pair(int fd, const unsigned char *mac8_hint)
+{
+    unsigned char mac8[8], body[64];
+    int body_len = 0, got_mac = 0;
 
-	// Convert the MAC address into the command
-	for (size_t i = 0; i < strlen(mac_ascii); i += 4) {
-		unsigned char byte;
-		sscanf(mac_ascii + i + 2, "%02hhX", &byte);  // Convert the hex string to a byte
-		cmd[cmd_len++] = byte;
-	}
+    /* Guide user to put chime in pairing mode */
+    printf("1. Unplug chime 10+ s, plug back in.\n");
+    printf("2. Hold button until slow blue flash (~3-4 s).\n");
+    printf("3. Press ENTER when LED is slowly flashing blue...\n");
+    getchar();
 
-	// Add SOUND ID, REPEAT, and VOLUME
-	cmd[cmd_len++] = sound_id;  // SOUND ID based on the provided argument
-	cmd[cmd_len++] = (unsigned char)repeat_count;  // REPEAT based on the provided argument
-	cmd[cmd_len++] = volume_value;  // VOLUME based on the provided argument
+    rx_clear();
 
-	// Calculate the checksum
-	unsigned short checksum = calculate_checksum(cmd, cmd_len);
-	cmd[cmd_len++] = (checksum >> 8) & 0xFF;  // Checksum high byte
-	cmd[cmd_len++] = checksum & 0xFF;  // Checksum low byte
+    dbg("── [1] SUB1G_INIT ──\n");
+    do_init(fd);
 
-	// Print the command in debug mode
-	if (debug_mode) {
-		printf("Debug Mode: Command to be sent to /dev/ttyS0: ");
-		for (size_t i = 0; i < cmd_len; i++) {
-			printf("\\x%02X", cmd[i]);
-		}
-		printf("\n");
-	}
+    if (do_delete) {
+        dbg("── [2] DELETE_ALL ──\n");
+        do_delete_all(fd);
+        usleep(400000);
+    }
 
-	// Write the command to the serial port
-	if (write(serial_port, cmd, cmd_len) != cmd_len) {
-		perror("Error writing to /dev/ttyS0");
-		close(serial_port);
-		return EXIT_FAILURE;
-	}
+    dbg("── [3] START_PAIRING ──\n");
+    do_start_pairing(fd);
+    usleep(400000);
 
-	printf("Command sent to /dev/ttyS0\n");
+    /* Step 4: wait up to 45 s for chime broadcast */
+    printf("Waiting for chime (45 s)... LED should be slowly flashing blue.\n");
+    if (wait_for(fd, 0x20, 45, body, &body_len, "CHIME_ANNOUNCE")) {
+        /* Body layout: [1 unknown byte][8 ASCII MAC bytes][type][ver] */
+        if (body_len >= 9) {
+            memcpy(mac8, body + 1, 8);
+            got_mac = 1;
+            dbg("[+] MAC from 0x20: %.8s\n", mac8);
+        }
+    }
 
-	// Close the serial port
-	close(serial_port);
+    if (!got_mac) {
+        if (mac8_hint) {
+            memcpy(mac8, mac8_hint, 8);
+            dbg("[!] No 0x20 — using provided MAC fallback\n");
+        } else {
+            fprintf(stderr, "Error: no chime announcement and no MAC given.\n");
+            do_stop_pairing(fd);
+            return;
+        }
+    }
 
-	return EXIT_SUCCESS;
+    dbg("── [5] CHALLENGE ──\n");
+    do_challenge(fd, mac8);
+
+    dbg("── [6] Waiting 0x22 CHALLENGE_RESP ──\n");
+    if (!wait_for(fd, 0x22, 10, NULL, NULL, "CHALLENGE_RESP"))
+        dbg("[!] No 0x22 — proceeding\n");
+
+    dbg("── [7] VERIFY_RESULT ──\n");
+    do_verify(fd, mac8);
+    wait_for(fd, 0x23, 5, NULL, NULL, "VERIFY ACK");
+
+    dbg("── [8] STOP_PAIRING ──\n");
+    do_stop_pairing(fd);
+
+    printf("Done! Listen for the success tone from the chime.\n");
+}
+
+/*
+ * cmd_play: trigger a sound on an already-paired chime.
+ * sound: 1-19, volume: 1-8 (up to 32 accepted), repeat: 1-255
+ */
+static void cmd_play(int fd, const unsigned char *mac8,
+                     int sound, int volume, int repeat)
+{
+    unsigned char payload[11], pkt[32];
+    memcpy(payload, mac8, 8);
+    payload[8]  = (unsigned char)sound;
+    payload[9]  = (unsigned char)repeat;
+    payload[10] = (unsigned char)volume;
+    int n = build_pkt(pkt, 0x70, payload, 11);
+    send_pkt(fd, pkt, n, "→ PLAY (0x70)");
+    wait_for(fd, 0x70, 3, NULL, NULL, "PLAY ACK");
+}
+
+/* ──────────────────────────── help ─────────────────────────────── */
+
+static void usage(const char *prog)
+{
+    printf("Wyze Doorbell V1 Chime Controller\n\n");
+    printf("Usage:\n");
+    printf("  %s [-d] [-D] pair|-p [<MAC>]              # full pairing\n", prog);
+    printf("  %s [-d] <MAC> <SOUND> [VOLUME] [REPEAT]   # play (positional)\n", prog);
+    printf("  %s [-d] play <MAC> <SOUND> [VOL] [REP]    # play (named)\n", prog);
+    printf("  %s [-d] init|delete|start|stop            # low-level commands\n", prog);
+    printf("  %s [-d] challenge|verify <MAC>            # pairing steps\n", prog);
+    printf("\nOptions:\n");
+    printf("  -d, --debug    Show TX/RX hex dumps and protocol steps\n");
+    printf("  -D, --delete   Delete existing pairings before pairing\n");
+    printf("  -h, --help     Show this help\n");
+    printf("\nMAC: XX:XX:XX:XX (e.g. 00:11:22:33); detected by ':' in any argument.\n");
+    printf("VOLUME default=%d (1-8), REPEAT default=%d (1-255)\n\n",
+           DEFAULT_VOLUME, DEFAULT_REPEAT);
+    printf("Sounds (name or number 1-19):\n");
+    printf("  SPACE_WAVE(1)   WIND_CHIME(2)  CURIOSITY(3)   SURPRISE(4)   CHEERFUL(5)\n");
+    printf("  DOORBELL_1(6)   DOORBELL_2(7)  DOORBELL_3(8)  DOORBELL_4(9) BIRD_CHIRP(10)\n");
+    printf("  DOG_BARK_1(11)  DOG_BARK_2(12) DOOR_CLOSE(13) DOOR_OPEN(14) SIMPLE_1(15)\n");
+    printf("  SIMPLE_2(16)    SIMPLE_3(17)   SIMPLE_4(18)   INTRUDER(19)\n\n");
+    printf("Examples:\n");
+    printf("  %s -p 00:11:22:33 # Pair with chime at MAC 00:11:22:33 \n", prog);
+    printf("  %s 00:11:22:33 DOORBELL_1 5 2 # Play DOORBELL_1 sound at volume 5, repeat 2 times\n", prog);
+    printf("  %s 00:11:22:33 15 8 # Play SIMPLE_1 sound at maximum volume\n", prog);
+    printf("  %s -D pair 00:11:22:33    # pair, clearing old pairings first\n", prog);
+}
+
+/* ──────────────────────────── main ─────────────────────────────── */
+
+int main(int argc, char **argv)
+{
+    const char *prog = argv[0];  /* save before argv++ shifts it */
+    int pair_flag = 0;
+
+    /* Strip leading option flags (all flags must precede the command/MAC) */
+    while (argc > 1) {
+        if      (!strcmp(argv[1], "-d") || !strcmp(argv[1], "--debug"))  debug_mode = 1;
+        else if (!strcmp(argv[1], "-D") || !strcmp(argv[1], "--delete")) do_delete  = 1;
+        else if (!strcmp(argv[1], "-p") || !strcmp(argv[1], "--pair"))   pair_flag  = 1;
+        else if (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))
+            { usage(prog); return EXIT_SUCCESS; }
+        else break;
+        argc--; argv++;
+    }
+
+    if (argc < 2) { usage(prog); return EXIT_FAILURE; }
+
+    /* Locate MAC address anywhere in the remaining args (detected by ':') */
+    unsigned char mac8[8];
+    int mac_idx = -1;
+    for (int i = 1; i < argc; i++) {
+        if (looks_like_mac(argv[i])) {
+            if (parse_mac(argv[i], mac8) < 0) {
+                fprintf(stderr, "%s: invalid MAC '%s'\n", prog, argv[i]);
+                return EXIT_FAILURE;
+            }
+            mac_idx = i;
+            break;
+        }
+    }
+    int have_mac = (mac_idx >= 0);
+
+    /* First non-flag arg: either a command word or a MAC (positional play) */
+    const char *cmd = argv[1];
+    int is_cmd = !looks_like_mac(cmd);  /* if not a MAC, it's a command word */
+
+    int fd = open_serial();
+
+    /* ── pair ─────────────────────────────────────────────────── */
+    if (pair_flag ||
+        (is_cmd && (!strcmp(cmd, "pair") || !strcmp(cmd, "-p")))) {
+        cmd_pair(fd, have_mac ? mac8 : NULL);
+
+    /* ── play (named) ─────────────────────────────────────────── */
+    } else if (is_cmd && !strcmp(cmd, "play")) {
+        if (!have_mac) {
+            fprintf(stderr, "%s: play requires a MAC address\n", prog);
+            close(fd); return EXIT_FAILURE;
+        }
+        int sound = -1, vol = DEFAULT_VOLUME, rep = DEFAULT_REPEAT, extra = 0;
+        const char *sound_arg = NULL;  /* track for error message */
+        for (int i = 2; i < argc; i++) {
+            if (i == mac_idx) continue;
+            if (extra == 0) {
+                sound_arg = argv[i];
+                sound = resolve_sound(argv[i]);
+                extra++;
+            } else if (extra == 1) { vol = atoi(argv[i]); extra++; }
+            else if (extra == 2) { rep = atoi(argv[i]); extra++; }
+        }
+        if (sound < 1) {
+            fprintf(stderr, "%s: invalid sound '%s' (use name or 1-19)\n",
+                    prog, sound_arg ? sound_arg : "(missing)");
+            close(fd); return EXIT_FAILURE;
+        }
+        if (vol < 1 || vol > 32) {
+        fprintf(stderr, "%s: volume %d out of range (1-32)\n", prog, vol);
+        close(fd); return EXIT_FAILURE;
+        }
+        if (rep < 1 || rep > 255) {
+            fprintf(stderr, "%s: repeat %d out of range (1-255)\n", prog, rep);
+            close(fd); return EXIT_FAILURE;
+        }
+        cmd_play(fd, mac8, sound, vol, rep);
+
+    /* ── low-level standalone commands ───────────────────────── */
+    } else if (is_cmd && !strcmp(cmd, "init")) {
+        do_init(fd);
+    } else if (is_cmd && !strcmp(cmd, "delete")) {
+        do_delete_all(fd);
+    } else if (is_cmd && !strcmp(cmd, "start")) {
+        do_start_pairing(fd);
+    } else if (is_cmd && !strcmp(cmd, "stop")) {
+        do_stop_pairing(fd);
+    } else if (is_cmd && !strcmp(cmd, "challenge")) {
+        if (!have_mac) { fprintf(stderr, "%s: challenge requires a MAC\n", prog); close(fd); return EXIT_FAILURE; }
+        do_challenge(fd, mac8);
+    } else if (is_cmd && !strcmp(cmd, "verify")) {
+        if (!have_mac) { fprintf(stderr, "%s: verify requires a MAC\n", prog); close(fd); return EXIT_FAILURE; }
+        do_verify(fd, mac8);
+
+    /* ── positional play: <MAC> <SOUND> [VOL] [REP] ─────────── */
+    } else if (have_mac && mac_idx == 1) {
+        if (argc < 3) {
+            fprintf(stderr, "Usage: %s <MAC> <SOUND> [VOLUME] [REPEAT]\n", prog);
+            close(fd); return EXIT_FAILURE;
+        }
+        int sound = resolve_sound(argv[2]);
+        if (sound < 1) {
+            fprintf(stderr, "%s: invalid sound '%s' (use name or 1-19)\n",
+                    prog, argv[2]);
+            close(fd); return EXIT_FAILURE;
+        }
+        int vol = (argc >= 4) ? atoi(argv[3]) : DEFAULT_VOLUME;
+        int rep = (argc >= 5) ? atoi(argv[4]) : DEFAULT_REPEAT;
+        cmd_play(fd, mac8, sound, vol, rep);
+
+    } else {
+        fprintf(stderr, "%s: unknown command '%s' (try -h)\n", prog, cmd);
+        close(fd); return EXIT_FAILURE;
+    }
+
+    close(fd);
+    return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Due to the lack of handshaking and the original doorbell_chime.c essentially just doing the verify step, the pairing of chimes to the doorbell was more of a glitch for some wyze doorbell v1 cameras and could take hours to days.  

So this was born to make pairing more reliable and consistent.

After writing a skeleton, I gathered and fed to claude how the protocol for other sensors worked to produce a more complete pairing procedure.

I tested it out and looked over things a bit as well to at least get an idea how everything works and tweaked a few things, but 95% of this is claude merging the original doorbell_chime.c with a from scratch reimplementation focused on pairing.  This was done to keep this as a drop-in replacement.

Also added a few more commands(though it is not exhaustive, the protocol supports a great deal more) and this can be used as a base to eventually pair other types of sensor and accessories that are having difficulty.