### PR TITLE
package/timps: bump to v1.3.0 (T23 support + SRT AAC fix)

### DIFF
--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,7 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.2.0
+TIMPS_VERSION = v1.3.0
 
 # Submodule provides the IMP headers (ingenic-headers).
 TIMPS_GIT_SUBMODULES = YES


### PR DESCRIPTION
Bumps the pinned timps release from v1.2.0 to v1.3.0. v1.2.0 predates the T23 framesource/ABI fix and the SRT ADTS audio fix, so on T23 the current pin builds a streamer with no video and broken SRT audio. v1.3.0 (Lu-Fi/timps) contains both.