### PR TITLE
webui: add send photo/video toggles to ntfy config page

### DIFF
--- a/package/thingino-webui/files/www/a/tool-send2-ntfy.js
+++ b/package/thingino-webui/files/www/a/tool-send2-ntfy.js
@@ -14,6 +14,10 @@
       $("#ntfy_token").value = ntfy.token || "";
       $("#ntfy_use_ssl").checked =
         ntfy.use_ssl !== false && ntfy.use_ssl !== "false";
+      $("#ntfy_send_photo").checked =
+        ntfy.send_photo !== false && ntfy.send_photo !== "false";
+      $("#ntfy_send_video").checked =
+        ntfy.send_video === true || ntfy.send_video === "true";
     });
   }
 
@@ -28,6 +32,8 @@
           password: $("#ntfy_password").value.trim(),
           token: $("#ntfy_token").value.trim(),
           use_ssl: $("#ntfy_use_ssl").checked,
+          send_photo: $("#ntfy_send_photo").checked,
+          send_video: $("#ntfy_send_video").checked,
           enabled: true,
         },
       })),

--- a/package/thingino-webui/files/www/a/tool-send2.js
+++ b/package/thingino-webui/files/www/a/tool-send2.js
@@ -10,7 +10,7 @@
     mqtt: { photo: true, video: false },
     webhook: { photo: true, video: true },
     storage: { photo: true, video: true },
-    ntfy: { photo: true, video: false },
+    ntfy: { photo: true, video: true },
     gphotos: { photo: true, video: true },
   };
 

--- a/package/thingino-webui/files/www/tool-send2-ntfy.html
+++ b/package/thingino-webui/files/www/tool-send2-ntfy.html
@@ -31,7 +31,7 @@
       </div>
 
       <form id="ntfyForm" class="needs-validation" novalidate autocomplete="off">
-        <div class="row row-cols-1 row-cols-md-2 g-4 mb-4">
+        <div class="row row-cols-1 row-cols-md-2 row-cols-xl-3 g-4 mb-4">
 
           <!-- Server Settings -->
           <div class="col">
@@ -78,6 +78,23 @@
                   <label for="ntfy_token">Access Token</label>
                   <input type="text" class="form-control" id="ntfy_token" name="ntfy_token">
                   <small class="form-text text-secondary">Use token instead of username/password</small>
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <!-- Content Options -->
+          <div class="col">
+            <div class="card h-100">
+              <div class="card-header">Content Options</div>
+              <div class="card-body">
+                <p class="form-switch">
+                  <input type="checkbox" class="form-check-input" id="ntfy_send_photo" name="ntfy_send_photo" checked>
+                  <label class="form-check-label" for="ntfy_send_photo">Send photo</label>
+                </p>
+                <p class="form-switch">
+                  <input type="checkbox" class="form-check-input" id="ntfy_send_video" name="ntfy_send_video">
+                  <label class="form-check-label" for="ntfy_send_video">Send video</label>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
currently ntfy config UI lacks the capability to enable sending images and videos however the backend as well as the Motion view support this. The PR adds the this function similar to the FTP config.

Tested the photo function on Sonoff S2 slim and private ntfy server. I tried to test video but the hardware itself may not support it (no picture in video, size ~58kb), saving motion video to mmc also does not work (same file size)