### PR TITLE
package/timps: restore WebUI overlay, color hook, ONVIF discovery, selftest

### DIFF
--- a/package/timps/README.md
+++ b/package/timps/README.md
@@ -1,0 +1,233 @@
+# timps (thingino package)
+
+**timps** — Tiny IMP Streamer (https://github.com/Lu-Fi/timps).
+Minimal-dependency streamer for Ingenic SoCs, replacing prudynt-t:
+RTSP (H.264/H.265, AAC/G.711) + fragmented-MP4 browser preview (MSE) +
+JPEG/MJPEG (incl. piggyback encoders on the video channels), OSD with its
+own TrueType rasterizer, motion detection (IMP_IVS), on-demand encoding.
+Pure C, links only against vendor libimp/libalog/libsysutils + pthread.
+
+## Layout
+
+```
+package/timps/
+├── Config.in                 BR2_PACKAGE_TIMPS (+ _CONTROL, _DAYNIGHT)
+├── timps.mk                  buildroot package (SITE_METHOD=git)
+└── files/
+    ├── timps.conf.example    -> /etc/timps.conf.example
+    ├── S95timps              -> /etc/init.d/S95timps
+    ├── color                 -> /usr/sbin/color (day/night hook, _DAYNIGHT)
+    └── www/x/*.cgi           -> /var/www/x/ (WebUI bridge, finalize hook)
+```
+
+## Source download (git + header submodule)
+
+The package fetches timps via git (`TIMPS_SITE_METHOD = git`)
+with `TIMPS_GIT_SUBMODULES = YES`, which also pulls the Ingenic IMP
+headers from the `gtxaspec/ingenic-headers` submodule at `include/` — the
+exact prudynt-t pattern. The source Makefile's `IMP_INC` default
+(`./include/<SoC>/<ver>/<lang>`) therefore works without overrides.
+
+`TIMPS_SITE` points at <https://github.com/Lu-Fi/timps>
+(`TIMPS_SITE_BRANCH = main`). **After the first push** pin
+`TIMPS_VERSION` in `timps.mk` to a commit hash (currently `main` = branch
+tip). thingino convention: `_SITE_BRANCH` = branch, `_VERSION` = exact
+commit — only a pinned commit is reproducible.
+
+## Enabling
+
+timps is one of the exclusive **streamer choices**:
+
+* `make menuconfig` → Thingino Firmware → Streamer Packages → **Streamer**
+  → `timps (minimal RTSP/MP4/MJPEG)`
+  (`BR2_PACKAGE_THINGINO_STREAMER_TIMPS=y`, selects
+  `BR2_PACKAGE_TIMPS`).
+* Because the choice is exclusive, prudynt-t / raptor / strero can never be
+  enabled at the same time — the old "conflicts with prudynt-t" caveat is
+  gone (timps also no longer installs any `prudyntctl`).
+* `BR2_PACKAGE_FAAC=y` — optional; automatically builds with `USE_FAAC=1`
+  (software AAC for browser MP4 + RTSP audio; without it audio falls back
+  to G.711/pcmu).
+* `BR2_PACKAGE_TIMPS_CONTROL=y` — optional `/control` endpoint
+  (`USE_CONTROL=1`) for live web-UI-style imaging changes. Not needed for
+  the preview.
+* `BR2_PACKAGE_TIMPS_DAYNIGHT=y` — native automatic day/night switching
+  (`USE_DAYNIGHT=1`, selects `_CONTROL` and `thingino-daynight`). See
+  "Automatic day/night" below.
+
+Build as usual; incremental rebuild: `make br-timps-rebuild`.
+
+## What gets installed
+
+* `/usr/bin/timpsd` (stripped)
+* `/etc/timps.conf.example` — seeded to `/etc/timps.conf` on first
+  start; adjust `sensor.*` if needed.
+* `/etc/init.d/S95timps` — start/stop/restart init script.
+* `/var/www/x/*.cgi` — WebUI bridge CGIs (only with WebUI + `_CONTROL`,
+  see "WebUI integration" below).
+
+The preview page talks to timps directly (see below).
+
+## Endpoints / thingino compatibility
+
+* RTSP on **port 554**, paths **`/ch0`** (main) and **`/ch1`** (sub) — same
+  as prudynt, so `rtsp://user:pass@<ip>:554/ch0` NVR URLs keep working
+  (set in the shipped conf example; timps's built-in default is 8554).
+* HTTP server on **port 8880**: `/` player page, `/?embed=1&chn=N` bare
+  player, `/stream.mp4?chn=N` (fMP4), `/snapshot.jpg?chn=N`,
+  `/stream.mjpeg?chn=N`. Requests from 127.0.0.0/8 bypass timps's
+  HTTP Basic auth. On `BR2_PACKAGE_TIMPS_CONTROL` builds the three media
+  endpoints also accept the timps token as `?token=` (viewing only, never
+  RTSP) — that is how the WebUI previews load them directly (a query token
+  can land in access logs; accepted on the LAN).
+* `GET /events` (SSE, `BR2_PACKAGE_TIMPS_CONTROL` builds): pushes `motion`
+  (grid cells), `daynight` (mode/brightness/gain) and periodic `stats`
+  events as JSON — same access rules as `/control`; the browser passes the
+  per-boot token as `?token=` (EventSource cannot send headers; may land in
+  logs, accepted on the LAN). The preview motion overlay subscribes to
+  `?stream=motion` instead of polling; config keys `events.enabled` /
+  `events.stats_ms` / `events.max_clients` (see the conf example).
+
+## Web UI preview (raptor pattern)
+
+When the timps streamer is chosen, `package/thingino-webui` installs
+`files/www/preview-timps.html` as `/var/www/preview.html`
+(`THINGINO_WEBUI_PREVIEW_HTML` switch in `thingino-webui.mk`, exactly like
+`preview-raptor.html` for raptor — no finalize-hook override anymore).
+
+That page is a **native MSE/fMP4 player** (no iframe): it fetches
+`http://<location.hostname>:8880/stream.mp4?chn=N` and drives a MediaSource
+SourceBuffer with the same queue/eviction/live-edge logic as timps's
+embedded player (`src/mp4/httpd.c`, `PLAYER_TAIL`); codec strings probed:
+`avc1.640028` (+ `mp4a.40.2`), `hvc1.1.6.L123.B0`. The motor joystick and
+`/a/preview-motors.js` are carried over unchanged from `preview-raptor.html`,
+so PTZ via `/x/json-motor.cgi` keeps working.
+
+The motion-grid overlay (`/a/preview-motion.js`) gets the per-boot token
+from `/x/timps-token.cgi`, probes `GET /control` once (feature detection +
+initial state) and then **subscribes** to
+`http://<host>:8880/events?stream=motion&token=<tok>` — timps pushes grid
+changes, no polling. If EventSource is unavailable or `/events` keeps
+failing (old timpsd, `events.enabled = 0`), it falls back to the previous
+4 Hz `GET /control` polling, so nothing regresses. The stream is closed
+while the tab is hidden and reopened on return; EventSource reconnects on
+its own after a streamer restart (server `retry: 3000`).
+
+**Known limitation (mixed content):** if the web UI is served over HTTPS,
+browsers block the plain-HTTP `:8880` video request and the preview stays
+black. Serve the web UI over HTTP or reverse-proxy timps under the
+same HTTPS origin.
+
+**Note (HTTP auth):** the stream is fetched by the *browser*, not by the
+camera. The page appends the per-boot timps token (`?token=`, shared with
+the motion overlay's single `/x/timps-token.cgi` fetch) to the
+`/stream.mp4` fetch, so the preview works even when `http.user`/`http.pass`
+are set in timps.conf. Without a token (endpoint unavailable) the old
+behavior remains: open `http://<ip>:8880/` once to cache Basic credentials,
+or leave timps's HTTP auth empty — the 401 hint in the status line stays.
+
+## No snapshot proxy CGIs
+
+All previews are fully self-contained: the main preview page plays timps's
+fMP4 stream directly from the camera's HTTP port, and the settings pages'
+small live preview, the fullscreen modal and the endpoint list
+(`/a/preview.js`) build
+`http://<host>:8880/stream.mjpeg?chn=N&token=<tok>` /
+`.../snapshot.jpg?chn=N&token=<tok>` URLs directly (token from
+`/x/timps-token.cgi`, cached per page; re-fetched once when the stream
+errors after a camera reboot, `nostream.svg` fallback when unavailable).
+**No `/x/ch*.jpg|mjpg` proxy CGIs and no `prudyntctl` shim are installed**
+— the finalize hook even purges the WebUI's own prudynt-flavored copies, so
+a timps image carries no dead snapshot endpoints (keep `videoN.jpeg = true`
+in timps.conf so `?chn=N` works). PTZ still uses thingino's own
+`/x/json-motor.cgi` (the real motor control, not a timps shim). External
+consumers should fetch `http://<ip>:8880/snapshot.jpg?chn=N` directly
+(Basic auth, or `?token=`/`X-Timps-Token` with the persistent `http.token`).
+
+## WebUI integration (bridge CGIs)
+
+The stock WebUI settings pages talk prudynt JSON to a handful of shell CGIs.
+When `BR2_PACKAGE_THINGINO_WEBUI=y` **and** `BR2_PACKAGE_TIMPS_CONTROL=y`,
+`timps.mk` installs timps-flavored replacements from `files/www/x/` via a
+`TARGET_FINALIZE_HOOK`, overriding the WebUI's own copies (same file names;
+the pages themselves only carry small streamer-agnostic tweaks in
+`package/thingino-webui`, e.g. the caps-based grey-out on the Image/Audio
+pages and the restart hint on the Main-/Substream pages). All of them keep
+the WebUI session auth
+(`/var/www/x/auth.sh`) and talk to `http://127.0.0.1:8880/control`
+(localhost bypasses timps's HTTP auth).
+
+| CGI | What it does now |
+|---|---|
+| `json-prudynt.cgi` | Workhorse. Translates prudynt-shaped JSON to `/control`: all numeric `image.*` keys pass through, filtered by the per-SoC `caps.image` list of `GET /control` (unsupported keys are dropped from forward and echo, so the page keeps them greyed out); `image.{hflip,vflip}` `true/false` -> `1/0`; audio live keys `mic_vol`/`mic_gain`/`mic_alc_gain`/`mic_high_pass_filter`/`mic_agc_enabled`/`mic_agc_target_level_dbfs`/`mic_agc_compression_gain_db`/`mic_noise_suppression` -> `audio.{volume,gain,alc_gain,high_pass,agc,agc_target_dbfs,agc_compression_db,ns}` (applied to the running input, filtered by `caps.audio`); audio persist-only keys `mic_enabled`/`mic_format` (AAC/G711A/G711U)/`mic_sample_rate` (8/16 kHz)/`mic_bitrate`/`force_stereo`/`spk_enabled`/`spk_vol`/`spk_gain` -> `audio.{enabled,codec,samplerate,bitrate,force_stereo,spk_enabled,spk_volume,spk_gain}` (saved to `timps.conf`, applied on restart; the echo adds `"restart_required":true` so the Audio page shows a restart hint); `streamN.*` and `sensor.*` (ALL persist-only — encoder/stream/sensor settings are never reconfigured live; saved to `timps.conf`, applied on the next restart, echo adds `"restart_required":true`): `streamN.format` (H264/H265) -> `videoN.codec`, `streamN.fps/width/height/bitrate/gop/max_gop/profile/buffers/enabled` -> same-named `videoN.*` keys, a `"WIDTHxHEIGHT"` `resolution` string is split into width/height, `streamN.mode` (CBR/VBR/FIXQP/SMART/CAPPED_VBR/CAPPED_QUALITY) -> `videoN.rc_mode`, `streamN.rtsp_endpoint` (`ch0`) -> `videoN.rtsp_path` (`/ch0`), `sensor.{model,i2c_addr,fps,width,height}` -> `sensor.*`; `streamN.osd.*` (the prudynt per-stream OSD tree) -> timps's PER-STREAM overlay set `osdN.M.*`, applied LIVE (stream0's page edits timps `osd0.*`, stream1's page `osd1.*`; item 0 = time, 1 = user text, 2 = uptime, 3 = logo): `enabled`, `position "x,y"` -> `x/y`, `fill_color "#rrggbb[aa]"` -> `color 0xAARRGGBB`, `stroke_color` -> `outline_color` (text outline drawn under the fill), osd-level `stroke_size` -> `outline` (px) and `font_size` -> `font_size` of all text items, `time.format`/`usertext.format` -> item texts (`%hostname` <-> `{hostname}`), osd-level `enabled` -> the GLOBAL `osd.enabled` master switch (restart); the echo returns each stream's own set so each OSD page populates its stream; `action.save_config` -> no-op "ok" (timps persists live); `action.dump_config` -> `GET /control` passthrough; `mp4.start/stop` -> explicit error (no record API); `motion/privacy.enabled` -> echoed only (not wired); `streamN.audio_enabled` dropped (timps audio is global, the toggle stays greyed out). |
+| `json-imp.cgi` | Live day/night bar: `auto` -> `{"daynight":{"enabled":true}}` (native auto detection on); `color` -> disables auto + `image.running_mode`; `daynight` -> disables auto + `force_mode`; `ir850/ir940/white/ircut` keep calling the GPIO helpers `light`/`ircut`. |
+| `json-prudynt-save.cgi` | No-op success — timps already persisted every applied change to `/etc/timps.conf`. |
+| `json-prudynt-config.cgi` | Config export: streams `GET /control` (timps shape) as a JSON download. |
+| `restart-prudynt.cgi` / `restart-timps.cgi` | `/etc/init.d/S95timps restart` (same ok-JSON as the original; the prudynt name is kept because the WebUI calls it). |
+| `json-heartbeat.cgi` / `json-heartbeat-slow.cgi` | timps-aware control-bar heartbeat (SSE / single shot; payload built by `timps-heartbeat.sh` from `GET /control` + the GPIO tools). Carries the day/night telemetry the control bar reads: `daynight_brightness` (%), `total_gain` (ISP [24.8] linear, 256 = 1x — feeds the `.dnd-gain` display), `daynight_mode` (`day`/`night`), `daynight_enabled`; `null` while unknown, like the stock heartbeat. |
+| `json-timegraph-stream.cgi` | Photosensing data-collector SSE (`tool-sensor-data.html`): polls `GET /control` every second (bounded, default 1 h — the page's EventSource reconnects) and emits `data: {"time_now","total_gain","daynight_brightness","daynight_mode"}` events, plus the `total_gain_*_threshold` chart lines when the photosensing page saved them to `/etc/thingino.json`. The page's history request (`json-prudynt.cgi`, `{"daynight":{"history":null}}`) is answered with the single current sample — timps keeps no sample ring, the graph grows from the live stream. |
+
+Not bridged (see the CGI headers for details): recording (`mp4`), motion
+toggle, mic/spk mute, `spk_sample_rate`, the G726/OPUS/PCM audio codecs,
+per-stream `audio_enabled`, and the remaining `prudyntctl events` consumers
+(`events.cgi`, `json-send2.cgi` live-apply). The page metrics `ev` and
+`ae_luma` are prudynt-only and stay absent from the timegraph stream.
+
+### Direct-to-timps token (`timps-token.cgi`)
+
+timps generates a random **per-boot token** and writes it to
+`/run/timps.token` (0640). `timps-token.cgi` (WebUI session auth via
+`auth.sh`) serves it as `{"token":"...","port":8880}` (port/token-file path
+read from `/etc/timps.conf`). With it a WebUI page can skip the localhost
+bridge CGIs and call timps **directly from the browser**: fetch the token
+once, then `fetch('http://<host>:8880/control', {method:'POST', headers:
+{'X-Timps-Token': token}, body: json})` — timps answers the CORS preflight
+and reflects the page's `Origin`. The token unlocks `/control`, `/events`
+and **viewing** the HTTP media endpoints (`/stream.mp4`, `/stream.mjpeg`,
+`/snapshot.jpg` — that is what the settings-page previews and the MSE
+preview use, as `?token=` since an `<img>`/`EventSource` cannot send
+headers), but never RTSP. The remaining bridge CGIs stay as-is (they use
+the localhost bypass and keep working). A cross-origin attacker cannot
+obtain the token (the file is only readable on-device by the authenticated
+WebUI backend), so serving it to the logged-in session does not widen the
+attack surface.
+
+## Automatic day/night
+
+With `BR2_PACKAGE_TIMPS_DAYNIGHT=y` (default when timps is selected) timps does
+the day/night **detection natively** — the separate `daynightd` daemon is not
+needed and its init script `S97daynightd` plus the WebUI "Photosensing" nav
+entry are removed at finalize (`TIMPS_DISABLE_DAYNIGHTD` hook). Detection is a
+thread inside `timpsd`: it samples `/proc/jz/isp/isp-m0` (integration time +
+gains), computes a scene brightness %, applies the same
+threshold/hysteresis/dwell rules as `daynightd` and on a change runs
+thingino's `/sbin/daynight day|night` (package `thingino-daynight`, selected),
+which drives the IR-cut filter, IR LEDs and the `color` hook per
+/etc/thingino.json. The package installs a timps flavor of `color` to
+`/usr/sbin/color` (same CLI as raptor's) that sets `image.running_mode`
+through `/control` — timps never sets the ISP mode directly, so manual
+`daynight`/`color` calls and the auto thread stay consistent.
+
+Config keys in `/etc/timps.conf` (defaults = daynightd's):
+`daynight.enabled` (1), `daynight.threshold_low` (25), `daynight.threshold_high`
+(75), `daynight.hysteresis` (0.1), `daynight.interval_ms` (500),
+`daynight.transition_s` (5), `daynight.switch_cmd` (`daynight`),
+`daynight.isp_path` (`/proc/jz/isp/isp-m0`).
+
+The WebUI imaging bar works as before: **Auto** re-enables detection
+(`{"daynight":{"enabled":true}}` via `/control`), the manual day/night/color
+buttons disable it and force a mode (see `json-imp.cgi` above); `GET /control`
+reports the live status `"daynight":{"enabled":N,"mode":N,"brightness":N,
+"total_gain":N}` — brightness in %, total_gain in the IMP [24.8] linear scale
+(256 = 1x, derived from the isp-m0 analog/digital/ISP-digital gain fields, log2
+units with 32 = 2x — the same value prudynt/raptor report), −1 while unknown.
+The thread keeps measuring in manual mode, so the WebUI gain display and the
+Photosensing data collector stay live with auto detection off.
+
+## Sizes / build flags
+
+The .mk builds with `-Os -ffunction-sections -fdata-sections` and links with
+`--gc-sections`; the binary is stripped on install. `USE_FAAC=0` and
+`USE_CONTROL=0` keep it smallest. For small-RAM SoCs (T10/T20, 64 MB) buffer
+bounds can be shrunk via `TIMPS_CFLAGS += -DMS_AU_BUF_MAX=...` etc.
+(see the comment at the top of the source Makefile).

--- a/package/timps/files/S96onvif_discovery
+++ b/package/timps/files/S96onvif_discovery
@@ -1,0 +1,337 @@
+#!/bin/sh
+
+DAEMON="/usr/sbin/wsd_simple_server"
+DAEMON_SHORT="wsd_simple_server"
+ONVIF_CONFIG=/etc/onvif.json
+MOTORS_CONFIG=/etc/thingino.json
+MOTORS_BIN="/bin/motors"
+PORTAL_MODE_FLAG="/run/portal_mode"
+
+RAPTOR_CONFIG=/etc/raptor.conf
+TIMPS_CONFIG=/etc/timps.conf
+OS_RELEASE_FILE="/etc/os-release"
+SOC_MODEL="$(soc -m)"
+
+iface_default() {
+	local iface
+
+	[ -z "$iface" ] && iface=$(ip -4 r | awk '/default/{print $5; exit}')
+	[ -z "$iface" ] && iface=$(ip -4 r | awk '{print $3; exit}')
+	[ -z "$iface" ] && iface=$(ip -6 r | awk '/default/{print $5; exit}')
+	[ -z "$iface" ] && iface=$(ip -6 r | awk '{print $3; exit}')
+
+	echo "$iface"
+}
+
+is_gateway_reachable() {
+	[ -z "$iface" ] && return 1
+	ping -c 1 -W 1 -I $iface $(ip -4 route | grep $iface | grep default | awk '{print $3}') >/dev/null 2>&1 ||
+		ping -6 -c 1 -W 1 -I $iface $(ip -6 route | grep $iface | grep default | awk '{print $3}') >/dev/null 2>&1
+}
+
+# ------------------------------------------------------------------ raptor ---
+raptor_conf_get() {
+	section="$1"
+	key="$2"
+
+	raptorctl config get "$section" "$key" 2>/dev/null
+}
+
+raptor_bool_default() {
+	section="$1"
+	key="$2"
+	default="$3"
+
+	val=$(raptor_conf_get "$section" "$key" | tr 'A-Z' 'a-z')
+	[ -n "$val" ] || val="$default"
+
+	case "$val" in
+		true | yes | 1 | on) echo "true" ;;
+		false | no | 0 | off) echo "false" ;;
+		*) echo "$default" ;;
+	esac
+}
+
+raptor_rtsp_scheme() {
+	if [ "$(raptor_bool_default rtsp tls true)" = "true" ]; then
+		echo "rtsps"
+	else
+		echo "rtsp"
+	fi
+}
+
+raptor_rtsp_port() {
+	port=$(raptor_conf_get rtsp port)
+	if [ -n "$port" ]; then
+		echo "$port"
+	elif [ "$(raptor_rtsp_scheme)" = "rtsps" ]; then
+		echo "322"
+	else
+		echo "554"
+	fi
+}
+
+raptor_rtsp_endpoint() {
+	case "$1" in
+		0)
+			key="endpoint_main"
+			def="ch0"
+			;;
+		1)
+			key="endpoint_sub"
+			def="ch1"
+			;;
+		*)
+			echo ""
+			return
+			;;
+	esac
+
+	ep=$(raptor_conf_get rtsp "$key")
+	[ -n "$ep" ] || ep="$def"
+	echo "${ep#/}"
+}
+
+raptor_webrtc_enabled() {
+	raptor_bool_default webrtc enabled true
+}
+
+raptor_webrtc_scheme() {
+	if [ "$(raptor_bool_default webrtc https true)" = "true" ]; then
+		echo "https"
+	else
+		echo "http"
+	fi
+}
+
+raptor_webrtc_port() {
+	port=$(raptor_conf_get webrtc http_port)
+	[ -n "$port" ] || port="8554"
+	echo "$port"
+}
+
+configure_raptor_onvif_profiles() {
+	rtsp_scheme=$(raptor_rtsp_scheme)
+	rtsp_port=$(raptor_rtsp_port)
+	endpoint_main=$(raptor_rtsp_endpoint 0)
+	endpoint_sub=$(raptor_rtsp_endpoint 1)
+
+	jct "$tmpfile" set profiles.stream0.url "${rtsp_scheme}://%s:${rtsp_port}/${endpoint_main}"
+	jct "$tmpfile" set profiles.stream1.url "${rtsp_scheme}://%s:${rtsp_port}/${endpoint_sub}"
+	jct "$tmpfile" set audio.backchannel.uri "${rtsp_scheme}://%s:${rtsp_port}/${endpoint_main}"
+
+	if [ "$(raptor_webrtc_enabled)" = "true" ]; then
+		webrtc_scheme=$(raptor_webrtc_scheme)
+		webrtc_port=$(raptor_webrtc_port)
+		stream0_width=$(jct "$tmpfile" get profiles.stream0.width 2>/dev/null | tr -d '\n')
+		stream0_height=$(jct "$tmpfile" get profiles.stream0.height 2>/dev/null | tr -d '\n')
+
+		jct "$tmpfile" set profiles.webrtc.name "WebRTC"
+		[ -n "$stream0_width" ] && jct "$tmpfile" set profiles.webrtc.width "$stream0_width"
+		[ -n "$stream0_height" ] && jct "$tmpfile" set profiles.webrtc.height "$stream0_height"
+		jct "$tmpfile" set profiles.webrtc.type "H264"
+		jct "$tmpfile" set profiles.webrtc.url "${webrtc_scheme}://%s:${webrtc_port}/webrtc.html"
+	fi
+}
+
+# ------------------------------------------------------------------- timps ---
+# timps uses a flat "key = value" config (dotted keys); parse it with sed,
+# mirroring the credential/URL logic that S95timps already uses for TLS keys.
+timps_conf_get() {
+	key="$1"
+	esc=$(echo "$key" | sed 's/[.[\*^$]/\\&/g')
+	sed -n "s/^[[:space:]]*${esc}[[:space:]]*=[[:space:]]*\([^#]*\).*/\1/p" \
+		"$TIMPS_CONFIG" 2>/dev/null | head -n1 | sed 's/[[:space:]]*$//'
+}
+
+timps_bool_default() {
+	val=$(timps_conf_get "$1" | tr 'A-Z' 'a-z')
+	[ -n "$val" ] || val="$2"
+	case "$val" in
+		true | yes | 1 | on) echo "true" ;;
+		*) echo "false" ;;
+	esac
+}
+
+timps_rtsp_scheme() {
+	if [ "$(timps_bool_default rtsp.tls false)" = "true" ]; then
+		echo "rtsps"
+	else
+		echo "rtsp"
+	fi
+}
+
+timps_rtsp_port() {
+	if [ "$(timps_rtsp_scheme)" = "rtsps" ]; then
+		port=$(timps_conf_get rtsp.tls_port); [ -n "$port" ] || port="322"
+	else
+		port=$(timps_conf_get rtsp.port);     [ -n "$port" ] || port="8554"
+	fi
+	echo "$port"
+}
+
+timps_rtsp_endpoint() {
+	case "$1" in
+		0) ep=$(timps_conf_get video0.rtsp_path); def="ch0" ;;
+		1) ep=$(timps_conf_get video1.rtsp_path); def="ch1" ;;
+		*) echo ""; return ;;
+	esac
+	[ -n "$ep" ] || ep="$def"
+	echo "${ep#/}"
+}
+
+timps_http_scheme() {
+	if [ "$(timps_bool_default http.https false)" = "true" ]; then
+		echo "https"
+	else
+		echo "http"
+	fi
+}
+
+timps_http_port() {
+	port=$(timps_conf_get http.port); [ -n "$port" ] || port="8880"
+	echo "$port"
+}
+
+configure_timps_onvif_profiles() {
+	rtsp_scheme=$(timps_rtsp_scheme)
+	rtsp_port=$(timps_rtsp_port)
+	endpoint_main=$(timps_rtsp_endpoint 0)
+	endpoint_sub=$(timps_rtsp_endpoint 1)
+	http_scheme=$(timps_http_scheme)
+	http_port=$(timps_http_port)
+
+	jct "$tmpfile" set profiles.stream0.url "${rtsp_scheme}://%s:${rtsp_port}/${endpoint_main}"
+	jct "$tmpfile" set profiles.stream1.url "${rtsp_scheme}://%s:${rtsp_port}/${endpoint_sub}"
+	# timps snapshots are served by its own HTTP server (per-stream via ?chn=N,
+	# needs videoN.jpeg = true). No RTSP audio backchannel: timps is one-way.
+	jct "$tmpfile" set profiles.stream0.snapurl "${http_scheme}://%s:${http_port}/snapshot.jpg?chn=0"
+	jct "$tmpfile" set profiles.stream1.snapurl "${http_scheme}://%s:${http_port}/snapshot.jpg?chn=1"
+}
+
+# ----------------------------------------------------------------- daemons ---
+start_daemon() {
+	start-stop-daemon -S -b -m -p "$PIDFILE" -x "$DAEMON" -- $@
+}
+
+stop_daemon() {
+	if [ -f "$PIDFILE" ]; then
+		start-stop-daemon -K -p "$PIDFILE" -x "$DAEMON"
+		status=$?
+		rm -f "$PIDFILE"
+		return $status
+	fi
+
+	start-stop-daemon -K -x "$DAEMON"
+}
+
+iface="$(iface_default)"
+
+CAMERA=$(awk -F '=' '/^IMAGE_ID=/ {print $2}' $OS_RELEASE_FILE)
+
+start() {
+	echo -c 15 "Starting ONVIF discovery"
+
+	if [ -f "$PORTAL_MODE_FLAG" ]; then
+		echo -c 160 -e "Disabled" >&2
+		exit 1
+	fi
+
+	if ! is_gateway_reachable; then
+		echo -c 160 -e "Disabled" >&2
+		exit 1
+	fi
+
+	# Start one instance per active non-loopback interface
+	for active_iface in $(ip -4 -o addr show | awk '$2 != "lo" {print $2}' | sort -u); do
+		PIDFILE="/run/${DAEMON_SHORT}_${active_iface}.pid"
+		DAEMON_ARGS="-i $active_iface -x http://%s/onvif/device_service -m $CAMERA -n thingino -p $PIDFILE"
+		# shellcheck disable=SC2086
+		start_daemon $DAEMON_ARGS
+	done
+
+	tmpfile="$(mktemp -u).json"
+	echo '{}' >$tmpfile
+	jct $tmpfile set camera.manufacturer "Thingino"
+	jct $tmpfile set camera.model "$CAMERA"
+	jct $tmpfile set camera.hardware_id "ingenic_$SOC_MODEL"
+	jct $tmpfile set camera.serial_num "$(fw_printenv -n ethaddr | sed 's/://g' | tr -d "\n")"
+	jct $tmpfile set camera.firmware_ver "$(awk -F'[=,"]' '/^BUILD_ID/{print $3 $4}' /etc/os-release | tr -d "\n")"
+	jct $tmpfile set server.ifs $iface
+
+	# Pick the credential/URL source from the active streamer. timps stores its
+	# RTSP user/pass and stream paths in /etc/timps.conf; raptor answers via
+	# raptorctl. Sourcing ONVIF auth from the wrong one is what makes clients
+	# fail to log in.
+	if [ -f "$TIMPS_CONFIG" ]; then
+		configure_timps_onvif_profiles
+		username=$(timps_conf_get rtsp.user | tr -d '\n')
+		password=$(timps_conf_get rtsp.pass | tr -d '\n')
+	else
+		configure_raptor_onvif_profiles
+		username=$(raptor_conf_get rtsp username | tr -d '\n')
+		password=$(raptor_conf_get rtsp password | tr -d '\n')
+	fi
+
+	# Only write credentials when auth is actually configured. An empty
+	# "username":"" string is NOT the same as "no auth": onvif_simple_server
+	# treats a present-but-empty username as auth-enabled and then checks the
+	# password against an empty string, locking every client out. When no RTSP
+	# user is set we therefore DELETE the keys so ONVIF stays open, matching
+	# timps' open RTSP.
+	if [ -n "$username" ]; then
+		jct $tmpfile set server.username "$username"
+		jct $tmpfile set server.password "$password"
+	fi
+
+	# conditional PTZ config
+	if [ -f "$MOTORS_BIN" ]; then
+		steps_pan=$(jct $MOTORS_CONFIG get motors.steps_pan | tr -d "\n")
+		steps_tilt=$(jct $MOTORS_CONFIG get motors.steps_tilt | tr -d "\n")
+
+		jct $tmpfile set ptz.enable 1
+		jct $tmpfile set ptz.max_step_x "$steps_pan"
+		jct $tmpfile set ptz.max_step_y "$steps_tilt"
+	else
+		jct $tmpfile set ptz.enable 0
+	fi
+	jct $ONVIF_CONFIG import $tmpfile
+
+	# import can only add/overwrite, never remove -> clear stale creds here when
+	# no auth is configured, otherwise a previously written user would linger.
+	if [ -z "$username" ]; then
+		jct $ONVIF_CONFIG del server.username 2>/dev/null
+		jct $ONVIF_CONFIG del server.password 2>/dev/null
+	fi
+
+	rm -f $tmpfile
+}
+
+stop() {
+	echo -c 15 "Stopping ONVIF discovery"
+
+	for pidfile in /run/${DAEMON_SHORT}_*.pid; do
+		[ -f "$pidfile" ] || continue
+		PIDFILE="$pidfile"
+		stop_daemon
+	done
+}
+
+case "$1" in
+	start)
+		start
+		;;
+	stop)
+		stop
+		;;
+	restart)
+		stop
+		start
+		;;
+	*)
+		echo "Usage: $0 {start|stop|restart}"
+		exit 1
+		;;
+esac
+
+exit 0

--- a/package/timps/files/color
+++ b/package/timps/files/color
@@ -1,0 +1,50 @@
+#!/bin/sh
+# Controls color mode of the image (timps flavor).
+# Same CLI as raptor's color script, but the ISP day/night mode is set through
+# timps's /control JSON API (localhost bypasses timps's HTTP auth).
+# Called by /sbin/daynight when daynight.controls.color is enabled.
+
+MODE_FILE="/tmp/colormode.txt"
+[ -f "$MODE_FILE" ] || touch "$MODE_FILE"
+
+CONTROL_URL="http://127.0.0.1:8880/control"
+
+# NB! ISP mode is set backwards: 0 - color, 1 - monochrome
+
+switch_to_color() {
+  curl -s -m 5 -X POST "$CONTROL_URL" -d '{"image":{"running_mode":0}}' >/dev/null 2>&1
+  echo "1" >"$MODE_FILE"
+}
+
+switch_to_monochrome() {
+  curl -s -m 5 -X POST "$CONTROL_URL" -d '{"image":{"running_mode":1}}' >/dev/null 2>&1
+  echo "0" >"$MODE_FILE"
+}
+
+case "$1" in
+0 | off | night)
+  switch_to_monochrome
+  ;;
+1 | on | day)
+  switch_to_color
+  ;;
+~ | toggle)
+  if [ "$(cat "$MODE_FILE")" = "1" ]; then
+    switch_to_monochrome
+  else
+    switch_to_color
+  fi
+  ;;
+status)
+  cat "$MODE_FILE"
+  ;;
+\? | read)
+  cat "$MODE_FILE" | tr -d '\n'
+  ;;
+*)
+  echo "Usage: $0 [on|off|toggle|status|read]" >&2
+  exit 1
+  ;;
+esac
+
+exit 0

--- a/package/timps/files/timps-selftest.sh
+++ b/package/timps/files/timps-selftest.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# timps-selftest - on-device smoke test of the timps HTTP API and features.
+# Run on the camera:  timps-selftest        (or: timps-selftest -v  for bodies)
+# Exits 0 when nothing FAILED (warnings are non-fatal: they usually mean a
+# feature is simply not enabled/available on this build or no SD is mounted).
+
+CONF=/etc/timps.conf
+VERBOSE=0
+[ "$1" = "-v" ] && VERBOSE=1
+
+port=$(sed -n 's/^[[:space:]]*http\.port[[:space:]]*=[[:space:]]*\([0-9]\{1,\}\).*/\1/p' "$CONF" 2>/dev/null | head -n1)
+[ -n "$port" ] || port=8880
+https=$(sed -n 's/^[[:space:]]*http\.https[[:space:]]*=[[:space:]]*\([0-9A-Za-z]*\).*/\1/p' "$CONF" 2>/dev/null | head -n1)
+case "$https" in 1|true|yes|on) scheme=https; K="-k" ;; *) scheme=http; K="" ;; esac
+tok=$(head -n1 /run/timps.token 2>/dev/null | tr -cd '0-9A-Za-z')
+BASE="$scheme://127.0.0.1:$port"
+AUTH="X-Timps-Token: $tok"
+
+pass=0; fail=0
+ok()   { echo "  [PASS] $1"; pass=$((pass + 1)); }
+bad()  { echo "  [FAIL] $1"; fail=$((fail + 1)); }
+warn() { echo "  [WARN] $1"; }
+get()  { curl -s $K -m 5 -H "$AUTH" "$BASE$1"; }
+post() { curl -s $K -m 5 -H "$AUTH" -X POST "$BASE/control" -d "$1" >/dev/null 2>&1; }
+
+if [ -n "$tok" ]; then tokstate=present; else tokstate=MISSING; fi
+echo "timps selftest -> $BASE  (token: $tokstate)"
+command -v curl >/dev/null 2>&1 || { echo "curl not found"; exit 1; }
+
+# ---- /control + sections ----
+CTL=$(get /control)
+[ "$VERBOSE" = 1 ] && echo "$CTL" | head -c 400 && echo
+echo "$CTL" | grep -q '"caps"' && ok "/control responds" || { bad "/control not responding"; echo "timps running? try: /etc/init.d/S95timps status"; }
+for k in image audio video osd motion privacy record daynight; do
+  echo "$CTL" | grep -q "\"$k\":" && ok "section: $k" || bad "section: $k missing"
+done
+
+# ---- caps ----
+echo "$CTL" | grep -q '"privacy":{"available":1' && ok "caps.privacy" || bad "caps.privacy"
+echo "$CTL" | grep -q '"record":{"available":1'  && ok "caps.record"  || bad "caps.record"
+if echo "$CTL" | grep -o '"motion":{"available":[01]' | grep -q ':1'; then ok "motion available"
+else warn "motion not available (SoC/SDK has no IMP_IVS move API)"; fi
+
+# ---- media endpoints ----
+sz=$(curl -s $K -m 5 -H "$AUTH" "$BASE/snapshot.jpg?chn=0" | wc -c)
+[ "$sz" -gt 200 ] && ok "snapshot.jpg ($sz bytes)" || bad "snapshot.jpg empty"
+mp=$(curl -s $K -m 3 -H "$AUTH" "$BASE/stream.mp4?chn=1" | head -c 64 | wc -c)
+[ "$mp" -gt 0 ] && ok "stream.mp4 flowing" || bad "stream.mp4 no data"
+mj=$(curl -s $K -m 3 -H "$AUTH" "$BASE/stream.mjpeg?chn=1" | head -c 64 | wc -c)
+[ "$mj" -gt 0 ] && ok "stream.mjpeg flowing" || warn "stream.mjpeg no data"
+
+# ---- /events push ----
+ev=$(curl -s $K -m 4 -N "$BASE/events?stream=stats&token=$tok" 2>/dev/null | head -c 200)
+echo "$ev" | grep -q 'event:' && ok "/events pushing" || warn "/events no frame (events.enabled=0?)"
+
+# ---- privacy round-trip (uses region 3 so it won't clobber a real mask 0) ----
+post '{"privacy":{"0":{"3":{"enabled":1,"x":8,"y":8,"w":48,"h":48,"color":"0xFF0000FF"}}}}'
+get /control | grep -q '"3":{"enabled":1,"x":8,"y":8,"w":48,"h":48' && ok "privacy set + readback" || bad "privacy set/readback"
+post '{"privacy":{"0":{"3":{"enabled":0,"w":0,"h":0}}}}'
+
+# ---- recording start/stop ----
+post '{"record":{"active":1}}'; sleep 2
+rec=$(get /control | grep -o '"record":{[^}]*}')
+[ "$VERBOSE" = 1 ] && echo "  record=$rec"
+echo "$rec" | grep -q '"recording":1' && ok "recording started" || warn "recording not active (is record.dir mounted/writable?)"
+post '{"record":{"active":0}}'
+
+# ---- SRT listener ----
+srten=$(sed -n 's/^[[:space:]]*srt\.enabled[[:space:]]*=[[:space:]]*\([0-9A-Za-z]*\).*/\1/p' "$CONF" 2>/dev/null | head -n1)
+srtport=$(sed -n 's/^[[:space:]]*srt\.port[[:space:]]*=[[:space:]]*\([0-9]\{1,\}\).*/\1/p' "$CONF" 2>/dev/null | head -n1)
+[ -n "$srtport" ] || srtport=9000
+case "$srten" in
+  1|true|yes|on)
+    if netstat -lun 2>/dev/null | grep -q ":$srtport\b"; then ok "SRT listening on udp/$srtport"
+    else warn "SRT udp/$srtport not listening (libsrt build? check logread)"; fi ;;
+  *) warn "SRT disabled (srt.enabled not set)" ;;
+esac
+
+# ---- HTTPS note ----
+[ "$scheme" = https ] && ok "HTTPS scheme active" || echo "  [info] plain HTTP (http.https not set)"
+
+echo "--------------------------------------------------"
+echo "timps selftest: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/package/timps/files/www/a/config-audio.js
+++ b/package/timps/files/www/a/config-audio.js
@@ -1,0 +1,281 @@
+/* config-audio.js - NATIVE Audio Settings page. Talks directly to the timps
+ * streamer over window.timpsApi (GET/POST /control on timps's own port, per-
+ * boot token) - no json-prudynt.cgi bridge for this page (a/audio.js and
+ * a/streamer-config.js are no longer loaded here).
+ *
+ * Load:  timpsApi.get() -> populate every control from the "audio" object.
+ *        LIVE controls are enabled only when their timps key is listed in
+ *        caps.audio (the SoC capability matrix); the persist+restart keys
+ *        (codec/samplerate/bitrate) are deliberately NOT in caps.audio, so
+ *        they enable when the audio object carries them. Speaker and stereo
+ *        controls stay greyed out: timps has no audio-output (AO) pipeline.
+ * Save:  LIVE keys (volume/gain/alc_gain/high_pass/agc/agc_target_dbfs/
+ *        agc_compression_db/ns) go straight to timpsApi.set({audio:{...}}),
+ *        debounced so slider drags coalesce into one POST; timps applies
+ *        them live AND persists immediately. PERSIST+RESTART keys (codec/
+ *        samplerate/bitrate) are saved the same way but only take effect
+ *        after a streamer restart, so those changes show the existing
+ *        "Restart streamer" hint (the menu entry calls /x/restart-prudynt.cgi).
+ * Offline: if timps is unreachable the controls stay disabled and a small
+ *        notice appears; nothing throws.
+ */
+(function () {
+  "use strict";
+
+  if (!document.body || document.body.id !== "page-config-audio") return;
+
+  // page field id (prudynt-era name) -> timps audio.* key.
+  // live:true = in caps.audio and applied immediately by the HAL;
+  // live:false = persist-only, needs a streamer restart to take effect.
+  // (The page has no mic on/off switch - the control bar's mic button is the
+  // live mute; it maps to audio.mute elsewhere.)
+  var FIELD_MAP = {
+    audio_mic_vol: { key: "volume", live: true },
+    audio_mic_gain: { key: "gain", live: true },
+    audio_mic_alc_gain: { key: "alc_gain", live: true },
+    audio_mic_high_pass_filter: { key: "high_pass", live: true },
+    audio_mic_agc_enabled: { key: "agc", live: true },
+    audio_mic_agc_target_level_dbfs: { key: "agc_target_dbfs", live: true },
+    audio_mic_agc_compression_gain_db: { key: "agc_compression_db", live: true },
+    audio_mic_noise_suppression: { key: "ns", live: true },
+    audio_mic_format: { key: "codec", live: false },
+    audio_mic_sample_rate: { key: "samplerate", live: false },
+    audio_mic_bitrate: { key: "bitrate", live: false },
+  };
+
+  // no audio output (AO) pipeline in timps: these controls never enable
+  var UNSUPPORTED = [
+    "audio_spk_vol",
+    "audio_spk_gain",
+    "audio_spk_sample_rate",
+    "audio_force_stereo",
+  ];
+
+  // page codec names <-> timps canonical codec spelling. The page options
+  // timps cannot encode (G726/OPUS/PCM) are disabled in wireControls().
+  var CODEC_TO_TIMPS = { AAC: "aac", G711U: "pcmu", G711A: "pcma" };
+  var CODEC_FROM_TIMPS = { aac: "AAC", pcmu: "G711U", pcma: "G711A" };
+
+  function $id(id) { return document.getElementById(id); }
+
+  function toast(type, message, ms) {
+    if (typeof window.showAlert === "function")
+      window.showAlert(type, message, ms);
+    else console.log("[config-audio]", type + ":", message);
+  }
+
+  function restartHint() {
+    toast(
+      "warning",
+      "Setting saved. Restart the streamer (Restart streamer in the menu) for it to take effect.",
+      8000,
+    );
+  }
+
+  // same disabled styling audio.js/main.js always used: input.disabled + a
+  // "disabled" class on the wrapping block
+  function setEnabled(id, on) {
+    var el = $id(id);
+    if (!el) return;
+    el.disabled = !on;
+    var wrap =
+      el.closest(
+        ".range, .number-range, .number, .select, .boolean, .file, .form-switch",
+      ) || el.parentElement;
+    if (wrap) wrap.classList.toggle("disabled", !on);
+  }
+
+  // rebuild the sample-rate/bitrate <select> options from the data-* hints
+  // (same behavior initDynamicSelects() in a/audio.js provided)
+  function populateDynamicSelect(select) {
+    if (!select || select.dataset.dynamicOptionsReady === "1") return;
+    var values = null;
+    if (select.dataset.optionValues) {
+      values = select.dataset.optionValues
+        .split(",").map(function (s) { return s.trim(); }).filter(Boolean);
+    } else if (select.dataset.rangeMin && select.dataset.rangeMax) {
+      var min = Number(select.dataset.rangeMin);
+      var max = Number(select.dataset.rangeMax);
+      var step = Number(select.dataset.rangeStep) || 1;
+      if (isFinite(min) && isFinite(max)) {
+        values = [];
+        for (var v = min; v <= max; v += step) values.push(String(v));
+      }
+    }
+    if (!values || !values.length) return;
+    select.innerHTML = '<option value="">- Select -</option>';
+    values.forEach(function (item) {
+      var option = document.createElement("option");
+      option.value = item;
+      option.textContent = item;
+      select.appendChild(option);
+    });
+    select.dataset.dynamicOptionsReady = "1";
+  }
+
+  function populate(id, value) {
+    var el = $id(id);
+    if (!el || value === undefined || value === null) return;
+    if (el.type === "checkbox") el.checked = !!Number(value);
+    else if (id === "audio_mic_format")
+      el.value = CODEC_FROM_TIMPS[String(value).toLowerCase()] || "";
+    else el.value = value;
+  }
+
+  // one changed control -> POST {"audio":{key:val}} to timps. Live keys are
+  // debounced (slider drags coalesce); persist+restart keys go out directly
+  // and show the restart hint.
+  function send(id) {
+    var el = $id(id);
+    var map = FIELD_MAP[id];
+    if (!el || !map) return;
+    var value;
+    if (el.type === "checkbox") value = el.checked ? 1 : 0;
+    else if (id === "audio_mic_format") {
+      value = CODEC_TO_TIMPS[el.value];
+      if (!value) return;
+    } else {
+      value = parseInt(el.value, 10);
+      if (isNaN(value)) return;
+    }
+    var audio = {};
+    audio[map.key] = value;
+    el.classList.add("opacity-75");
+    var done = function () { el.classList.remove("opacity-75"); };
+    var fail = function (err) {
+      console.error("timps set failed:", err);
+      toast("danger", "Failed to apply setting: " + (err.message || err));
+    };
+    if (map.live) {
+      window.timpsApi.setDebounced({ audio: audio }, 150).catch(fail).then(done);
+    } else {
+      window.timpsApi
+        .set({ audio: audio })
+        .then(function () { restartHint(); }, fail)
+        .then(done);
+    }
+  }
+
+  function wireControls() {
+    populateDynamicSelect($id("audio_mic_sample_rate"));
+    populateDynamicSelect($id("audio_mic_bitrate"));
+    populateDynamicSelect($id("audio_spk_sample_rate"));
+
+    // codecs timps cannot encode stay listed but not selectable
+    var fmt = $id("audio_mic_format");
+    if (fmt) {
+      Array.prototype.forEach.call(fmt.options, function (opt) {
+        if (opt.value && !CODEC_TO_TIMPS[opt.value]) {
+          opt.disabled = true;
+          opt.textContent = opt.textContent + " (not supported)";
+        }
+      });
+    }
+
+    Object.keys(FIELD_MAP).forEach(function (id) {
+      var el = $id(id);
+      if (!el) return;
+      setEnabled(id, false); // disabled until timps confirms support
+      el.addEventListener("change", function () { send(id); });
+    });
+
+    // speaker + stereo: no AO pipeline in timps, keep greyed out + a note
+    UNSUPPORTED.forEach(function (id) { setEnabled(id, false); });
+    var spkHead = Array.prototype.find.call(
+      document.querySelectorAll("main h4"),
+      function (h) { return /speaker/i.test(h.textContent); },
+    );
+    if (spkHead && !$id("timps-no-ao-note")) {
+      var note = document.createElement("small");
+      note.id = "timps-no-ao-note";
+      note.className = "d-block text-warning";
+      note.textContent =
+        "Not available: this streamer has no audio output (speaker) pipeline. Stereo capture is not supported either.";
+      spkHead.parentNode.insertBefore(note, spkHead.nextSibling);
+    }
+
+    // timps applies + persists every change immediately; the button is
+    // kept only to reassure users trained on the old save-to-file step.
+    var saveBtn = $id("save-prudynt-config");
+    if (saveBtn) {
+      saveBtn.addEventListener("click", function () {
+        toast(
+          "success",
+          "Nothing to do: audio settings are applied and already saved to the streamer configuration (codec, sampling and bitrate take effect after a streamer restart).",
+          5000,
+        );
+      });
+    }
+
+    var reloadBtn = $id("audio-reload");
+    if (reloadBtn) {
+      reloadBtn.addEventListener("click", function () {
+        reloadBtn.disabled = true;
+        load(true).then(function () { reloadBtn.disabled = false; });
+      });
+    }
+  }
+
+  function offlineNotice() {
+    if ($id("timps-offline-notice")) return;
+    var div = document.createElement("div");
+    div.id = "timps-offline-notice";
+    div.className = "alert alert-warning mt-2";
+    div.innerHTML =
+      '<i class="bi bi-exclamation-triangle me-1"></i>' +
+      "The streamer is not reachable, audio controls are disabled. " +
+      "Check that the timps service is running, then reload this page.";
+    var section = document.querySelector("main section");
+    var container = document.querySelector("main .container");
+    if (section && section.parentNode)
+      section.parentNode.insertBefore(div, section);
+    else if (container) container.appendChild(div);
+  }
+
+  // silent=true: reload triggered by the button (toast instead of busy veil)
+  function load(silent) {
+    if (!window.timpsApi) {
+      console.error("timps-api.js not loaded");
+      offlineNotice();
+      return Promise.resolve();
+    }
+    if (!silent && typeof window.showBusy === "function")
+      window.showBusy("Loading audio settings...");
+    return window.timpsApi
+      .get()
+      .then(function (json) {
+        var audio = json.audio || {};
+        var capsAudio = (json.caps && json.caps.audio) || [];
+        Object.keys(FIELD_MAP).forEach(function (id) {
+          var map = FIELD_MAP[id];
+          populate(id, audio[map.key]);
+          // live keys: only what the SoC can drive (caps.audio); persist+
+          // restart keys are not listed in caps by design - enable them
+          // whenever timps reports a value for them
+          var on = map.live
+            ? capsAudio.indexOf(map.key) >= 0
+            : audio[map.key] !== undefined;
+          setEnabled(id, on);
+        });
+        var offline = $id("timps-offline-notice");
+        if (offline) offline.remove();
+        if (silent) toast("info", "Audio settings reloaded.", 3000);
+      })
+      .catch(function (err) {
+        console.warn("timps unreachable, audio controls stay disabled:", err);
+        offlineNotice();
+      })
+      .then(function () {
+        if (!silent && typeof window.hideBusy === "function") window.hideBusy();
+      });
+  }
+
+  function init() {
+    wireControls();
+    load(false);
+  }
+
+  if (document.readyState === "loading")
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  else init();
+})();

--- a/package/timps/files/www/a/config-motion.js
+++ b/package/timps/files/www/a/config-motion.js
@@ -1,0 +1,198 @@
+/* config-motion.js - NATIVE timps IMP_IVS grid motion detection settings.
+ *
+ * Talks DIRECTLY to the timps streamer over window.timpsApi (GET/POST /control,
+ * per-boot token) - no /x/json-prudynt.cgi bridge.
+ *   load: timpsApi.get() -> json.motion {available,enabled,cols,rows,
+ *         max_cells,sensitivity,monitor_stream} (caps.motion carries the same
+ *         available/max_cells). All settings apply LIVE (timps stops and
+ *         recreates its IVS grid) and persist.
+ *   save: timpsApi.set({motion:{key:val}}); timps clamps cols*rows to the
+ *         SDK cell budget, so we re-read once and re-apply the (possibly
+ *         clamped) echo. When motion is unavailable (no IMP_IVS move API) or
+ *         timps is unreachable the whole page is greyed with a notice.
+ *
+ * Kept lean (embedded target): no libraries, no polling, changes fire on
+ * 'change' only. */
+(function () {
+  "use strict";
+
+  const MAX_AXIS = 16; // sane UI cap per axis even on 52-cell SDKs
+
+  const els = {
+    enabled: $("#motion_enabled"),
+    cols: $("#motion_cols"),
+    rows: $("#motion_rows"),
+    stream: $("#motion_monitor_stream"),
+    sens: $("#motion_sensitivity"),
+    sensValue: $("#motion_sensitivity_value"),
+    unavailable: $("#motion-unavailable"),
+    capsNote: $("#motion-caps-note"),
+    gridPreview: $("#motion-grid-preview"),
+  };
+  const controls = [els.enabled, els.cols, els.rows, els.stream, els.sens];
+
+  let maxCells = 0; // unknown until the first echo
+  let loading = true; // suppress change handlers while populating
+
+  function showAlert(variant, message, timeout = 6000) {
+    if (window.showAlert && typeof window.showAlert === "function") {
+      window.showAlert(variant, message, timeout);
+    } else {
+      console.log(`[${variant}] ${message}`);
+    }
+  }
+
+  function setDisabled(disabled) {
+    controls.forEach((el) => {
+      if (el) el.disabled = disabled;
+    });
+  }
+
+  function markUnavailable(message) {
+    setDisabled(true);
+    if (els.unavailable) {
+      els.unavailable.classList.remove("d-none");
+      if (message) els.unavailable.textContent = message;
+    }
+  }
+
+  /* rebuild one axis selector: 1..limit, keeping the current value */
+  function fillAxis(select, limit, current) {
+    if (!select) return;
+    const cur = current || Number(select.value) || 1;
+    select.innerHTML = "";
+    for (let i = 1; i <= limit; i++) {
+      const opt = document.createElement("option");
+      opt.value = String(i);
+      opt.textContent = String(i);
+      select.appendChild(opt);
+    }
+    select.value = String(Math.min(cur, limit));
+  }
+
+  /* limit each axis so cols*rows <= max_cells (given the OTHER axis' value) */
+  function rebuildAxisLimits(cols, rows) {
+    if (!maxCells) return;
+    const colLimit = Math.min(MAX_AXIS, Math.max(1, Math.floor(maxCells / rows)), maxCells);
+    const rowLimit = Math.min(MAX_AXIS, Math.max(1, Math.floor(maxCells / cols)), maxCells);
+    fillAxis(els.cols, colLimit, cols);
+    fillAxis(els.rows, rowLimit, rows);
+  }
+
+  function drawGridPreview(cols, rows) {
+    const grid = els.gridPreview;
+    if (!grid) return;
+    grid.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
+    grid.style.gridTemplateRows = `repeat(${rows}, 1fr)`;
+    grid.innerHTML = "";
+    const n = cols * rows;
+    for (let i = 0; i < n; i++) {
+      const cell = document.createElement("div");
+      cell.className = "cell";
+      grid.appendChild(cell);
+    }
+  }
+
+  /* apply a motion query/echo result to the form */
+  function applyMotion(mo) {
+    if (!mo) return;
+    if (mo.available === false || mo.available === 0) {
+      markUnavailable();
+      return;
+    }
+    if (typeof mo.max_cells === "number" && mo.max_cells > 0) {
+      maxCells = mo.max_cells;
+      if (els.capsNote) {
+        els.capsNote.textContent =
+          `This SoC supports up to ${maxCells} detection cells ` +
+          `(columns × rows ≤ ${maxCells}).`;
+      }
+    }
+    loading = true;
+    const cols = typeof mo.cols === "number" && mo.cols > 0 ? mo.cols : 1;
+    const rows = typeof mo.rows === "number" && mo.rows > 0 ? mo.rows : 1;
+    rebuildAxisLimits(cols, rows);
+    // timps reports enabled as 0/1; the old bridge used true/false - accept both
+    if (els.enabled && mo.enabled !== undefined) els.enabled.checked = !!Number(mo.enabled);
+    if (els.stream && typeof mo.monitor_stream === "number")
+      els.stream.value = String(mo.monitor_stream);
+    if (els.sens && typeof mo.sensitivity === "number") {
+      els.sens.value = String(mo.sensitivity);
+      if (els.sensValue) els.sensValue.textContent = String(mo.sensitivity);
+    }
+    drawGridPreview(cols, rows);
+    setDisabled(false);
+    loading = false;
+  }
+
+  async function loadMotion() {
+    if (!window.timpsApi) {
+      markUnavailable("timps-api.js not loaded.");
+      return;
+    }
+    try {
+      const json = await window.timpsApi.get();
+      const mo = json && json.motion;
+      // caps.motion carries available/max_cells too; merge as a fallback
+      if (mo && json.caps && json.caps.motion) {
+        if (mo.available === undefined) mo.available = json.caps.motion.available;
+        if (!mo.max_cells) mo.max_cells = json.caps.motion.max_cells;
+      }
+      if (!mo) throw new Error("no motion data from streamer");
+      applyMotion(mo);
+    } catch (err) {
+      console.error("Failed to load motion settings", err);
+      markUnavailable(
+        "Motion detection is not available (streamer unreachable or no " +
+          `IMP_IVS move API): ${err.message || err}.`,
+      );
+    }
+  }
+
+  async function saveMotion(key, value) {
+    if (loading) return;
+    try {
+      await window.timpsApi.set({ motion: { [key]: value } });
+      // cols/rows may come back CLAMPED by timps: re-read the live state once
+      const json = await window.timpsApi.get();
+      if (json && json.motion) applyMotion(json.motion);
+    } catch (err) {
+      console.error(`Failed to update motion.${key}`, err);
+      showAlert("danger", `Failed to update ${key.replace(/_/g, " ")}: ${err.message || err}`);
+    }
+  }
+
+  function bind() {
+    if (els.enabled)
+      els.enabled.addEventListener("change", () => saveMotion("enabled", els.enabled.checked));
+    if (els.cols)
+      els.cols.addEventListener("change", () => saveMotion("cols", Number(els.cols.value)));
+    if (els.rows)
+      els.rows.addEventListener("change", () => saveMotion("rows", Number(els.rows.value)));
+    if (els.stream)
+      els.stream.addEventListener("change", () =>
+        saveMotion("monitor_stream", Number(els.stream.value)),
+      );
+    if (els.sens) {
+      els.sens.addEventListener("input", () => {
+        if (els.sensValue) els.sensValue.textContent = els.sens.value;
+      });
+      els.sens.addEventListener("change", () =>
+        saveMotion("sensitivity", Number(els.sens.value)),
+      );
+    }
+  }
+
+  function init() {
+    setDisabled(true); // greyed until the streamer confirms support
+    drawGridPreview(5, 5);
+    bind();
+    loadMotion();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/package/timps/files/www/a/config-photosensing.js
+++ b/package/timps/files/www/a/config-photosensing.js
@@ -1,0 +1,157 @@
+/* config-photosensing.js - timps day/night (photosensing) settings.
+ *
+ * Overlay replacing the stock thingino page script, which POSTed the gain
+ * thresholds to /x/json-config-daynight.cgi (thingino.json) - a file the
+ * timps streamer never reads, so the thresholds did nothing. This version
+ * talks DIRECTLY to timps via GET/POST /control (a/timps-api.js):
+ *   #daynight_enabled                     -> daynight.enabled
+ *   #daynight_total_gain_night_threshold  -> daynight.total_gain_night_threshold
+ *   #daynight_total_gain_day_threshold    -> daynight.total_gain_day_threshold
+ * timps persists them into /etc/timps.conf itself and the detection thread
+ * picks them up live (gain-based decision, prudynt scale: 256 = 1x gain,
+ * lower gain = brighter = day).
+ *
+ * The Controls (color/ircut/IR850/IR940/white) and Time Schedule columns
+ * configure the BOARD daynight script, not timps - they stay on the stock
+ * /x/json-config-daynight.cgi backend, loaded and saved best-effort. */
+(function () {
+  "use strict";
+
+  if (!document.body || document.body.id !== "page-config-photosensing") return;
+  if (!window.timpsApi) {
+    console.error("[photosensing] timps-api.js not loaded");
+    return;
+  }
+
+  var LEGACY = "/x/json-config-daynight.cgi"; // board script config (controls/schedule)
+  var CONTROLS = ["color", "ircut", "ir850", "ir940", "white"];
+  var SCHEDULE = ["enabled", "start_at", "stop_at"];
+
+  var $ = function (id) { return document.getElementById(id); };
+
+  var reloadBtn = $("photosensing-reload");
+  var saveBtn = $("save-prudynt-config");
+
+  function toast(type, msg, ms) {
+    if (typeof window.showAlert === "function") window.showAlert(type, msg, ms);
+    else console.log("[photosensing]", type + ":", msg);
+  }
+
+  /* ---- timps part: enabled + gain thresholds -------------------------- */
+
+  function fillTimps(dn) {
+    dn = dn || {};
+    var en = $("daynight_enabled");
+    if (en) en.checked = (dn.enabled === true || dn.enabled === 1);
+    ["total_gain_night_threshold", "total_gain_day_threshold"].forEach(function (k) {
+      var el = $("daynight_" + k);
+      if (!el) return;
+      var v = dn[k];
+      el.value = (v === null || typeof v === "undefined") ? "" : Math.round(v);
+    });
+  }
+
+  function collectTimps() {
+    var out = {};
+    var en = $("daynight_enabled");
+    if (en) out.enabled = !!en.checked;
+    ["total_gain_night_threshold", "total_gain_day_threshold"].forEach(function (k) {
+      var el = $("daynight_" + k);
+      if (!el) return;
+      var v = parseInt(el.value, 10);
+      if (!isNaN(v) && v >= 0) out[k] = v;
+    });
+    return out;
+  }
+
+  /* ---- legacy part: controls + schedule (board daynight script) ------- */
+
+  function fillLegacy(dn) {
+    dn = dn || {};
+    if (dn.controls) CONTROLS.forEach(function (c) {
+      var el = $("daynight_controls_" + c);
+      if (el && Object.prototype.hasOwnProperty.call(dn.controls, c))
+        el.checked = !!dn.controls[c];
+    });
+    if (dn.schedule) SCHEDULE.forEach(function (p) {
+      var el = $("daynight_schedule_" + p);
+      if (!el || !Object.prototype.hasOwnProperty.call(dn.schedule, p)) return;
+      if (el.type === "checkbox") el.checked = !!dn.schedule[p];
+      else el.value = dn.schedule[p] || "";
+    });
+  }
+
+  function collectLegacy() {
+    var controls = {}, schedule = {};
+    CONTROLS.forEach(function (c) {
+      var el = $("daynight_controls_" + c);
+      if (el) controls[c] = !!el.checked;
+    });
+    SCHEDULE.forEach(function (p) {
+      var el = $("daynight_schedule_" + p);
+      if (!el) return;
+      schedule[p] = (el.type === "checkbox") ? !!el.checked : (el.value || "");
+    });
+    return { controls: controls, schedule: schedule };
+  }
+
+  function loadLegacy() {
+    return fetch(LEGACY, { cache: "no-store" })
+      .then(function (res) { return res.ok ? res.json() : null; })
+      .then(function (data) { if (data) fillLegacy(data); })
+      .catch(function () {
+        console.warn("[photosensing] " + LEGACY + " unavailable - controls/schedule not loaded");
+      });
+  }
+
+  function saveLegacy() {
+    return fetch(LEGACY, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ daynight: collectLegacy() }),
+    }).then(function (res) {
+      if (!res.ok) throw new Error("HTTP " + res.status);
+    });
+  }
+
+  /* ---- load / save ----------------------------------------------------- */
+
+  function load() {
+    if (reloadBtn) reloadBtn.disabled = true;
+    var t = window.timpsApi.get().then(function (json) {
+      fillTimps(json && json.daynight);
+    }).catch(function (e) {
+      toast("danger", "Unable to load timps day/night settings: " + (e.message || e));
+    });
+    Promise.allSettled([t, loadLegacy()]).then(function () {
+      if (typeof window.attachSliderButtons === "function") window.attachSliderButtons();
+      if (reloadBtn) reloadBtn.disabled = false;
+    });
+  }
+
+  function save(ev) {
+    if (ev) { ev.preventDefault(); ev.stopImmediatePropagation(); }
+    if (saveBtn) saveBtn.disabled = true;
+    window.timpsApi.set({ daynight: collectTimps() }).then(function () {
+      // controls/schedule stay on the board-script backend; best-effort
+      return saveLegacy().catch(function (e) {
+        toast("warning", "Thresholds saved to timps.conf, but controls/schedule not saved (" +
+          (e.message || e) + ").", 6000);
+      });
+    }).then(function () {
+      toast("success", "Photosensing settings saved (thresholds live in timps.conf).", 4000);
+      load();
+    }).catch(function (e) {
+      toast("danger", "Failed to save photosensing settings: " + (e.message || e));
+    }).finally(function () {
+      if (saveBtn) saveBtn.disabled = false;
+    });
+  }
+
+  if (saveBtn) saveBtn.addEventListener("click", save, { capture: true });
+  if (reloadBtn) reloadBtn.addEventListener("click", load);
+
+  if (document.readyState === "loading")
+    document.addEventListener("DOMContentLoaded", load, { once: true });
+  else load();
+})();

--- a/package/timps/files/www/a/main.css
+++ b/package/timps/files/www/a/main.css
@@ -1,0 +1,992 @@
+@media (max-width: 575.98px) {
+  body:before {
+    content: "xs"
+  }
+}
+@media (min-width: 576px) and (max-width: 767.98px) {
+  body:before {
+    content: "sm"
+  }
+}
+@media (min-width: 768px) and (max-width: 991.98px) {
+  body:before {
+    content: "md"
+  }
+}
+@media (min-width: 992px) and (max-width: 1199.98px) {
+  body:before {
+    content: "lg"
+  }
+}
+@media (min-width: 1200px) and (max-width: 1399.98px) {
+  body:before {
+    content: "xl"
+  }
+}
+@media (min-width: 1400px) {
+  body:before {
+    content: "xxl"
+  }
+}
+
+@keyframes a1 {
+  90%, 100% { flex-grow: 1; }
+}
+@keyframes blinker {
+  0% { opacity: 0; }
+  15% { opacity: 1; }
+}
+@keyframes pulse {
+  0%,
+  100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+@keyframes diagCopied {
+  0% { transform: scale(1); }
+  40% { transform: scale(1.12); }
+  100% { transform: scale(1); }
+}
+@keyframes slideOutRight {
+  from { transform: translateX(0); opacity: 1; }
+  to { transform: translateX(400px); opacity: 0; }
+}
+
+:root {
+  --ansi-66: #5f8787;
+  --ansi-70: #5faf00;
+  --ansi-142: #afaf00;
+  --ansi-144: #afaf87;
+  --ansi-240: #585858;
+  --bs-font-sans-serif: "Montserrat", sans-serif;
+  --bs-btn-active-color: #ffffff;
+  --bs-btn-active-bg: #008040;
+  --bs-btn-active-border-color: #00a050;
+}
+
+body:before {
+  bottom: 1rem;
+  color: #333;
+  display: block;
+  font-size: 3rem;
+  font-variant: all-small-caps;
+  font-weight: 700;
+  line-height: 1;
+  position: fixed;
+  right: 1rem;
+  z-index: -1;
+}
+
+main>div.container {
+  position: relative;
+}
+
+body>main>.container>h2 {
+  color: var(--bs-primary);
+  margin: 2rem 0 1.5rem;
+}
+
+dt {
+  font-weight: 500;
+  color: var(--bs-light);
+}
+
+input[type="checkbox"],
+.form-check-label {
+  cursor: pointer;
+}
+
+input[type="color"]+input[type="range"] {
+  width: 100%;
+}
+
+pre {
+  background: var(--bs-secondary-bg);
+  font-size: 0.8125rem;
+  padding: 1rem;
+}
+
+pre.list b {
+  display: inline-block;
+  width: 8em;
+}
+
+input[type="text"],
+input[type="password"],
+input[type="number"],
+select {
+  font-family: var(--bs-font-monospace);
+  font-size: 1rem;
+}
+
+.password-reveal-wrapper {
+  position: relative;
+}
+
+.password-reveal-wrapper > input[type="password"],
+.password-reveal-wrapper > input[type="text"] {
+  padding-right: 2.25rem;
+}
+
+.password-reveal-toggle {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  color: var(--bs-secondary-color);
+  display: inline-flex;
+  height: calc(100% - 0.5rem);
+  justify-content: center;
+  padding: 0;
+  position: absolute;
+  right: 0.5rem;
+  top: 0.25rem;
+  width: 1.5rem;
+}
+
+.password-reveal-toggle:hover {
+  color: var(--bs-body-color);
+}
+
+.password-reveal-toggle:focus-visible {
+  border-radius: 0.25rem;
+  outline: 2px solid var(--bs-primary);
+  outline-offset: 1px;
+}
+
+textarea {
+  font-family: var(--bs-font-monospace);
+  text-wrap: auto;
+}
+
+textarea.nowrap {
+  height: 50vh;
+  white-space: pre;
+}
+
+.ansi-log {
+  color: var(--bs-body-color);
+  font-family: var(--bs-font-monospace);
+  font-size: 0.875rem;
+}
+
+.ansi-fragment {
+  display: inline;
+}
+
+.ansi-bold {
+  font-weight: 600;
+}
+
+.ansi-fg-66 {
+  color: var(--ansi-66);
+}
+
+.ansi-fg-70 {
+  color: var(--ansi-70);
+}
+
+.ansi-fg-142 {
+  color: var(--ansi-142);
+}
+
+.ansi-fg-144 {
+  color: var(--ansi-144);
+}
+
+.ansi-fg-240 {
+  color: var(--ansi-240);
+}
+
+.alert p:last-of-type {
+  margin-bottom: 0;
+}
+
+.blink {
+  animation: blinker 4s step-end infinite;
+  color: red;
+}
+
+.btn {
+  white-space: nowrap;
+}
+
+.card-header {
+  position: relative;
+}
+
+.card-header h2.card-title {
+  color: darkorange;
+  font-size: x-large;
+  margin-bottom: 0;
+  margin-top: 0.5rem;
+}
+
+.card-header h2 + small {
+  color: lightgray;
+}
+
+.card-header h2 + small + button {
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+}
+
+.card-header .btn {
+  --bs-btn-padding-y: 0.2rem;
+  --bs-btn-padding-x: 0.4rem;
+  --bs-btn-font-size: 0.75rem;
+}
+
+.card-body {
+  position: relative;
+}
+
+.card-body h4 {
+  color: lightslategray;
+  font-size: large;
+  font-weight: 700;
+  margin-bottom: 0;
+}
+
+.card-body h4 + small {
+  color: lightgray;
+  display: block;
+  font-size: 0.86rem;
+  margin-bottom: 1.2rem;
+}
+
+.cb {
+  cursor: pointer;
+  text-decoration-color: #f80;
+  text-decoration-line: underline;
+  text-underline-offset: 0.25em;
+  white-space: nowrap;
+}
+
+.cols-2 {
+  columns: 2;
+}
+
+.container {
+  display: block;
+}
+
+.col>h3 {
+  color: var(--bs-secondary-color);
+  font-size: 1.3rem;
+  margin-bottom: 1.3rem;
+}
+
+.col .ex>h6 {
+  color: var(--bs-tertiary-color);
+  font-weight: 500;
+}
+
+.diagnostic-link-row {
+  align-items: center;
+  background: rgba(4, 7, 11, 0.85);
+  border-radius: 2rem;
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.4rem 0.6rem 0.4rem 1rem;
+}
+
+.diagnostic-link {
+  color: #9ce8ff;
+  display: inline-block;
+  flex: 1;
+  font-size: 1.1rem;
+  font-weight: 600;
+  text-decoration: none;
+  word-break: break-all;
+}
+
+.diagnostic-link:hover {
+  text-decoration: underline;
+}
+
+.diagnostic-copy-icon {
+  align-items: center;
+  background: rgba(16, 24, 40, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 999px;
+  color: #c9eeff;
+  display: inline-flex;
+  font-size: 1.05rem;
+  height: 2.35rem;
+  justify-content: center;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease, color 0.2s ease;
+  width: 2.35rem;
+}
+
+.diagnostic-copy-icon:hover:not(:disabled) {
+  background: rgba(2, 132, 199, 0.35);
+  border-color: rgba(2, 132, 199, 0.5);
+  transform: translateY(-1px);
+}
+
+.diagnostic-copy-icon:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.diagnostic-link-row.copied {
+  background: rgba(13, 148, 136, 0.32);
+  box-shadow: 0 0 1.25rem rgba(13, 148, 136, 0.35);
+}
+
+.diagnostic-copy-icon.copied,
+.diagnostic-link.copied {
+  border-color: rgba(13, 148, 136, 0.7);
+  color: #e0fff8;
+}
+
+.diagnostic-copy-icon.copied {
+  animation: diagCopied 0.45s ease;
+}
+
+.diagnostic-output {
+  background: rgba(4, 7, 11, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.75rem;
+  color: #9ce8ff;
+  margin-top: 1rem;
+}
+
+.dropdown-item {
+  font-size: 0.9rem;
+}
+
+.form-control:disabled,
+.form-control::placeholder {
+  color: var(--bs-tertiary-color);
+}
+
+.form-range {
+  height: 2.375rem;
+  padding: 0.1rem 0.375rem;
+}
+
+.global-message-overlay {
+  background: rgba(15, 23, 42, 0.95);
+  border-radius: 0 0 0.5rem 0.5rem;
+  box-shadow: 0 0.5rem 1.5rem rgba(15, 23, 42, 0.3);
+  color: #fff;
+  font-size: 0.9rem;
+  left: 50%;
+  line-height: 1.2;
+  opacity: 0;
+  padding: 1.0rem 1.5rem;
+  pointer-events: none;
+  position: fixed;
+  text-align: center;
+  top: 0;
+  transform: translate(-50%, -100%);
+  transition: opacity 0.5s ease, transform 0.5s ease-out;
+  width: min(90vw, 36rem);
+  z-index: 2000;
+}
+
+.global-message-overlay.show {
+  cursor: pointer;
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, 0);
+}
+
+.global-message-overlay[data-variant="success"] {
+  background: #0f5132;
+}
+
+.global-message-overlay[data-variant="info"] {
+  background: #084298;
+}
+
+.global-message-overlay[data-variant="danger"] {
+  background: #842029;
+}
+
+.hint {
+  font-size: 0.875rem;
+  margin-bottom: 0;
+  margin-top: 0.2rem;
+}
+
+.icon-sm {
+  max-width: 1.5rem;
+}
+
+.input-color {
+  height: 2.4rem;
+}
+
+.hidden {
+  display: none;
+}
+
+.input-group .dropdown-toggle {
+  border: var(--bs-border-width) solid var(--bs-border-color);
+}
+
+.input-group-text {
+  font-size: 0.875rem;
+  min-width: 3.1rem;
+}
+
+.input-group-text.switch {
+  min-width: 2.5rem;
+}
+
+.link {
+  color: #f80;
+  cursor: pointer;
+}
+
+.navbar {
+  margin-top: 30px;
+}
+
+.navbar-brand {
+  padding: .5rem 0 0;
+}
+
+.navbar-nav .nav-link.active {
+  color: #ff8800;
+  font-weight: 400;
+}
+
+.offcanvas .active {
+  color: darkorange !important;
+}
+
+.pending {
+  opacity: 0.6;
+  pointer-events: none;
+  position: relative;
+}
+
+.pending::after {
+  animation: spin 0.6s linear infinite;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  border-top-color: rgba(255, 255, 255, 0.8);
+  content: '';
+  height: 16px;
+  left: 50%;
+  margin: -8px 0 0 -8px;
+  position: absolute;
+  top: 50%;
+  width: 16px;
+}
+
+.preview canvas {
+  height: auto;
+  width: 100%;
+}
+
+.preview .btn {
+  min-width: 2.5rem;
+}
+
+.progress-bar {
+  background-color: gray;
+  cursor: pointer;
+}
+
+.progress-bar:hover {
+  background-color: #f80;
+}
+
+.progress-stacked {
+  cursor: pointer;
+}
+
+.range-value {
+  text-align: right;
+}
+
+.recorder-active {
+  animation: pulse 2s infinite;
+  background-color: #dc3545 !important;
+  border-color: #dc3545 !important;
+}
+
+.spinning {
+  animation: spin 1s linear infinite;
+}
+
+.status-overlay {
+  min-height: 3rem;
+  position: relative;
+}
+
+.status-overlay[data-overlay="true"] {
+  color: transparent;
+}
+
+.status-overlay[data-overlay="true"]::after {
+  align-items: center;
+  backdrop-filter: blur(2px);
+  background: rgba(0, 0, 0, 0.55);
+  border-radius: inherit;
+  bottom: 0;
+  color: #fff;
+  content: attr(data-overlay-text);
+  display: flex;
+  font-weight: 500;
+  justify-content: center;
+  left: 0;
+  padding: 0 1rem;
+  pointer-events: none;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  top: 0;
+  transition: opacity 0.2s ease;
+}
+
+.status-overlay-region {
+  position: relative;
+}
+
+.status-overlay-region .status-overlay[data-overlay="true"] {
+  bottom: 0;
+  left: 0;
+  margin-bottom: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 15;
+}
+
+.tab-pane {
+  padding: 1rem 0;
+}
+
+.tab-title {
+  margin-bottom: .75em;
+}
+
+.table.files td {
+  font-family: monospace;
+}
+
+.table.files td a {
+  text-decoration: none;
+}
+
+.table.files td:first-child,
+.table.files th:first-child {
+  width: auto;
+}
+
+.table.files td:not(:first-child),
+.table.files th:not(:first-child) {
+  text-align: right;
+  width: 10em;
+  white-space: nowrap;
+}
+
+.usage-modal .progress {
+  background-color: rgba(255, 255, 255, 0.08);
+}
+
+.usage-bar-active {
+  background-color: #ff6b6b !important;
+}
+
+.usage-bar-buffers {
+  background-color: #ffb347 !important;
+}
+
+.usage-bar-cached {
+  background-color: #4ecdc4 !important;
+}
+
+.usage-bar-other {
+  background-color: #95a5a6 !important;
+}
+
+.usage-bar-overlay {
+  background-color: #b084f7 !important;
+}
+
+.usage-bar-extras {
+  background-color: #4a90e2 !important;
+}
+
+.x-small {
+  font-size: 0.8125rem;
+}
+
+#button-bar .btn.is-night {
+  background-color: rgba(5, 13, 25, 0.95);
+  color: #f3f6ff;
+}
+
+#button-bar .btn.is-night .bi {
+  color: #f3f6ff;
+}
+
+#button-bar .btn.is-day {
+  background-color: rgba(255, 193, 98, 0.9);
+  color: #1c1102;
+}
+
+#button-bar .btn.is-day .bi {
+  color: #2d1c05;
+}
+
+#button-bar .btn.active,
+#button-bar .btn.active:focus,
+#button-bar .btn.active:hover {
+  background-color: #cf5e00;
+  border-color: #cf5e00;
+  color: #fff;
+}
+
+#button-bar .btn.active .bi {
+  color: #fff;
+}
+
+@media (max-width: 992px) {
+  #button-bar.is-compact > .btn-group > .btn {
+    align-items: center;
+    display: inline-flex;
+    justify-content: center;
+  }
+
+  #button-bar.is-compact > .btn-group > .btn .btn-label,
+  #button-bar.is-compact #daynight-text {
+    display: none;
+  }
+}
+
+#day_night_interval {
+  display: inline-block;
+  margin: auto 0.25rem;
+  max-width: 3rem;
+}
+
+#preview-wrapper button {
+  visibility: hidden;
+}
+
+#preview-wrapper:hover button {
+  visibility: visible;
+}
+
+#day_night_max-show,
+#day_night_min-show {
+  min-width: 5rem;
+}
+
+#editor_text {
+  min-height: 20rem;
+}
+
+#frame {
+  border: rgba(128, 128, 128, 0.5) 1px solid;
+  text-align: center;
+}
+
+.preview-endpoint-list {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.preview-endpoint-item {
+  align-items: flex-start;
+  display: flex;
+  gap: 0.75rem;
+  overflow: hidden;
+}
+
+.preview-endpoint-item:hover {
+  background: rgba(10, 14, 21, 0.96);
+}
+
+.preview-endpoint-item.copied {
+  background: rgba(255, 136, 0, 0.12);
+}
+
+.preview-endpoint-link {
+  align-items: center;
+  color: var(--bs-body-color);
+  display: inline-flex;
+  gap: 0.1rem;
+  justify-content: center;
+  min-height: 2.0rem;
+  padding: 0.25rem 0.75rem;
+  text-decoration: underline 1px transparent;
+}
+
+.preview-endpoint-link:hover {
+  color: #fff;
+  background: rgba(10, 14, 21, 0.96);
+}
+
+.preview-endpoint-link.copied {
+  background: rgba(255, 136, 0, 0.28);
+}
+
+.preview-endpoint-short {
+  color: #f8b25c;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
+.preview-endpoint-hint {
+  align-items: center;
+  color: #f8b25c;
+  display: inline-flex;
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  gap: 0.35rem;
+}
+
+.preview-endpoint-link:hover {
+  color: #fff;
+}
+
+.preview-endpoint-link:hover .preview-endpoint-url {
+  color: #fff;
+}
+
+.preview-endpoint-link:hover .preview-endpoint-hint {
+  background: rgba(255, 136, 0, 0.16);
+  color: #ffd39a;
+}
+
+.preview-endpoint-link:focus-visible {
+  border-radius: 0.25rem;
+}
+
+.preview-endpoint-link.copied .preview-endpoint-url,
+.preview-endpoint-link.copied .preview-endpoint-hint {
+  color: #ffd39a;
+}
+
+.preview-endpoint-link.copied .preview-endpoint-hint {
+  background: rgba(255, 136, 0, 0.18);
+}
+
+#page-texteditor .tab-pane {
+  min-height: 60vh;
+}
+
+#preview {
+  cursor: zoom-in;
+}
+
+@media (max-width: 767.98px) {
+  .preview-endpoint-item {
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .preview-endpoint-label {
+    flex-basis: auto;
+  }
+
+  .preview-endpoint-link {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+}
+
+#preview-col.preview-stretching #frame {
+  width: 100%;
+}
+
+#preview-col.preview-stretching #frame img {
+  display: block;
+  height: auto;
+  max-width: none;
+  width: 100%;
+}
+
+pre#output[data-cmd] {
+  background-color: rgb(0, 0, 0);
+  color: rgba(170, 170, 170, 0.8);
+}
+
+li.enabled {
+  border-left: 5px solid green;
+  margin-left: -5px;
+}
+
+/* Disabled form controls */
+.range.disabled,
+.select.disabled,
+.boolean.disabled,
+.col.disabled,
+.file.disabled,
+p.disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.expert {
+  display: none;
+}
+
+body.expert .expert {
+  display: initial;
+}
+
+/* Fixed width for daynight button text to prevent jumping */
+#daynight-text {
+  display: inline-block;
+  min-width: 3.5rem;
+  text-align: left;
+}
+
+#daynight-gain {
+  display: inline-block;
+  min-width: 3rem;
+  text-align: right;
+}
+
+#motor {
+  height: 300px;
+  margin: 0 auto;
+  width: 300px;
+}
+
+#motor:hover .jst {
+  visibility: visible;
+}
+
+.jst {
+  border-radius: 50%;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+  visibility: hidden;
+  width: 100%;
+}
+
+.jst a {
+  cursor: pointer;
+  left: 50%;
+  position: absolute;
+  top: 50%;
+}
+
+.jst a.s {
+  background-color: #88888833;
+  height: 5000px;
+  margin-left: -5000px;
+  margin-top: -5000px;
+  transform-origin: 100% 100%;
+  width: 5000px;
+}
+
+.jst a.s:hover {
+  background-color: #ff880088;
+}
+
+.jst a.s:active {
+  background-color: #ff8800ff;
+}
+
+.jst a.s:nth-child(1) {
+  transform: rotate( 67.5deg) skew(45deg);
+}
+
+.jst a.s:nth-child(2) {
+  transform: rotate(112.5deg) skew(45deg);
+}
+
+.jst a.s:nth-child(3) {
+  transform: rotate(157.5deg) skew(45deg);
+}
+
+.jst a.s:nth-child(4) {
+  transform: rotate(202.5deg) skew(45deg);
+}
+
+.jst a.s:nth-child(5) {
+  transform: rotate(247.5deg) skew(45deg);
+}
+
+.jst a.s:nth-child(6) {
+  transform: rotate(292.5deg) skew(45deg);
+}
+
+.jst a.s:nth-child(7) {
+  transform: rotate(-22.5deg) skew(45deg);
+}
+
+.jst a.s:nth-child(8) {
+  transform: rotate( 22.5deg) skew(45deg);
+}
+
+.jst a.b {
+  background: #808080;
+  clip-path: circle(30%);
+  height: 60%;
+  margin-left: -30%;
+  margin-top: -30%;
+  width: 60%;
+}
+
+.jst a.b:hover {
+  background: #ff330088;
+}
+
+.jst a.b:active {
+  background: #ff3300ff;
+}
+
+#fileTable tbody td {
+  font-family: var(--bs-font-monospace);
+}
+
+.btn-check:checked+.btn,
+.btn.active,
+.btn.show,
+.btn:first-child:active,
+:not(.btn-check)+.btn:active {
+    color: var(--bs-btn-active-color);
+    background-color: var(--bs-btn-active-bg);
+    border-color: var(--bs-btn-active-border-color);
+}
+
+.ui-debug h6 {
+  text-transform: uppercase;
+  margin-bottom: 0.25rem;
+  color: rgba(var(--bs-secondary-rgb),var(--bs-text-opacity))!important;
+}
+.ui-debug pre {
+  margin-bottom: 2rem;
+  background: rgba(var(--bs-black-rgb),var(--bs-bg-opacity))!important;
+  color: rgba(var(--bs-success-rgb),var(--bs-text-opacity))!important;
+}
+
+.terminal {
+  background-color: rgb(0, 0, 0);
+  border-radius: 6px;
+  color: rgb(49 203 130);
+  color-scheme: dark;
+  font-family: var(--bs-font-monospace);
+  font-size: 14px;
+  font-weight: 400;
+  overflow-wrap: break-word;
+  white-space:pre-wrap;
+}
+
+table.send2services td:not(:first-child),
+table.send2services th:not(:first-child) {
+  text-align: center;
+}
+table.send2services td:first-child a {
+  text-decoration: none;
+}

--- a/package/timps/files/www/a/main.js
+++ b/package/timps/files/www/a/main.js
@@ -1,0 +1,2942 @@
+const ThreadRtsp = 1;
+const ThreadVideo = 2;
+const ThreadAudio = 4;
+const ThreadOSD = 8;
+
+const ImageNoStream = "/a/nostream.svg";
+
+let max = 0;
+
+if (typeof window !== "undefined") {
+  window.network_address =
+    window.network_address || window.location.hostname || "";
+}
+
+let recordingState = {
+  ch0: false,
+  ch1: false,
+};
+// NATIVE: the timelapse lives in timps (timelapse.* keys in timps.conf, the
+// Timelapse Recorder page edits them); the control-bar button only toggles
+// timelapse.enabled via /control, so all we track here is that flag.
+let timelapseState = {
+  enabled: false,
+};
+let timelapseStateLoaded = false;
+const HeartBeatReconnectDelay = 5 * 1000;
+const HeartBeatMaxReconnectDelay = 120 * 1000;
+const HeartBeatEndpoint = "/x/json-heartbeat.cgi";
+const SlowHeartbeatEndpoint = "/x/json-heartbeat-slow.cgi";
+
+// The control bar (this file) is loaded on every page, but the tiny timps
+// native API client a/timps-api.js is only <script>-included on the streamer/
+// preview pages. The control-bar write actions (motion / mic / privacy) now
+// talk to timps /control directly, so load timps-api.js on demand where it
+// isn't already present. Resolves with window.timpsApi.
+let _timpsApiPromise = null;
+function timpsApiReady() {
+  if (window.timpsApi) return Promise.resolve(window.timpsApi);
+  if (_timpsApiPromise) return _timpsApiPromise;
+  _timpsApiPromise = new Promise((resolve, reject) => {
+    const sc = document.createElement("script");
+    sc.src = "/a/timps-api.js";
+    sc.onload = () =>
+      window.timpsApi
+        ? resolve(window.timpsApi)
+        : reject(new Error("timps-api.js loaded but window.timpsApi missing"));
+    sc.onerror = () => reject(new Error("failed to load timps-api.js"));
+    document.head.appendChild(sc);
+  });
+  return _timpsApiPromise;
+}
+const SlowHeartbeatPollInterval = 15 * 1000;
+let heartbeatSource = null;
+let slowHeartbeatTimer = null;
+let slowHeartbeatInFlight = false;
+let currentReconnectDelay = HeartBeatReconnectDelay;
+let debugModalCtx = null;
+
+// Password check state - must be initialized before heartbeat can start
+let isDefaultPassword = false;
+let passwordCheckComplete = false;
+
+function $(n) {
+  return document.querySelector(n);
+}
+
+function $$(n) {
+  return document.querySelectorAll(n);
+}
+
+function $n(n) {
+  return document.createElement(n);
+}
+
+function decodeBase64String(encoded) {
+  if (!encoded) return "";
+  try {
+    const binary = atob(encoded);
+    if (window.TextDecoder) {
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i += 1) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+      return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+    }
+    return binary;
+  } catch (err) {
+    console.warn("Failed to decode base64 payload", err);
+    return "";
+  }
+}
+
+function agentApiUrl(path) {
+  const rawPath = String(path || "");
+  const normalized = rawPath.startsWith("/") ? rawPath : `/${rawPath}`;
+  const queryIndex = normalized.indexOf("?");
+  const agentPath =
+    queryIndex >= 0 ? normalized.slice(0, queryIndex) : normalized;
+  const query = queryIndex >= 0 ? normalized.slice(queryIndex + 1) : "";
+  const params = new URLSearchParams(query);
+  params.set("agent_path", agentPath);
+  return `/x/agent.cgi?${params.toString()}`;
+}
+
+if (typeof window !== "undefined") {
+  window.agentApiUrl = agentApiUrl;
+}
+
+const AgentConfigCache = {
+  pending: null,
+  value: null,
+  fetchedAt: 0,
+};
+
+function invalidateAgentConfigCache() {
+  AgentConfigCache.pending = null;
+  AgentConfigCache.value = null;
+  AgentConfigCache.fetchedAt = 0;
+}
+
+async function getAgentConfig(options = {}) {
+  const { force = false, maxAgeMs = 3000 } = options;
+  const now = Date.now();
+  if (
+    !force &&
+    AgentConfigCache.value &&
+    now - AgentConfigCache.fetchedAt <= maxAgeMs
+  ) {
+    return AgentConfigCache.value;
+  }
+  if (!force && AgentConfigCache.pending) {
+    return AgentConfigCache.pending;
+  }
+
+  AgentConfigCache.pending = agentJsonRequest("/api/v1/config", {
+    cache: "no-store",
+  })
+    .then((payload) => {
+      AgentConfigCache.value = payload;
+      AgentConfigCache.fetchedAt = Date.now();
+      return payload;
+    })
+    .finally(() => {
+      AgentConfigCache.pending = null;
+    });
+
+  return AgentConfigCache.pending;
+}
+
+if (typeof window !== "undefined") {
+  window.getThinginoAgentConfig = getAgentConfig;
+  window.invalidateThinginoAgentConfig = invalidateAgentConfigCache;
+}
+
+function isPreviewBootPending() {
+  return (
+    typeof document !== "undefined" &&
+    document.body &&
+    document.body.id === "page-preview" &&
+    typeof window !== "undefined" &&
+    window.__thinginoPreviewBootPending === true
+  );
+}
+
+async function agentJsonRequest(path, options = {}) {
+  const requestOptions = { ...options };
+  const headers = new Headers(requestOptions.headers || {});
+  headers.set("Accept", "application/json");
+
+  if (requestOptions.body !== undefined) {
+    headers.set("Content-Type", "application/json");
+    requestOptions.body = JSON.stringify(requestOptions.body);
+  }
+
+  requestOptions.headers = headers;
+
+  const response = await fetch(agentApiUrl(path), requestOptions);
+  const text = await response.text();
+  const trimmedText = text ? text.trim() : "";
+  let payload = null;
+
+  if (trimmedText) {
+    try {
+      payload = JSON.parse(trimmedText);
+    } catch (_err) {
+      payload = null;
+    }
+  }
+
+  if (!response.ok) {
+    const message =
+      (payload && payload.error && payload.error.message) ||
+      (payload && payload.message) ||
+      (trimmedText && trimmedText.length <= 200 ? trimmedText : null) ||
+      `HTTP error ${response.status}`;
+    const error = new Error(message);
+    error.status = response.status;
+    error.body = trimmedText;
+    throw error;
+  }
+
+  return payload;
+}
+
+function clearPendingButton(button) {
+  if (button) button.classList.remove("pending");
+}
+
+function hideDebugModal(ctx = debugModalCtx) {
+  if (!ctx) return;
+  if (ctx.modalInstance) {
+    ctx.modalInstance.hide();
+  } else {
+    ctx.modalEl.classList.remove("show");
+    ctx.modalEl.style.display = "none";
+    ctx.modalEl.setAttribute("aria-hidden", "true");
+    ctx.modalEl.removeAttribute("aria-modal");
+    if (ctx.buttonRef) ctx.buttonRef.classList.remove("active");
+  }
+}
+
+function showDebugModal(ctx = debugModalCtx) {
+  if (!ctx) return;
+  if (ctx.modalInstance) {
+    ctx.modalInstance.show();
+  } else {
+    ctx.modalEl.classList.add("show");
+    ctx.modalEl.style.display = "block";
+    ctx.modalEl.removeAttribute("aria-hidden");
+    ctx.modalEl.setAttribute("aria-modal", "true");
+  }
+}
+
+function ensureDebugModalStructure() {
+  if (debugModalCtx) return debugModalCtx;
+  const modalEl = document.createElement("div");
+  modalEl.id = "debugInfoModal";
+  modalEl.className = "modal fade";
+  modalEl.tabIndex = -1;
+  modalEl.setAttribute("aria-hidden", "true");
+  modalEl.innerHTML = `
+	  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+	    <div class="modal-content">
+	      <div class="modal-header">
+	        <h5 class="modal-title">Debug information</h5>
+	        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+	      </div>
+	      <div class="modal-body">
+	        <p class="text-body-secondary mb-0">No debug information available.</p>
+	      </div>
+	    </div>
+	  </div>`;
+  document.body.appendChild(modalEl);
+  const modalBody = modalEl.querySelector(".modal-body");
+  let modalInstance = null;
+  if (window.bootstrap && window.bootstrap.Modal) {
+    modalInstance = window.bootstrap.Modal.getOrCreateInstance(modalEl);
+  }
+  const ctx = {
+    modalEl,
+    modalBody,
+    modalInstance,
+    buttonRef: null,
+  };
+  const closeBtn = modalEl.querySelector(".btn-close");
+  if (closeBtn && (!window.bootstrap || !window.bootstrap.Modal)) {
+    closeBtn.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      hideDebugModal(ctx);
+    });
+  }
+  modalEl.addEventListener("hidden.bs.modal", () => {
+    if (ctx.buttonRef) ctx.buttonRef.classList.remove("active");
+  });
+  debugModalCtx = ctx;
+  return ctx;
+}
+
+function populateDebugModalContent() {
+  const ctx = ensureDebugModalStructure();
+  if (!ctx || !ctx.modalBody) return ctx;
+  const fragment = document.createDocumentFragment();
+  $$(".ui-debug").forEach((panel) => {
+    const clone = panel.cloneNode(true);
+    clone.classList.remove("d-none");
+    fragment.appendChild(clone);
+  });
+  ctx.modalBody.innerHTML = "";
+  if (!fragment.childNodes.length) {
+    const placeholder = document.createElement("p");
+    placeholder.className = "text-body-secondary mb-0";
+    placeholder.textContent = "No debug information available.";
+    ctx.modalBody.appendChild(placeholder);
+  } else {
+    ctx.modalBody.appendChild(fragment);
+  }
+  return ctx;
+}
+
+const ThemeState = {
+  endpoint: "/x/json-config-webui.cgi",
+  preferenceKey: "thingino-theme-preference",
+  activeKey: "thingino-theme-active",
+};
+
+function safeStorageGet(key) {
+  try {
+    if (!window.localStorage) return null;
+    return localStorage.getItem(key);
+  } catch (err) {
+    return null;
+  }
+}
+
+function safeStorageSet(key, value) {
+  try {
+    if (!window.localStorage) return;
+    if (value === null || typeof value === "undefined" || value === "") {
+      localStorage.removeItem(key);
+      return;
+    }
+    localStorage.setItem(key, value);
+  } catch (err) {
+    // Best effort cache, ignore failures
+  }
+}
+
+function applyThemeAttribute(theme) {
+  if (!theme) return;
+  let resolvedTheme = theme;
+
+  // Resolve 'auto' based on time of day
+  if (theme === "auto") {
+    const hour = new Date().getHours();
+    resolvedTheme = hour >= 8 && hour < 20 ? "light" : "dark";
+  }
+
+  document.documentElement.setAttribute("data-bs-theme", resolvedTheme);
+}
+
+function rememberThemeState(activeTheme, preferenceTheme) {
+  if (activeTheme) {
+    safeStorageSet(ThemeState.activeKey, activeTheme);
+    applyThemeAttribute(activeTheme);
+  }
+  if (preferenceTheme) {
+    safeStorageSet(ThemeState.preferenceKey, preferenceTheme);
+  }
+}
+
+async function refreshThemeFromServer() {
+  if (typeof fetch !== "function") return;
+  try {
+    const response = await fetch(ThemeState.endpoint, {
+      headers: { Accept: "application/json" },
+    });
+    if (!response.ok) return;
+    const data = await response.json();
+    const preference = data && (data.theme || (data.webui && data.webui.theme));
+    const active = (data && data.active_theme) || preference;
+    rememberThemeState(active, preference);
+  } catch (err) {
+    if (typeof console !== "undefined" && typeof console.debug === "function") {
+      console.debug(
+        "Theme refresh skipped",
+        err && err.message ? err.message : err,
+      );
+    }
+  }
+}
+
+(function initThemeBridge() {
+  const cachedTheme = safeStorageGet(ThemeState.activeKey);
+  if (cachedTheme) {
+    applyThemeAttribute(cachedTheme);
+  }
+  refreshThemeFromServer();
+})();
+
+window.thinginoTheme = {
+  apply: applyThemeAttribute,
+  remember: rememberThemeState,
+  refresh: refreshThemeFromServer,
+  getPreference: () => safeStorageGet(ThemeState.preferenceKey),
+  getActive: () => safeStorageGet(ThemeState.activeKey),
+};
+
+function ts() {
+  return Math.floor(Date.now());
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function hasNavigatorClipboard() {
+  return (
+    typeof navigator !== "undefined" &&
+    !!navigator.clipboard &&
+    !!window.isSecureContext
+  );
+}
+
+function fallbackClipboardCopy(text) {
+  return new Promise((resolve, reject) => {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.left = "-9999px";
+    textarea.style.top = "-9999px";
+    document.body.appendChild(textarea);
+    try {
+      textarea.focus();
+      textarea.select();
+      const successful = document.execCommand("copy");
+      if (successful) {
+        resolve(true);
+      } else {
+        reject(new Error("clipboard-fallback"));
+      }
+    } catch (err) {
+      reject(err);
+    } finally {
+      textarea.remove();
+    }
+  });
+}
+
+async function copyTextToClipboard(text) {
+  const value =
+    typeof text === "string"
+      ? text
+      : text === null || typeof text === "undefined"
+        ? ""
+        : String(text);
+  if (!value) {
+    return Promise.reject(new Error("clipboard-empty"));
+  }
+  if (hasNavigatorClipboard()) {
+    try {
+      await navigator.clipboard.writeText(value);
+      return true;
+    } catch (err) {
+      // Fallback below
+    }
+  }
+  return fallbackClipboardCopy(value);
+}
+
+const clipboardApi = window.thinginoClipboard || {};
+clipboardApi.copy = copyTextToClipboard;
+clipboardApi.fallbackCopy = fallbackClipboardCopy;
+clipboardApi.canUseNavigator = hasNavigatorClipboard;
+window.thinginoClipboard = clipboardApi;
+
+function setProgressBar(id, value, maxvalue, name) {
+  const el = $(id);
+  const safeMax = Number(maxvalue);
+  if (!el || !Number.isFinite(safeMax) || safeMax <= 0) return;
+  const safeValue = Math.max(0, Number(value) || 0);
+  const valuePercent = Math.min(
+    100,
+    Math.max(0, Math.round((safeValue / safeMax) * 100)),
+  );
+  el.setAttribute("aria-valuemin", "0");
+  el.setAttribute("aria-valuemax", safeMax);
+  el.setAttribute("aria-valuenow", safeValue);
+  el.style.width = valuePercent + "%";
+  el.title =
+    (name || "Usage") + ": " + safeValue + "KiB (" + valuePercent + "%)";
+}
+
+function setValue(data, domain, name) {
+  const id = `#${domain}_${name}`;
+  const el = $(id);
+  if (!el) return;
+  const value = data[name];
+  if (typeof value === "undefined") return;
+
+  el.disabled = false;
+  const wrapper = el.closest(
+    ".range, .number-range, .number, .select, .boolean, .file, .form-switch",
+  );
+  if (wrapper) wrapper.classList.remove("disabled");
+
+  if (el.type === "checkbox") {
+    el.checked = value;
+  } else {
+    el.value = value;
+    if (el.type === "range") {
+      $(`${id}-show`).textContent = value;
+    }
+    // Also update modal slider for number_range fields
+    const slider = $(`${id}-slider`);
+    if (slider) {
+      slider.value = value;
+      slider.disabled = false;
+      const sliderValue = $(`${id}-slider-value`);
+      if (sliderValue) sliderValue.textContent = value;
+    }
+  }
+}
+
+function updateRecordingIcons() {
+  $$("#recorder-ch0, #recorder-ch1").forEach((button) => {
+    const channel = parseInt(button.dataset.channel);
+    const isRecording = recordingState[`ch${channel}`];
+    button.classList.remove("pending");
+    button.classList.toggle("active", isRecording);
+    button.classList.toggle("recorder-active", isRecording);
+  });
+}
+
+function updateRecordingState(state) {
+  recordingState.ch0 = state.ch0;
+  recordingState.ch1 = state.ch1;
+  updateRecordingIcons();
+}
+
+function applyTimelapseState(timelapse = {}) {
+  timelapseState = {
+    enabled: timelapse.enabled === true || timelapse.enabled === 1,
+  };
+  timelapseStateLoaded = true;
+  updateTimelapseButtonState();
+}
+
+function updateTimelapseButtonState() {
+  const timelapseBtn = $("#timelapse");
+  if (!timelapseBtn) return;
+
+  timelapseBtn.classList.remove("pending");
+  timelapseBtn.classList.toggle("active", timelapseState.enabled === true);
+}
+
+async function loadTimelapseState() {
+  // NATIVE: the timelapse state comes straight from timps GET /control
+  // ("timelapse":{...} - see a/tool-timelapse.js for the settings page).
+  const api = await timpsApiReady();
+  const json = await api.get();
+  applyTimelapseState((json && json.timelapse) || {});
+  return timelapseState;
+}
+
+async function toggleTimelapse() {
+  const timelapseBtn = $("#timelapse");
+  if (timelapseBtn) timelapseBtn.classList.add("pending");
+
+  try {
+    // always refresh: the config is edited on the Timelapse Recorder page,
+    // so the in-memory state here goes stale
+    await loadTimelapseState();
+
+    const nextEnabled = !timelapseState.enabled;
+    const api = await timpsApiReady();
+    // timelapse.enabled persists to timps.conf and the running timelapse
+    // thread picks it up live (like the record buttons above)
+    await api.set({ timelapse: { enabled: nextEnabled } });
+    await loadTimelapseState();
+    if (typeof showAlert === "function") {
+      showAlert(
+        "success",
+        nextEnabled ? "Timelapse enabled." : "Timelapse disabled.",
+        2500,
+      );
+    }
+  } catch (err) {
+    console.error("Timelapse toggle failed:", err);
+    updateTimelapseButtonState();
+    if (typeof showAlert === "function") {
+      showAlert("danger", err.message || "Failed to toggle timelapse.", 5000);
+    }
+  }
+}
+
+function toggleRecording(channel) {
+  const button = $(`#recorder-ch${channel}`);
+  const isRecording = recordingState[`ch${channel}`];
+  const want = isRecording ? 0 : 1; // manual override on/off
+  if (button) button.classList.add("pending");
+
+  // NATIVE: timps records ONE channel at a time (record.channel). The REC ch0 /
+  // ch1 buttons pick WHICH stream to record: starting sets record.channel to the
+  // clicked channel AND record.active=1 (so ch0 really records ch0); stopping
+  // sets active=0. The heartbeat reports the real rec_chN state back.
+  const payload = want
+    ? { record: { channel: channel, active: 1 } }
+    : { record: { active: 0 } };
+  timpsApiReady()
+    .then((api) => api.set(payload))
+    .then(() =>
+      updateRecordingState({
+        ch0: !!want && channel === 0,
+        ch1: !!want && channel === 1,
+      }),
+    )
+    .catch((err) => {
+      console.error("Recording toggle error", err);
+      if (button) button.classList.remove("pending");
+      if (typeof showAlert === "function")
+        showAlert("danger", "Failed to toggle recording: " + (err.message || err));
+    });
+}
+
+function toggleMotion(state) {
+  const button = $("#motion");
+  if (button) button.classList.add("pending");
+
+  // NATIVE: timps motion detection is toggled through /control (LIVE)
+  timpsApiReady()
+    .then((api) => api.set({ motion: { enabled: state ? 1 : 0 } }))
+    .then(() => updateHeartbeatUi({ motion_enabled: state ? 1 : 0 }))
+    .catch((err) => {
+      console.error("Motion toggle error", err);
+      if (button) button.classList.remove("pending");
+    });
+}
+
+function togglePrivacy(state) {
+  const button = $("#privacy");
+  if (button) button.classList.add("pending");
+
+  // NATIVE: timps privacy is per-region (no global switch), so this quick
+  // toggle enables/disables ALL configured cover regions on every stream.
+  timpsApiReady()
+    .then((api) =>
+      api.get().then((json) => {
+        const priv = json.privacy || {};
+        const payload = {};
+        Object.keys(priv).forEach((s) => {
+          payload[s] = {};
+          Object.keys(priv[s]).forEach((n) => {
+            payload[s][n] = { enabled: state ? 1 : 0 };
+          });
+        });
+        return Object.keys(payload).length ? api.set({ privacy: payload }) : null;
+      }),
+    )
+    .then(() => updateHeartbeatUi({ privacy_enabled: state ? 1 : 0 }))
+    .catch((err) => {
+      console.error("Privacy toggle error", err);
+      if (button) button.classList.remove("pending");
+    });
+}
+
+function toggleWireGuard(state) {
+  const button = $("#wireguard");
+  if (button) button.classList.add("pending");
+
+  const targetState = state ? 1 : 0;
+  fetch("/x/json-wireguard.cgi?iface=wg0&state=" + targetState)
+    .then(async (res) => {
+      const text = await res.text();
+      const data = text ? JSON.parse(text) : {};
+      console.log(ts(), "<===", JSON.stringify(data));
+
+      if (!res.ok || data.error) {
+        throw new Error(data?.error?.message || `HTTP error ${res.status}`);
+      }
+
+      return data;
+    })
+    .then((data) => {
+      const nextStatus =
+        data && data.message && data.message.status !== undefined
+          ? data.message.status
+          : targetState;
+      updateHeartbeatUi({ wg_status: nextStatus });
+    })
+    .catch((err) => {
+      if (typeof window.showOverlayMessage === "function") {
+        window.showOverlayMessage(
+          err.message || "Failed to toggle WireGuard",
+          "danger",
+        );
+      }
+      console.warn("WireGuard toggle error", err);
+      if (button) button.classList.remove("pending");
+    });
+}
+
+function toggleDayNight(mode) {
+  const button = $("#daynight");
+  if (button) button.classList.add("pending");
+
+  const payload = JSON.stringify({ cmd: "daynight", val: mode });
+  console.log("Sending daynight payload:", payload);
+  fetch("/x/json-imp.cgi", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: payload,
+  })
+    .then((res) => {
+      if (!res.ok) throw new Error(`HTTP error ${res.status}`);
+      return res.text();
+    })
+    .then((text) => {
+      if (text) {
+        const data = JSON.parse(text);
+        console.log(ts(), "<===", JSON.stringify(data));
+      }
+      // Update button state immediately from the known target mode
+      updateHeartbeatUi({ daynight_mode: mode, daynight_enabled: false });
+    })
+    .catch((err) => {
+      console.error("DayNight toggle error", err);
+      if (button) button.classList.remove("pending");
+    });
+}
+
+// Grey out an audio control-bar button the streamer declared unsupported
+// (e.g. the Speaker on timps, which has no audio-output pipeline).
+function disableAudioButton(device, reason) {
+  const button = $("#" + device);
+  if (!button) return;
+  button.classList.remove("pending", "active");
+  button.disabled = true;
+  button.classList.add("disabled");
+  if (reason) button.title = reason;
+}
+
+function toggleAudio(device, state) {
+  const button = $("#" + device);
+  if (button) button.classList.add("pending");
+
+  // timps has no audio-output (speaker) pipeline: grey the speaker button out.
+  if (device !== "microphone") {
+    disableAudioButton(device, "No speaker output on timps");
+    if (typeof window.showOverlayMessage === "function")
+      window.showOverlayMessage("The timps streamer has no speaker output.", "info");
+    return;
+  }
+
+  // NATIVE: the mic button is the live mute. mic_enabled=false -> audio.mute 1,
+  // true -> 0. Applied through timps /control.
+  timpsApiReady()
+    .then((api) => api.set({ audio: { mute: state ? 0 : 1 } }))
+    .then(() => updateHeartbeatUi({ mic_enabled: state }))
+    .catch((err) => {
+      console.error("Audio toggle error", err);
+      if (button) button.classList.remove("pending");
+    });
+}
+
+function toggleTheme() {
+  const htmlEl = document.documentElement;
+  const currentTheme = htmlEl.getAttribute("data-bs-theme");
+  const newTheme = currentTheme === "dark" ? "light" : "dark";
+
+  htmlEl.setAttribute("data-bs-theme", newTheme);
+
+  const themeBtn = $("#theme-toggle");
+  if (themeBtn) {
+    const img = themeBtn.querySelector("img");
+    if (img) {
+      img.src = newTheme === "dark" ? "/a/brilliance.svg" : "/a/brilliance.svg";
+      img.alt = newTheme === "dark" ? "Light mode" : "Dark mode";
+    }
+  }
+}
+
+async function toggleButton(el) {
+  if (!el) return;
+  const currentState = el.classList.contains("active") ? 1 : 0;
+  let newState = currentState ? 0 : 1;
+
+  // Special handling for color button: ISP mode 0=color, 1=b&w
+  // When active (color mode), we want to send 1 to switch to b&w
+  // When inactive (b&w mode), we want to send 0 to switch to color
+  if (el.id === "color") {
+    newState = currentState ? 1 : 0;
+  }
+
+  el.classList.add("pending");
+
+  const payload = JSON.stringify({ cmd: el.id, val: newState });
+  console.log("Sending to json-imp.cgi:", payload);
+  await fetch("/x/json-imp.cgi", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: payload,
+  })
+    .then((res) => res.json())
+    .then((data) => {
+      console.log(data.message);
+      // Map button IDs to their heartbeat UI keys and update immediately
+      const keyMap = {
+        color: { color_mode: newState },
+        ircut: { ircut_state: newState },
+        ir850: { ir850_state: newState },
+        ir940: { ir940_state: newState },
+        white: { white_state: newState },
+        auto: {
+          daynight_enabled: newState,
+          daynight_mode: newState ? undefined : "day",
+        },
+      };
+      const update = keyMap[el.id];
+      if (update) {
+        // Remove undefined values (e.g. daynight_mode when enabling auto)
+        Object.keys(update).forEach(
+          (k) => update[k] === undefined && delete update[k],
+        );
+        updateHeartbeatUi(update);
+      } else {
+        el.classList.remove("pending");
+      }
+    })
+    .catch((err) => {
+      console.error("toggleButton error", err);
+      el.classList.remove("pending");
+    });
+}
+
+function resolveDeviceTimezone() {
+  const uiConfig = window.thinginoUIConfig || {};
+  const deviceTimezone =
+    uiConfig.device && typeof uiConfig.device.timezone === "string"
+      ? uiConfig.device.timezone.trim()
+      : "";
+  if (deviceTimezone) return deviceTimezone;
+  if (typeof uiConfig.timezone === "string" && uiConfig.timezone.trim())
+    return uiConfig.timezone.trim();
+  return "";
+}
+
+function updateHeartbeatUi(json) {
+  if (!json) return;
+  const timeNowEl = $("#time-now");
+  if (timeNowEl && json.time_now != null && json.time_now !== "") {
+    const d = new Date(json.time_now * 1000);
+    const configuredTimezone = resolveDeviceTimezone();
+    const heartbeatTimezone =
+      typeof json.timezone === "string" ? json.timezone.trim() : "";
+    const timezoneLabel = configuredTimezone || heartbeatTimezone;
+    const timeZoneId = timezoneLabel
+      ? timezoneLabel.replaceAll(" ", "_")
+      : "UTC";
+    let options = {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      timeZone: timeZoneId,
+    };
+    const formatted = d.toLocaleString(navigator.language, options);
+    timeNowEl.textContent = timezoneLabel
+      ? formatted + " " + timezoneLabel
+      : formatted;
+  }
+
+  const hasBrightness =
+    typeof json.daynight_brightness !== "undefined" &&
+    json.daynight_brightness !== "unknown" &&
+    json.daynight_brightness !== "";
+  const hasTotalGain =
+    typeof json.total_gain !== "undefined" &&
+    json.total_gain !== "unknown" &&
+    json.total_gain !== "" &&
+    json.total_gain >= 0;
+  const hasMode =
+    typeof json.daynight_mode !== "undefined" &&
+    json.daynight_mode !== "unknown" &&
+    json.daynight_mode !== "";
+  if (hasTotalGain || hasBrightness || hasMode) {
+    // const icon = dayNightIcon(json.daynight_mode);
+    // const label = hasTotalGain ? `${icon} ${json.total_gain}` : (hasBrightness ? `${icon} ${json.daynight_brightness}` : icon);
+    const label = hasTotalGain
+      ? json.total_gain
+      : hasBrightness
+        ? json.daynight_brightness
+        : "---";
+    $$(".dnd-gain").forEach((el) => (el.textContent = label));
+  }
+
+  const uptimeEl = $("#uptime");
+  if (uptimeEl && typeof json.uptime !== "undefined" && json.uptime !== "")
+    uptimeEl.textContent = "Uptime:️ " + json.uptime;
+
+  updateRecordingState({
+    ch0: json.rec_ch0 === true,
+    ch1: json.rec_ch1 === true,
+  });
+
+  // Update motion detection icon
+  if (typeof json.motion_enabled !== "undefined") {
+    const motionBtn = $("#motion");
+    if (motionBtn) {
+      motionBtn.classList.remove("pending");
+      motionBtn.classList.toggle("active", json.motion_enabled === true);
+    }
+  }
+
+  // Update privacy icon
+  if (typeof json.privacy_enabled !== "undefined") {
+    const privacyBtn = $("#privacy");
+    if (privacyBtn) {
+      privacyBtn.classList.remove("pending");
+      privacyBtn.classList.toggle("active", json.privacy_enabled === true);
+    }
+  }
+
+  // Update wireguard icon
+  if (typeof json.wg_status !== "undefined") {
+    const wireguardBtn = $("#wireguard");
+    if (wireguardBtn) {
+      wireguardBtn.classList.remove("pending");
+      wireguardBtn.classList.toggle("active", json.wg_status === 1);
+    }
+  }
+
+  // Update daynight mode button
+  if (typeof json.daynight_mode !== "undefined") {
+    const daynightBtn = $("#daynight");
+    if (daynightBtn) {
+      daynightBtn.classList.remove("pending");
+      const isNight = json.daynight_mode === "night";
+      const isAutoEnabled =
+        json.daynight_enabled === true || json.daynight_enabled === 1;
+      daynightBtn.classList.toggle("active", isAutoEnabled);
+      daynightBtn.classList.toggle("is-night", isNight);
+      daynightBtn.classList.toggle("is-day", !isNight);
+
+      // Update button text and icon based on photosensing state
+      const daynightText = $("#daynight-text");
+      const daynightIcon = daynightBtn.querySelector("i");
+
+      if (daynightText) {
+        daynightText.textContent = isAutoEnabled
+          ? "Auto"
+          : isNight
+            ? "Night"
+            : "Day";
+      }
+
+      if (daynightIcon) {
+        daynightIcon.className = isNight ? "bi bi-moon-stars" : "bi bi-sun";
+      }
+    }
+
+    // Update Day button active state
+    const dayBtn = $("#day");
+    if (dayBtn) {
+      const isAutoEnabled =
+        json.daynight_enabled === true || json.daynight_enabled === 1;
+      const isDay = json.daynight_mode === "day";
+      dayBtn.classList.toggle("active", !isAutoEnabled && isDay);
+    }
+
+    // Update Night button active state
+    const nightBtn = $("#night");
+    if (nightBtn) {
+      const isAutoEnabled =
+        json.daynight_enabled === true || json.daynight_enabled === 1;
+      const isNight = json.daynight_mode === "night";
+      nightBtn.classList.toggle("active", !isAutoEnabled && isNight);
+    }
+  }
+
+  // Update color mode button
+  if (typeof json.color_mode !== "undefined" && json.color_mode !== null) {
+    const colorBtn = $("#color");
+    if (colorBtn) {
+      colorBtn.classList.remove("pending");
+      // ISP mode: 0 = color, 1 = b&w, so active when 0
+      colorBtn.classList.toggle("active", json.color_mode === 0);
+    }
+  }
+
+  // Update ircut button
+  if (typeof json.ircut_state !== "undefined" && json.ircut_state !== null) {
+    const ircutBtn = $("#ircut");
+    if (ircutBtn) {
+      ircutBtn.classList.remove("pending");
+      ircutBtn.classList.toggle("active", json.ircut_state === 1);
+    }
+  }
+
+  // Update ir850 button
+  if (typeof json.ir850_state !== "undefined" && json.ir850_state !== null) {
+    const ir850Btn = $("#ir850");
+    if (ir850Btn) {
+      ir850Btn.classList.remove("pending");
+      ir850Btn.classList.toggle("active", json.ir850_state === 1);
+    }
+  }
+
+  // Update ir940 button
+  if (typeof json.ir940_state !== "undefined" && json.ir940_state !== null) {
+    const ir940Btn = $("#ir940");
+    if (ir940Btn) {
+      ir940Btn.classList.remove("pending");
+      ir940Btn.classList.toggle("active", json.ir940_state === 1);
+    }
+  }
+
+  // Update white LED button
+  if (typeof json.white_state !== "undefined" && json.white_state !== null) {
+    const whiteBtn = $("#white");
+    if (whiteBtn) {
+      whiteBtn.classList.remove("pending");
+      whiteBtn.classList.toggle("active", json.white_state === 1);
+    }
+  }
+
+  // Update microphone button
+  if (typeof json.mic_enabled !== "undefined") {
+    const micBtn = $("#microphone");
+    if (micBtn) {
+      micBtn.classList.remove("pending");
+      const isActive = json.mic_enabled === true;
+      micBtn.classList.toggle("active", isActive);
+      const img = micBtn.querySelector("img");
+      if (img) {
+        img.src = isActive ? "/a/mic.svg" : "/a/mic-mute.svg";
+      }
+    }
+  }
+
+  // Speaker unsupported by the streamer (timps has no audio-output
+  // pipeline): keep the button greyed out instead of showing a dead toggle
+  if (json.spk_supported === false) {
+    disableAudioButton("speaker", "No speaker output on timps");
+  }
+
+  // Update speaker button
+  if (json.spk_supported !== false && typeof json.spk_enabled !== "undefined") {
+    const spkBtn = $("#speaker");
+    if (spkBtn) {
+      spkBtn.classList.remove("pending");
+      const isActive = json.spk_enabled === true;
+      spkBtn.classList.toggle("active", isActive);
+      const img = spkBtn.querySelector("img");
+      if (img) {
+        img.src = isActive ? "/a/volume-up.svg" : "/a/volume-mute.svg";
+      }
+    }
+  }
+
+  // Update Auto button
+  if (
+    typeof json.daynight_enabled !== "undefined" &&
+    json.daynight_enabled !== null
+  ) {
+    const autoBtn = $("#auto");
+    if (autoBtn) {
+      autoBtn.classList.remove("pending");
+      // heartbeat sends daynight_enabled as a JSON boolean, so accept true too
+      // (=== 1 alone left the Auto item un-highlighted in the menu)
+      autoBtn.classList.toggle(
+        "active",
+        json.daynight_enabled === true || json.daynight_enabled === 1,
+      );
+    }
+  }
+}
+
+function startHeartbeatSse() {
+  // Check password state before starting SSE
+  if (!passwordCheckComplete || isDefaultPassword) {
+    console.log(
+      "startHeartbeatSse blocked: passwordCheckComplete=" +
+        passwordCheckComplete +
+        ", isDefaultPassword=" +
+        isDefaultPassword,
+    );
+    return;
+  }
+
+  if (heartbeatSource) return;
+  heartbeatSource = new EventSource(HeartBeatEndpoint);
+  heartbeatSource.onmessage = (event) => {
+    try {
+      currentReconnectDelay = HeartBeatReconnectDelay;
+      updateHeartbeatUi(JSON.parse(event.data));
+    } catch (error) {
+      console.error("Heartbeat SSE payload error", error);
+    }
+  };
+  heartbeatSource.onerror = (error) => {
+    console.error("Heartbeat SSE error", error);
+    heartbeatSource.close();
+    heartbeatSource = null;
+    console.log(`Reconnecting in ${currentReconnectDelay / 1000}s`);
+    setTimeout(heartbeat, currentReconnectDelay); // Use heartbeat() instead of startHeartbeatSse()
+    // Double the delay for next failure, capped at max
+    currentReconnectDelay = Math.min(
+      currentReconnectDelay * 2,
+      HeartBeatMaxReconnectDelay,
+    );
+  };
+}
+
+async function fetchSlowHeartbeatStatus() {
+  if (
+    slowHeartbeatInFlight ||
+    !passwordCheckComplete ||
+    isDefaultPassword ||
+    document.hidden
+  ) {
+    return;
+  }
+
+  slowHeartbeatInFlight = true;
+
+  try {
+    const response = await fetch(SlowHeartbeatEndpoint, {
+      cache: "no-store",
+      credentials: "same-origin",
+    });
+
+    if (!response.ok) {
+      throw new Error(`Slow heartbeat request failed: ${response.status}`);
+    }
+
+    updateHeartbeatUi(await response.json());
+  } catch (error) {
+    console.error("Slow heartbeat fetch error", error);
+  } finally {
+    slowHeartbeatInFlight = false;
+    scheduleSlowHeartbeatStatus();
+  }
+}
+
+function scheduleSlowHeartbeatStatus(delay = SlowHeartbeatPollInterval) {
+  if (slowHeartbeatTimer) {
+    clearTimeout(slowHeartbeatTimer);
+    slowHeartbeatTimer = null;
+  }
+
+  if (!passwordCheckComplete || isDefaultPassword || document.hidden) {
+    return;
+  }
+
+  slowHeartbeatTimer = setTimeout(() => {
+    slowHeartbeatTimer = null;
+    fetchSlowHeartbeatStatus();
+  }, delay);
+}
+
+function startSlowHeartbeatStatus() {
+  if (slowHeartbeatTimer || slowHeartbeatInFlight) {
+    return;
+  }
+
+  fetchSlowHeartbeatStatus();
+}
+
+function cleanupHeartbeatResources() {
+  if (heartbeatSource) {
+    heartbeatSource.close();
+    heartbeatSource = null;
+  }
+  if (slowHeartbeatTimer) {
+    clearTimeout(slowHeartbeatTimer);
+    slowHeartbeatTimer = null;
+  }
+  slowHeartbeatInFlight = false;
+  currentReconnectDelay = HeartBeatReconnectDelay;
+}
+
+window.addEventListener("beforeunload", cleanupHeartbeatResources);
+window.addEventListener("pagehide", cleanupHeartbeatResources);
+
+document.addEventListener("visibilitychange", () => {
+  if (document.hidden) {
+    cleanupHeartbeatResources();
+  } else {
+    // Only restart heartbeat if password check is complete and password is OK
+    if (passwordCheckComplete && !isDefaultPassword) {
+      heartbeat();
+    }
+  }
+});
+
+function heartbeat() {
+  console.trace("heartbeat() called");
+  // Don't start heartbeat until password check is complete
+  if (!passwordCheckComplete) {
+    console.log("Heartbeat disabled: password check not complete");
+    return;
+  }
+  // Don't start heartbeat if using default password
+  if (isDefaultPassword) {
+    console.log("Heartbeat disabled: default password in use");
+    return;
+  }
+  startHeartbeatSse();
+  startSlowHeartbeatStatus();
+}
+
+function initCopyToClipboard() {
+  const clipboard = window.thinginoClipboard;
+  $$(".cb").forEach(function (el) {
+    el.title = "Click to copy to clipboard";
+    el.addEventListener("click", function (ev) {
+      ev.preventDefault();
+      const target = ev.currentTarget || ev.target;
+      const text = target && target.textContent ? target.textContent : "";
+      if (!text || !clipboard || typeof clipboard.copy !== "function") return;
+      if (target && typeof target.animate === "function") {
+        target.animate({ backgroundColor: "#f80" }, 250);
+      }
+      clipboard.copy(text).catch((err) => {
+        if (
+          typeof console !== "undefined" &&
+          typeof console.warn === "function"
+        ) {
+          console.warn("Clipboard copy failed", err);
+        }
+      });
+    });
+  });
+}
+
+// Shared quick actions for the Send modal to avoid duplicating markup.
+const sendModalTargets = [
+  { key: "email", label: "Email", icon: "bi bi-envelope-at" },
+  { key: "ftp", label: "FTP", icon: "bi bi-postage" },
+  { key: "mqtt", label: "MQTT", icon: "bi bi-postage" },
+  { key: "ntfy", label: "Ntfy", icon: "bi bi-postage" },
+  { key: "storage", label: "Storage", icon: "bi bi-sd-card" },
+  { key: "telegram", label: "Telegram", icon: "bi bi-telegram" },
+  { key: "webhook", label: "Webhook", icon: "bi bi-postage" },
+];
+
+let busyBarCtx = null;
+let busyBarTimeout = null;
+const BUSY_BAR_TTL = 20000; // 20 seconds
+
+function ensureBusyBar() {
+  if (busyBarCtx) return busyBarCtx;
+  const barEl = document.createElement("div");
+  barEl.id = "thinginoBusyBar";
+  barEl.style.cssText =
+    "position:fixed;top:0;left:0;right:0;height:4px;z-index:9999;background:#000;overflow:hidden;";
+  barEl.innerHTML =
+    '<div class="progress-bar" style="width:0;height:100%;background:linear-gradient(90deg,#0d6efd,#0dcaf0);transition:width 0.3s ease;"></div>';
+  document.body.insertBefore(barEl, document.body.firstChild);
+  const progressBar = barEl.querySelector(".progress-bar");
+  busyBarCtx = { barEl, progressBar };
+  return busyBarCtx;
+}
+
+function showBusy(message) {
+  const ctx = ensureBusyBar();
+
+  // Clear any existing timeout
+  if (busyBarTimeout) {
+    clearTimeout(busyBarTimeout);
+    busyBarTimeout = null;
+  }
+
+  // Animate progress bar
+  ctx.progressBar.style.width = "0%";
+  setTimeout(() => (ctx.progressBar.style.width = "70%"), 10);
+
+  // Set timeout to auto-hide with warning
+  busyBarTimeout = setTimeout(() => {
+    console.warn(
+      "Busy bar timeout reached - auto-hiding after",
+      BUSY_BAR_TTL / 1000,
+      "seconds",
+    );
+    hideBusy();
+    if (typeof showAlert === "function") {
+      showAlert(
+        "warning",
+        "Operation timed out. Please try again or check your connection.",
+        8000,
+      );
+    } else {
+      alert("Operation timed out. Please try again or check your connection.");
+    }
+  }, BUSY_BAR_TTL);
+}
+
+function hideBusy() {
+  // Clear the timeout when manually hiding
+  if (busyBarTimeout) {
+    clearTimeout(busyBarTimeout);
+    busyBarTimeout = null;
+  }
+
+  if (!busyBarCtx) {
+    console.warn("hideBusy: busyBarCtx is null");
+    return;
+  }
+
+  // Complete the progress bar then hide
+  busyBarCtx.progressBar.style.width = "100%";
+  setTimeout(() => {
+    if (busyBarCtx && busyBarCtx.progressBar) {
+      busyBarCtx.progressBar.style.width = "0%";
+    }
+  }, 300);
+}
+
+window.showBusy = showBusy;
+window.hideBusy = hideBusy;
+
+// Universal slider modal system
+let sliderModalInstance = null;
+let sliderModalElement = null;
+
+function ensureSliderModal() {
+  if (sliderModalElement) return sliderModalElement;
+
+  let modal = $("#thinginoSliderModal");
+  if (modal) {
+    sliderModalElement = modal;
+    return modal;
+  }
+
+  modal = document.createElement("div");
+  modal.className = "modal fade";
+  modal.id = "thinginoSliderModal";
+  modal.tabIndex = -1;
+  modal.setAttribute("aria-hidden", "true");
+  modal.innerHTML = `
+		<div class="modal-dialog modal-dialog-centered">
+			<div class="modal-content">
+				<div class="modal-header">
+					<h5 class="modal-title" id="sliderModalTitle"></h5>
+					<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+				</div>
+				<div class="modal-body">
+					<div class="d-flex justify-content-between mb-2">
+						<span id="sliderModalMin"></span>
+						<span class="fw-bold" id="sliderModalValue"></span>
+						<span id="sliderModalMax"></span>
+					</div>
+					<input type="range" id="sliderModalRange" class="form-range">
+				</div>
+				<div class="modal-footer">
+					<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+				</div>
+			</div>
+		</div>`;
+  document.body.appendChild(modal);
+  sliderModalElement = modal;
+
+  if (window.bootstrap && window.bootstrap.Modal) {
+    sliderModalInstance = new bootstrap.Modal(modal);
+  }
+
+  return modal;
+}
+
+function openSliderModal(inputId) {
+  const input = $("#" + inputId);
+  if (!input) return;
+
+  const min =
+    parseInt(input.dataset.min) || parseInt(input.getAttribute("min")) || 0;
+  const max =
+    parseInt(input.dataset.max) || parseInt(input.getAttribute("max")) || 100;
+  const step =
+    parseInt(input.dataset.step) || parseInt(input.getAttribute("step")) || 1;
+  const label =
+    input.parentElement.parentElement.querySelector("label")?.textContent ||
+    "Value";
+
+  const modal = ensureSliderModal();
+  const slider = $("#sliderModalRange");
+  const valueDisplay = $("#sliderModalValue");
+  const titleEl = $("#sliderModalTitle");
+  const minEl = $("#sliderModalMin");
+  const maxEl = $("#sliderModalMax");
+
+  if (!slider) return;
+
+  titleEl.textContent = label;
+  minEl.textContent = min;
+  maxEl.textContent = max;
+  slider.min = min;
+  slider.max = max;
+  slider.step = step;
+  slider.value = input.value || min;
+  valueDisplay.textContent = slider.value;
+
+  // Store initial value
+  const initialValue = input.value;
+
+  // Only update display while sliding, don't update input
+  slider.oninput = function () {
+    valueDisplay.textContent = this.value;
+  };
+
+  // Remove old hidden listener if exists
+  const oldHiddenHandler = sliderModalElement?._hiddenHandler;
+  if (oldHiddenHandler) {
+    sliderModalElement.removeEventListener("hidden.bs.modal", oldHiddenHandler);
+  }
+
+  // Update input only when modal closes
+  const hiddenHandler = function () {
+    const finalValue = slider.value;
+    if (finalValue !== initialValue) {
+      input.value = finalValue;
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+  };
+
+  // Store handler reference for cleanup
+  if (sliderModalElement) {
+    sliderModalElement._hiddenHandler = hiddenHandler;
+    sliderModalElement.addEventListener("hidden.bs.modal", hiddenHandler, {
+      once: true,
+    });
+  }
+
+  if (sliderModalInstance) {
+    sliderModalInstance.show();
+  }
+}
+
+// Initialize slider buttons on page load
+function attachSliderButtons(root = document) {
+  root.querySelectorAll(".number-range .dropdown-toggle").forEach((button) => {
+    if (button.dataset.sliderInitialized) return;
+    button.dataset.sliderInitialized = "true";
+    button.addEventListener("click", (e) => {
+      e.preventDefault();
+      const input = button
+        .closest(".input-group")
+        ?.querySelector('input[type="text"]');
+      if (input && input.id) {
+        openSliderModal(input.id);
+      }
+    });
+  });
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  attachSliderButtons();
+
+  /* Check if doorbell chime is configured and show warning if not */
+  if (document.querySelector(".doorbell-nav")) {
+    fetch("/x/json-chime-status.cgi")
+      .then((r) => r.json())
+      .then((data) => {
+        /* Reveal nav item if doorbell feature is present */
+        if (data.configured !== undefined) {
+          document.querySelectorAll(".doorbell-nav").forEach((el) => {
+            const li = el.closest("li");
+            if (li) li.classList.remove("d-none");
+          });
+        }
+        /* Show warning banner if no chimes are configured */
+        if (data.configured === false) {
+          const banner = document.createElement("div");
+          banner.className =
+            "alert alert-warning text-center rounded-0 mb-0 py-2";
+          banner.innerHTML =
+            '<i class="bi bi-exclamation-triangle-fill me-2"></i>' +
+            "No doorbell chime configured. " +
+            '<a href="/config-doorbell.html" class="alert-link">Pair a chime</a> ' +
+            "to enable the doorbell.";
+          const main = document.querySelector("main");
+          if (main) main.insertBefore(banner, main.firstChild);
+        }
+      })
+      .catch(() => {
+        /* Silently ignore — doorbell feature not installed */
+      });
+  }
+});
+
+window.attachSliderButtons = attachSliderButtons;
+
+// Unified slider initialization function (deprecated - kept for compatibility)
+function initSlider(id) {
+  const input = $("#" + id);
+  const slider = $("#" + id + "-slider");
+  const sliderValue = $("#" + id + "-slider-value");
+
+  if (!input || !slider || !sliderValue) return;
+
+  const min = parseInt(slider.getAttribute("min")) || 0;
+  const max = parseInt(slider.getAttribute("max")) || 100;
+
+  slider.addEventListener("input", function () {
+    input.value = this.value;
+    sliderValue.textContent = this.value;
+  });
+
+  input.addEventListener("input", function () {
+    const val = parseInt(this.value) || min;
+    const clampedVal = Math.max(min, Math.min(max, val));
+    slider.value = clampedVal;
+    sliderValue.textContent = clampedVal;
+  });
+}
+
+function initSliders(sliderIds) {
+  if (Array.isArray(sliderIds)) {
+    sliderIds.forEach(initSlider);
+  }
+}
+
+window.initSlider = initSlider;
+window.initSliders = initSliders;
+
+function ensureSendModal() {
+  if ($("#sendModal")) return;
+  const modal = document.createElement("div");
+  modal.className = "modal fade";
+  modal.id = "sendModal";
+  modal.tabIndex = -1;
+  modal.setAttribute("aria-labelledby", "sendModalLabel");
+  modal.setAttribute("aria-hidden", "true");
+  modal.innerHTML = `
+	  <div class="modal-dialog modal-lg">
+	    <div class="modal-content">
+	      <div class="modal-header">
+	        <h5 class="modal-title" id="sendModalLabel">Send snapshot/videoclip to...</h5>
+	        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+	      </div>
+	      <div class="modal-body">
+	        <div class="row g-2" id="send-modal-grid"></div>
+	      </div>
+	    </div>
+	  </div>`;
+  document.body.appendChild(modal);
+}
+
+function buildSendModalGrid() {
+  ensureSendModal();
+  const grid = $("#send-modal-grid");
+  if (!grid) return;
+
+  const triggerBlobDownload = (blob, filename) => {
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+  };
+
+  const resolveSnapshotStreamEnabled = (mediaConfig, streamKey) => {
+    const streams =
+      mediaConfig && typeof mediaConfig === "object"
+        ? mediaConfig.streams
+        : null;
+    if (!streams || typeof streams !== "object") {
+      return true;
+    }
+
+    const altStreamKey = streamKey === "ch0" ? "stream0" : "stream1";
+    const stream = streams[streamKey] || streams[altStreamKey] || null;
+    if (!stream || typeof stream !== "object") {
+      return false;
+    }
+
+    if (stream.available === false || stream.enabled === false) {
+      return false;
+    }
+
+    if (stream.snapshot_url === "" || stream.snapshot_url === null) {
+      return false;
+    }
+
+    return true;
+  };
+
+  const setDownloadLinkEnabled = (link, enabled, unavailableMessage) => {
+    link.dataset.disabled = enabled ? "false" : "true";
+    link.classList.toggle("disabled", !enabled);
+    link.setAttribute("aria-disabled", enabled ? "false" : "true");
+    if (enabled) {
+      link.removeAttribute("tabindex");
+      link.title = link.dataset.enabledTitle || "Download snapshot";
+      return;
+    }
+    link.setAttribute("tabindex", "-1");
+    link.title = unavailableMessage;
+  };
+
+  const downloadSnapshot = async (streamId, fallbackUrl, triggerEl) => {
+    const button = triggerEl;
+    if (button) {
+      button.classList.add("disabled");
+      button.setAttribute("aria-disabled", "true");
+    }
+    try {
+      const response = await fetch(
+        agentApiUrl(`/api/v1/actions/snapshot?stream_id=${streamId}`),
+        {
+          method: "POST",
+          cache: "no-store",
+          headers: {
+            Accept: "image/jpeg, application/json",
+          },
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const blob = await response.blob();
+      if (!blob || blob.size <= 0) {
+        throw new Error("empty snapshot response");
+      }
+
+      const contentType = String(blob.type || "").toLowerCase();
+      if (
+        contentType.includes("application/json") ||
+        contentType.startsWith("text/")
+      ) {
+        throw new Error(
+          `unexpected snapshot content type: ${contentType || "unknown"}`,
+        );
+      }
+
+      const stamp = new Date().toISOString().replace(/[.:]/g, "-");
+      triggerBlobDownload(blob, `snapshot-ch${streamId}-${stamp}.jpg`);
+    } catch (error) {
+      if (
+        typeof console !== "undefined" &&
+        typeof console.warn === "function"
+      ) {
+        console.warn(
+          "Agent snapshot download failed, falling back to legacy URL",
+          error,
+        );
+      }
+      if (typeof showAlert === "function") {
+        showAlert(
+          "warning",
+          "Agent snapshot download failed. Falling back to legacy snapshot endpoint.",
+          5000,
+        );
+      }
+      window.open(fallbackUrl, "_blank", "noopener");
+    } finally {
+      if (button) {
+        button.classList.remove("disabled");
+        button.removeAttribute("aria-disabled");
+      }
+    }
+  };
+
+  const createIcon = (className) => {
+    const icon = document.createElement("i");
+    icon.className = className;
+    return icon;
+  };
+
+  grid.innerHTML = "";
+
+  sendModalTargets.forEach((target) => {
+    const col = document.createElement("div");
+    col.className = "col-12 col-lg-6";
+
+    const group = document.createElement("div");
+    group.className = "btn-group d-flex gap-1";
+    group.setAttribute("role", "group");
+
+    const mainBtn = document.createElement("button");
+    mainBtn.type = "button";
+    mainBtn.className = "btn btn-secondary text-start w-100";
+    mainBtn.dataset.sendto = target.key;
+    mainBtn.title = "Send as configured";
+    mainBtn.appendChild(createIcon(target.icon));
+    mainBtn.appendChild(document.createTextNode(` ${target.label}`));
+    group.appendChild(mainBtn);
+
+    const photoBtn = document.createElement("button");
+    photoBtn.type = "button";
+    photoBtn.className = "btn btn-secondary flex-shrink-0";
+    photoBtn.dataset.sendto = target.key;
+    photoBtn.dataset.type = "photo";
+    photoBtn.title = "Send photo only";
+    photoBtn.appendChild(createIcon("bi bi-image"));
+    group.appendChild(photoBtn);
+
+    const videoBtn = document.createElement("button");
+    videoBtn.type = "button";
+    videoBtn.className = "btn btn-secondary flex-shrink-0";
+    videoBtn.dataset.sendto = target.key;
+    videoBtn.dataset.type = "video";
+    videoBtn.title = "Send video only";
+    videoBtn.appendChild(createIcon("bi bi-film"));
+    group.appendChild(videoBtn);
+
+    const configLink = document.createElement("a");
+    configLink.className = "btn btn-secondary flex-shrink-0";
+    configLink.href = `/tool-send2.html`;
+    configLink.title = "Configure";
+    configLink.appendChild(createIcon("bi bi-gear"));
+    group.appendChild(configLink);
+
+    col.appendChild(group);
+    grid.appendChild(col);
+  });
+
+  const downloadCol = document.createElement("div");
+  downloadCol.className = "col-12 col-lg-6";
+  const downloadGroup = document.createElement("div");
+  downloadGroup.className = "btn-group d-flex gap-1";
+  downloadGroup.setAttribute("role", "group");
+
+  const downloadLinkCh0 = document.createElement("a");
+  downloadLinkCh0.className = "btn btn-secondary w-100 text-start";
+  downloadLinkCh0.href = "#";
+  downloadLinkCh0.target = "_blank";
+  downloadLinkCh0.title = "Download main stream";
+  downloadLinkCh0.dataset.enabledTitle = "Download main stream";
+  downloadLinkCh0.appendChild(createIcon("bi bi-download"));
+  downloadLinkCh0.appendChild(document.createTextNode(" Download Ch0"));
+  downloadLinkCh0.addEventListener("click", (event) => {
+    event.preventDefault();
+    if (downloadLinkCh0.dataset.disabled === "true") {
+      if (typeof showAlert === "function") {
+        showAlert(
+          "info",
+          "Download Ch0 is unavailable for this camera stream.",
+          3500,
+        );
+      }
+      return;
+    }
+    downloadSnapshot(0, "/x/dl0.jpg", downloadLinkCh0);
+  });
+  downloadGroup.appendChild(downloadLinkCh0);
+
+  const downloadLinkCh1 = document.createElement("a");
+  downloadLinkCh1.className = "btn btn-secondary w-100 text-start";
+  downloadLinkCh1.href = "#";
+  downloadLinkCh1.target = "_blank";
+  downloadLinkCh1.download = "ch1-snapshot.jpg";
+  downloadLinkCh1.title = "Download substream";
+  downloadLinkCh1.dataset.enabledTitle = "Download substream";
+  downloadLinkCh1.appendChild(createIcon("bi bi-download"));
+  downloadLinkCh1.appendChild(document.createTextNode(" Download Ch1"));
+  downloadLinkCh1.addEventListener("click", (event) => {
+    event.preventDefault();
+    if (downloadLinkCh1.dataset.disabled === "true") {
+      if (typeof showAlert === "function") {
+        showAlert(
+          "info",
+          "Download Ch1 is unavailable for this camera stream.",
+          3500,
+        );
+      }
+      return;
+    }
+    downloadSnapshot(1, "/x/dl1.jpg", downloadLinkCh1);
+  });
+  downloadGroup.appendChild(downloadLinkCh1);
+
+  agentJsonRequest("/api/v1/runtime/media", { cache: "no-store" })
+    .then((mediaConfig) => {
+      const ch0Enabled = resolveSnapshotStreamEnabled(mediaConfig, "ch0");
+      const ch1Enabled = resolveSnapshotStreamEnabled(mediaConfig, "ch1");
+      setDownloadLinkEnabled(
+        downloadLinkCh0,
+        ch0Enabled,
+        "Download main stream is not available on this camera.",
+      );
+      setDownloadLinkEnabled(
+        downloadLinkCh1,
+        ch1Enabled,
+        "Download substream is not available on this camera.",
+      );
+    })
+    .catch((error) => {
+      if (
+        typeof console !== "undefined" &&
+        typeof console.warn === "function"
+      ) {
+        console.warn(
+          "Could not load media capabilities for send modal downloads",
+          error,
+        );
+      }
+      setDownloadLinkEnabled(downloadLinkCh0, true, "");
+      setDownloadLinkEnabled(downloadLinkCh1, true, "");
+    });
+
+  downloadCol.appendChild(downloadGroup);
+  grid.appendChild(downloadCol);
+}
+
+function ensureDebugControl(attempt = 0) {
+  const debugPanels = $$(".ui-debug");
+  if (!debugPanels.length) return;
+  debugPanels.forEach((panel) => panel.classList.add("d-none"));
+  const footerStack = $("#footer-action-stack");
+  if (!footerStack) {
+    if (attempt < 20) {
+      window.setTimeout(() => ensureDebugControl(attempt + 1), 150);
+    }
+    return;
+  }
+  let debugBtn = $("#debug");
+  if (!debugBtn) {
+    debugBtn = document.createElement("button");
+    debugBtn.type = "button";
+    debugBtn.id = "debug";
+    debugBtn.value = "1";
+    debugBtn.title = "Debug info";
+    debugBtn.className = "btn btn-outline-secondary btn-sm w-100";
+    debugBtn.innerHTML = '<i class="bi bi-bug"></i> Debug';
+    footerStack.appendChild(debugBtn);
+  } else if (debugBtn.parentElement !== footerStack) {
+    footerStack.appendChild(debugBtn);
+  }
+  if (debugBtn.dataset.bound === "true") return;
+  debugBtn.dataset.bound = "true";
+  debugBtn.addEventListener("click", (ev) => {
+    ev.preventDefault();
+    const ctx = ensureDebugModalStructure();
+    const isVisible = ctx.modalEl.classList.contains("show");
+    if (isVisible) {
+      hideDebugModal(ctx);
+      return;
+    }
+    ctx.buttonRef = debugBtn;
+    populateDebugModalContent();
+    debugBtn.classList.add("active");
+    showDebugModal(ctx);
+  });
+}
+
+const ConfirmDefaults = {
+  title: "Confirm action",
+  message: "Are you sure you want to continue?",
+  confirmLabel: "Continue",
+  cancelLabel: "Cancel",
+  intent: "danger",
+};
+
+let confirmModalCtx = null;
+const confirmProcessedElements = new WeakSet();
+const confirmFormSubmitters = new WeakMap();
+let confirmMutationObserver = null;
+let confirmScanScheduled = false;
+
+function ensureConfirmModalStructure() {
+  if (confirmModalCtx) return confirmModalCtx;
+  const modalEl = document.createElement("div");
+  modalEl.id = "thinginoConfirmModal";
+  modalEl.className = "modal fade";
+  modalEl.tabIndex = -1;
+  modalEl.setAttribute("aria-hidden", "true");
+  modalEl.innerHTML = `
+	  <div class="modal-dialog modal-dialog-centered">
+	    <div class="modal-content">
+	      <div class="modal-header">
+	        <h5 class="modal-title" data-confirm-title>${ConfirmDefaults.title}</h5>
+	        <button type="button" class="btn-close" data-confirm-close aria-label="Close"></button>
+	      </div>
+	      <div class="modal-body">
+	        <p class="mb-0" data-confirm-message>${ConfirmDefaults.message}</p>
+	      </div>
+	      <div class="modal-footer gap-2">
+	        <button type="button" class="btn btn-outline-secondary" data-confirm-cancel>${ConfirmDefaults.cancelLabel}</button>
+	        <button type="button" class="btn btn-primary" data-confirm-accept>${ConfirmDefaults.confirmLabel}</button>
+	      </div>
+	    </div>
+	  </div>`;
+  const mountTarget = document.body || document.documentElement;
+  mountTarget.appendChild(modalEl);
+  const ctx = {
+    modalEl,
+    titleEl: modalEl.querySelector("[data-confirm-title]"),
+    messageEl: modalEl.querySelector("[data-confirm-message]"),
+    confirmBtn: modalEl.querySelector("[data-confirm-accept]"),
+    cancelBtn: modalEl.querySelector("[data-confirm-cancel]"),
+    closeBtn: modalEl.querySelector("[data-confirm-close]"),
+    modalInstance: null,
+  };
+  if (window.bootstrap && window.bootstrap.Modal) {
+    ctx.modalInstance = window.bootstrap.Modal.getOrCreateInstance(modalEl);
+  }
+  if (ctx.closeBtn && (!window.bootstrap || !window.bootstrap.Modal)) {
+    ctx.closeBtn.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      hideConfirmModalInstant(ctx);
+    });
+  }
+  confirmModalCtx = ctx;
+  return ctx;
+}
+
+function hideConfirmModalInstant(ctx) {
+  if (!ctx || !ctx.modalEl) return;
+  ctx.modalEl.classList.remove("show");
+  ctx.modalEl.style.display = "none";
+  ctx.modalEl.setAttribute("aria-hidden", "true");
+  ctx.modalEl.removeAttribute("aria-modal");
+}
+
+function resolveConfirmIntentClass(intent) {
+  switch ((intent || ConfirmDefaults.intent).toLowerCase()) {
+    case "warning":
+      return "btn-warning";
+    case "success":
+      return "btn-success";
+    case "primary":
+      return "btn-primary";
+    case "danger":
+    default:
+      return "btn-danger";
+  }
+}
+
+function normalizeConfirmOptions(messageOrOptions, extraOptions) {
+  const normalized = { ...ConfirmDefaults };
+  const assignFrom = (source) => {
+    if (!source) return;
+    if (typeof source === "string") {
+      normalized.message = source;
+      return;
+    }
+    if (typeof source !== "object") return;
+    if (source.title) normalized.title = source.title;
+    if (source.message) normalized.message = source.message;
+    if (source.confirmLabel) normalized.confirmLabel = source.confirmLabel;
+    if (source.cancelLabel) normalized.cancelLabel = source.cancelLabel;
+    if (source.intent) normalized.intent = source.intent;
+  };
+  assignFrom(messageOrOptions);
+  assignFrom(extraOptions);
+  if (!normalized.message) normalized.message = ConfirmDefaults.message;
+  return normalized;
+}
+
+function showConfirmDialog(options) {
+  const ctx = ensureConfirmModalStructure();
+  if (!ctx) {
+    return Promise.resolve(true);
+  }
+  ctx.titleEl.textContent = options.title || ConfirmDefaults.title;
+  ctx.messageEl.textContent = options.message || ConfirmDefaults.message;
+  ctx.confirmBtn.textContent =
+    options.confirmLabel || ConfirmDefaults.confirmLabel;
+  ctx.cancelBtn.textContent =
+    options.cancelLabel || ConfirmDefaults.cancelLabel;
+  ctx.confirmBtn.className = "btn " + resolveConfirmIntentClass(options.intent);
+  return new Promise((resolve) => {
+    let finished = false;
+    const handleConfirm = (ev) => {
+      if (ev) ev.preventDefault();
+      finalize(true);
+    };
+    const handleCancel = (ev) => {
+      if (ev) ev.preventDefault();
+      finalize(false);
+    };
+    const handleHidden = () => finalize(false);
+    const cleanup = () => {
+      ctx.confirmBtn.removeEventListener("click", handleConfirm);
+      ctx.cancelBtn.removeEventListener("click", handleCancel);
+      if (ctx.closeBtn) ctx.closeBtn.removeEventListener("click", handleCancel);
+      ctx.modalEl.removeEventListener("hidden.bs.modal", handleHidden);
+    };
+    const hideModal = () => {
+      if (ctx.modalInstance && window.bootstrap && window.bootstrap.Modal) {
+        ctx.modalInstance.hide();
+      } else {
+        hideConfirmModalInstant(ctx);
+      }
+    };
+    const finalize = (result) => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      hideModal();
+      resolve(result);
+    };
+    ctx.confirmBtn.addEventListener("click", handleConfirm);
+    ctx.cancelBtn.addEventListener("click", handleCancel);
+    if (ctx.closeBtn) ctx.closeBtn.addEventListener("click", handleCancel);
+    ctx.modalEl.addEventListener("hidden.bs.modal", handleHidden, {
+      once: true,
+    });
+    if (window.bootstrap && window.bootstrap.Modal) {
+      ctx.modalInstance = window.bootstrap.Modal.getOrCreateInstance(
+        ctx.modalEl,
+      );
+      ctx.modalInstance.show();
+    } else {
+      ctx.modalEl.classList.add("show");
+      ctx.modalEl.style.display = "block";
+      ctx.modalEl.removeAttribute("aria-hidden");
+      ctx.modalEl.setAttribute("aria-modal", "true");
+    }
+  });
+}
+
+function getElementConfirmOptions(element) {
+  if (!element || !element.dataset) return {};
+  const opts = {};
+  const { dataset } = element;
+  if (dataset.confirmMessage) opts.message = dataset.confirmMessage;
+  else if (dataset.confirm) opts.message = dataset.confirm;
+  if (dataset.confirmTitle) opts.title = dataset.confirmTitle;
+  if (dataset.confirmIntent) opts.intent = dataset.confirmIntent;
+  if (dataset.confirmConfirm) opts.confirmLabel = dataset.confirmConfirm;
+  else if (dataset.confirmAction) opts.confirmLabel = dataset.confirmAction;
+  if (dataset.confirmCancel) opts.cancelLabel = dataset.confirmCancel;
+  return opts;
+}
+
+function isSubmitControl(element) {
+  if (!element) return false;
+  const tag = element.tagName;
+  const type = (element.getAttribute("type") || "").toLowerCase();
+  if (tag === "BUTTON") {
+    return type === "" || type === "submit";
+  }
+  if (tag === "INPUT") {
+    return type === "submit" || type === "image";
+  }
+  return false;
+}
+
+function attachConfirmTrigger(element) {
+  if (!element || confirmProcessedElements.has(element)) return;
+  const skip =
+    element.dataset &&
+    (element.dataset.confirmSkip === "true" ||
+      element.dataset.confirmSkip === "1");
+  if (skip) return;
+  confirmProcessedElements.add(element);
+  const form = element.closest("form");
+  if (form && isSubmitControl(element)) {
+    bindConfirmFormSubmit(form, element);
+    return;
+  }
+  bindConfirmClick(element);
+}
+
+function bindConfirmClick(element) {
+  element.addEventListener("click", (ev) =>
+    handleConfirmableClick(ev, element),
+  );
+}
+
+function bindConfirmFormSubmit(form, trigger) {
+  let submitters = confirmFormSubmitters.get(form);
+  if (!submitters) {
+    submitters = new Set();
+    confirmFormSubmitters.set(form, submitters);
+    form.addEventListener(
+      "submit",
+      (ev) => handleConfirmableSubmit(ev, form),
+      true,
+    );
+  }
+  submitters.add(trigger);
+}
+
+async function handleConfirmableClick(ev, element) {
+  if (element.dataset.confirmBypass === "1") {
+    delete element.dataset.confirmBypass;
+    return;
+  }
+  if (element.disabled) return;
+  ev.preventDefault();
+  ev.stopImmediatePropagation();
+  const options = getElementConfirmOptions(element);
+  const confirmed = await window.confirm(options.message, options);
+  if (!confirmed) return;
+  element.dataset.confirmBypass = "1";
+  window.setTimeout(() => {
+    if (typeof element.click === "function") {
+      element.click();
+      return;
+    }
+    if (element.tagName === "A" && element.href) {
+      if (element.target && element.target !== "_self") {
+        window.open(element.href, element.target, "noopener");
+      } else {
+        window.location.href = element.href;
+      }
+    }
+  }, 0);
+}
+
+async function handleConfirmableSubmit(ev, form) {
+  if (form.dataset.confirmBypass === "1") {
+    delete form.dataset.confirmBypass;
+    return;
+  }
+  const submitters = confirmFormSubmitters.get(form);
+  if (!submitters || !submitters.size) return;
+  const trigger = ev.submitter;
+  if (!trigger || !submitters.has(trigger)) return;
+  ev.preventDefault();
+  ev.stopImmediatePropagation();
+  const options = getElementConfirmOptions(trigger);
+  const confirmed = await window.confirm(options.message, options);
+  if (!confirmed) return;
+  form.dataset.confirmBypass = "1";
+  const submitAgain = () => {
+    if (typeof form.requestSubmit === "function") {
+      form.requestSubmit(trigger);
+    } else {
+      form.submit();
+    }
+  };
+  window.setTimeout(submitAgain, 0);
+}
+
+function scanConfirmTriggers(root = document) {
+  if (!root || typeof root.querySelectorAll !== "function") return;
+  root.querySelectorAll(".confirm").forEach(attachConfirmTrigger);
+}
+
+function scheduleConfirmScan() {
+  if (confirmScanScheduled) return;
+  confirmScanScheduled = true;
+  const run = () => {
+    confirmScanScheduled = false;
+    scanConfirmTriggers();
+  };
+  if (typeof window.requestAnimationFrame === "function") {
+    window.requestAnimationFrame(run);
+  } else {
+    window.setTimeout(run, 100);
+  }
+}
+
+function initConfirmObserver() {
+  if (confirmMutationObserver || !window.MutationObserver) return;
+  const target = document.body || document.documentElement;
+  if (!target) return;
+  confirmMutationObserver = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (
+        mutation.type === "childList" &&
+        mutation.addedNodes &&
+        mutation.addedNodes.length
+      ) {
+        scheduleConfirmScan();
+        break;
+      }
+    }
+  });
+  confirmMutationObserver.observe(target, { childList: true, subtree: true });
+}
+
+const nativeConfirm =
+  typeof window !== "undefined" && typeof window.confirm === "function"
+    ? window.confirm.bind(window)
+    : () => true;
+
+function thinginoConfirm(messageOrOptions, extraOptions) {
+  const options = normalizeConfirmOptions(messageOrOptions, extraOptions);
+  return showConfirmDialog(options);
+}
+
+thinginoConfirm.defaults = ConfirmDefaults;
+thinginoConfirm.normalize = normalizeConfirmOptions;
+thinginoConfirm.fromElement = getElementConfirmOptions;
+thinginoConfirm.scan = scanConfirmTriggers;
+
+window.nativeConfirm = nativeConfirm;
+window.confirm = thinginoConfirm;
+window.confirmAsync = thinginoConfirm;
+window.thinginoConfirm = thinginoConfirm;
+
+function initPasswordRevealToggles(root = document) {
+  if (!root || typeof root.querySelectorAll !== "function") return;
+
+  root
+    .querySelectorAll(
+      "input[type='password']:not([data-password-reveal-ready])",
+    )
+    .forEach((input) => {
+      if (!input.parentNode) return;
+
+      const wrapper = document.createElement("div");
+      wrapper.className = "password-reveal-wrapper";
+      input.parentNode.insertBefore(wrapper, input);
+      wrapper.appendChild(input);
+
+      const button = document.createElement("button");
+      button.type = "button";
+      button.className = "password-reveal-toggle";
+      button.setAttribute("aria-label", "Show password");
+      button.innerHTML = '<i class="bi bi-eye"></i>';
+
+      button.addEventListener("click", () => {
+        const reveal = input.type === "password";
+        input.type = reveal ? "text" : "password";
+        button.setAttribute(
+          "aria-label",
+          reveal ? "Hide password" : "Show password",
+        );
+        button.setAttribute(
+          "title",
+          reveal ? "Hide password" : "Show password",
+        );
+        button.innerHTML = reveal
+          ? '<i class="bi bi-eye-slash"></i>'
+          : '<i class="bi bi-eye"></i>';
+        input.focus();
+      });
+
+      wrapper.appendChild(button);
+      input.dataset.passwordRevealReady = "1";
+    });
+}
+
+(() => {
+  function initAll() {
+    function toggleAuto(el) {
+      const id = el.dataset.for;
+      const p = $("#" + id);
+      const s = $("#" + id + "-show");
+      if (el.checked) {
+        el.dataset.value = p.value;
+        p.value = "auto";
+        p.disabled = true;
+        s.textContent = "--";
+      } else {
+        p.value = el.dataset.value;
+        p.disabled = false;
+        s.textContent = p.value;
+      }
+    }
+
+    $$("form,input").forEach((el) => (el.autocomplete = "off"));
+
+    const tooltipTriggerList = $$('[data-bs-toggle="tooltip"]');
+    const tooltipList = [...tooltipTriggerList].map(
+      (tooltipTriggerEl) => new bootstrap.Tooltip(tooltipTriggerEl),
+    );
+
+    // Populate the shared Send modal once the DOM is ready.
+    buildSendModalGrid();
+
+    // ranges
+    $$("input[type=range]").forEach((el) => {
+      el.addEventListener("change", (ev) => {
+        if ($("#" + ev.target.id + "-show"))
+          $("#" + ev.target.id + "-show").textContent = ev.target.value;
+      });
+      el.addEventListener("input", (ev) => {
+        if ($("#" + ev.target.id + "-show"))
+          $("#" + ev.target.id + "-show").textContent = ev.target.value;
+      });
+    });
+
+    // scan for confirmable buttons and observe future additions
+    scanConfirmTriggers();
+    initConfirmObserver();
+
+    // toggle auto value
+    $$("input.auto-value").forEach((el) => {
+      el.addEventListener("click", (ev) => toggleAuto(ev.target));
+      toggleAuto(el);
+    });
+
+    // add password reveal toggles for password fields
+    initPasswordRevealToggles();
+
+    // reload window when refresh button is clicked
+    $$(".refresh").forEach((el) => {
+      el.addEventListener("click", (ev) => {
+        window.location.reload();
+      });
+    });
+
+    // set links to external resources to open in a new window.
+    $$("a[href^=http]").forEach((el) => (el.target = "_blank"));
+
+    // handle sendto buttons
+    $$("button[data-sendto]").forEach((el) => {
+      if (el.dataset.sendtoBypass === "1" || el.dataset.sendtoBypass === "true")
+        return;
+      el.addEventListener("click", async (ev) => {
+        ev.preventDefault();
+        const options = getElementConfirmOptions(el);
+        const confirmed = await confirm(
+          options.message || "Send this action now?",
+          options,
+        );
+        if (!confirmed) return;
+        const params = { to: el.dataset.sendto };
+        if (el.dataset.type) {
+          params.type = el.dataset.type;
+        }
+        fetch("/x/send.cgi", {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: new URLSearchParams(params).toString(),
+        })
+          .then((res) => res.json())
+          .then((data) => console.log(data));
+      });
+    });
+
+    // async output of a command running on camera
+    const outputEl = $("pre#output");
+    if (outputEl) {
+      let commandInFlight = false;
+
+      async function* makeLineIterator(reader) {
+        const td = new TextDecoder("utf-8");
+        let { value: chunk, done: readerDone } = await reader.read();
+        chunk = chunk ? td.decode(chunk) : "";
+        const re = /\r\n|\n|\r/gm;
+        let startIndex = 0;
+        let result;
+        for (;;) {
+          result = re.exec(chunk);
+          if (!result) {
+            if (readerDone) break;
+            let remainder = chunk.substring(startIndex);
+            ({ value: chunk, done: readerDone } = await reader.read());
+            chunk = remainder + (chunk ? td.decode(chunk) : "");
+            startIndex = re.lastIndex = 0;
+            continue;
+          }
+          const lineContent = chunk.substring(startIndex, result.index);
+          const lineEnding = result[0];
+          yield { line: lineContent, ending: lineEnding };
+          startIndex = re.lastIndex;
+        }
+        if (startIndex < chunk.length)
+          yield { line: chunk.substring(startIndex), ending: "" };
+      }
+
+      const finalizeStream = () => {
+        commandInFlight = false;
+        if ("true" === outputEl.dataset["reboot"]) {
+          window.location.href = "/x/reboot.cgi";
+        } else {
+          outputEl.innerHTML += "\n--- finished ---\n";
+        }
+        outputEl.dispatchEvent(new CustomEvent("thingino:command-finished"));
+      };
+
+      async function streamCommand(url) {
+        if (!url || commandInFlight) return;
+        commandInFlight = true;
+        try {
+          const streamResponse = await fetch(url);
+          if (!streamResponse.ok) {
+            outputEl.innerHTML =
+              "Error: server returned " +
+              streamResponse.status +
+              " " +
+              streamResponse.statusText +
+              "\n";
+            return;
+          }
+          for await (let { line, ending } of makeLineIterator(
+            streamResponse.body.getReader(),
+          )) {
+            const re1 = /\u001b\[1;(\d+)m/;
+            const re2 = /\u001b\[0m/;
+            line = line
+              .replace(re1, '<span class="ansi-$1">')
+              .replace(re2, "</span>");
+
+            // Handle carriage return - replace last line instead of adding new
+            if (ending === "\r") {
+              // Carriage return: replace the last line
+              const lines = outputEl.innerHTML.split("\n");
+              if (lines.length > 0) {
+                lines[lines.length - 1] = line;
+                outputEl.innerHTML = lines.join("\n");
+              } else {
+                outputEl.innerHTML = line;
+              }
+            } else {
+              // Normal newline: add new line
+              outputEl.innerHTML += line + "\n";
+            }
+
+            outputEl.scrollTop = outputEl.scrollHeight;
+          }
+        } finally {
+          finalizeStream();
+        }
+      }
+
+      const startStreaming = (command, options = {}) => {
+        if (commandInFlight) return;
+        const streamOverride =
+          options.stream || outputEl.dataset["stream"] || "";
+        const encodedOverride =
+          options.encoded || outputEl.dataset["encoded"] || "";
+        const resolvedCommand = command || outputEl.dataset["cmd"] || "";
+        let streamUrl = "";
+        let encodedValue = "";
+
+        if (streamOverride) {
+          streamUrl = streamOverride;
+        } else if (encodedOverride) {
+          encodedValue = encodedOverride;
+          streamUrl = "/x/run.cgi?cmd=" + encodedOverride;
+        } else if (resolvedCommand) {
+          encodedValue = btoa(resolvedCommand);
+          streamUrl = "/x/run.cgi?cmd=" + encodedValue;
+        } else {
+          return;
+        }
+        if (options.reboot !== undefined) {
+          outputEl.dataset["reboot"] = options.reboot ? "true" : "false";
+        }
+        outputEl.dataset["cmd"] = resolvedCommand;
+        outputEl.dataset["stream"] = streamOverride || "";
+        outputEl.dataset["encoded"] = encodedValue;
+        outputEl.innerHTML = "";
+        outputEl.dispatchEvent(
+          new CustomEvent("thingino:command-start", {
+            detail: { cmd: resolvedCommand },
+          }),
+        );
+        streamCommand(streamUrl);
+      };
+
+      if (
+        outputEl.dataset["cmd"] ||
+        outputEl.dataset["stream"] ||
+        outputEl.dataset["encoded"]
+      ) {
+        startStreaming(outputEl.dataset["cmd"] || "", {
+          stream: outputEl.dataset["stream"] || "",
+          encoded: outputEl.dataset["encoded"] || "",
+        });
+      }
+
+      outputEl.addEventListener("thingino:start-command", (ev) => {
+        const detail = ev.detail || {};
+        if (detail.reboot !== undefined) {
+          outputEl.dataset["reboot"] = detail.reboot ? "true" : "false";
+        }
+        if (detail.cmd || detail.stream || detail.encoded) {
+          startStreaming(detail.cmd || "", {
+            reboot: detail.reboot,
+            stream: detail.stream,
+            encoded: detail.encoded,
+          });
+        }
+      });
+    }
+
+    initCopyToClipboard();
+    // Don't start heartbeat here - wait for password check to complete
+
+    // setup recording button handlers
+    $$("#recorder-ch0, #recorder-ch1").forEach((button) => {
+      button.addEventListener("click", function (e) {
+        e.preventDefault();
+        const channel = parseInt(this.dataset.channel);
+        // State is managed by recordingState and will be toggled by toggleRecording
+        toggleRecording(channel);
+      });
+    });
+
+    const timelapseBtn = $("#timelapse");
+    if (timelapseBtn) {
+      timelapseBtn.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        toggleTimelapse();
+      });
+    }
+
+    // setup motion button handler
+    const motionBtn = $("#motion");
+    if (motionBtn) {
+      motionBtn.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        toggleMotion(!motionBtn.classList.contains("active"));
+      });
+    }
+
+    // setup privacy button handler
+    const privacyBtn = $("#privacy");
+    if (privacyBtn) {
+      privacyBtn.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        togglePrivacy(!privacyBtn.classList.contains("active"));
+      });
+    }
+
+    // setup wireguard button handler
+    const wireguardBtn = $("#wireguard");
+    if (wireguardBtn) {
+      wireguardBtn.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        toggleWireGuard(!wireguardBtn.classList.contains("active"));
+      });
+    }
+
+    // setup daynight button handler
+    const daynightBtn = $("#daynight");
+    if (daynightBtn) {
+      daynightBtn.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        const currentlyNight = daynightBtn.classList.contains("is-night");
+        const newMode = currentlyNight ? "day" : "night";
+        toggleDayNight(newMode);
+      });
+    }
+
+    // setup day mode button handler
+    const dayBtn = $("#day");
+    if (dayBtn) {
+      dayBtn.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        toggleDayNight("day");
+      });
+    }
+
+    // setup night mode button handler
+    const nightBtn = $("#night");
+    if (nightBtn) {
+      nightBtn.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        toggleDayNight("night");
+      });
+    }
+
+    // setup microphone button handler
+    const micBtn = $("#microphone");
+    if (micBtn) {
+      micBtn.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        toggleAudio("microphone", !micBtn.classList.contains("active"));
+      });
+    }
+
+    // setup speaker button handler
+    const spkBtn = $("#speaker");
+    if (spkBtn) {
+      spkBtn.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        toggleAudio("speaker", !spkBtn.classList.contains("active"));
+      });
+    }
+
+    ensureDebugControl();
+
+    // setup camera control buttons (color, ircut, ir850, ir940, white)
+    $$("#auto, #color, #ircut, #ir850, #ir940, #white").forEach((el) => {
+      if (el) {
+        el.addEventListener("click", (ev) => {
+          ev.preventDefault();
+          toggleButton(el);
+        });
+      }
+    });
+
+    // setup theme toggle link handler
+    const themeBtn = $("#theme-toggle");
+    if (themeBtn) {
+      themeBtn.addEventListener("click", (ev) => {
+        ev.preventDefault();
+        toggleTheme();
+      });
+    }
+
+    updateRecordingIcons();
+    loadTimelapseState().catch((err) => {
+      console.error("Unable to load timelapse state:", err);
+      updateTimelapseButtonState();
+    });
+  }
+
+  // Create universal alert area (uses existing global-message-overlay)
+  function createAlertArea() {
+    // The global-message-overlay is created by footer.js
+    // This is just for compatibility - can be removed later
+  }
+
+  // Universal alert function - delegates to global message overlay
+  window.showAlert = function (type, message, timeout = 6000) {
+    if (!message) return;
+
+    // Map alert types to variants
+    const variantMap = {
+      success: "success",
+      danger: "danger",
+      warning: "info",
+      info: "info",
+      primary: "info",
+      secondary: "info",
+    };
+
+    const variant = variantMap[type] || "info";
+
+    // Use the global message system from footer.js
+    if (
+      window.thinginoFooter &&
+      typeof window.thinginoFooter.showMessage === "function"
+    ) {
+      window.thinginoFooter.showMessage(message, variant);
+    } else {
+      // Fallback: create and show message directly
+      let el = $("#global-message-overlay");
+      if (!el) {
+        el = document.createElement("div");
+        el.id = "global-message-overlay";
+        el.className = "global-message-overlay";
+        el.setAttribute("role", "status");
+        el.setAttribute("aria-live", "polite");
+        document.body.appendChild(el);
+      }
+      el.textContent = message;
+      el.dataset.variant = variant;
+      el.classList.add("show");
+      setTimeout(() => el.classList.remove("show"), timeout);
+    }
+  };
+
+  window.clearAlerts = function () {
+    const el = $("#global-message-overlay");
+    if (el) el.classList.remove("show");
+    if (
+      window.thinginoFooter &&
+      typeof window.thinginoFooter.hideMessage === "function"
+    ) {
+      window.thinginoFooter.hideMessage();
+    }
+  };
+
+  // Shared overlay message helper - delegates to footer or falls back to showAlert.
+  // Exposed globally so per-page scripts don't need to duplicate this function.
+  window.showOverlayMessage = function (message, variant = "info") {
+    if (
+      window.thinginoFooter &&
+      typeof window.thinginoFooter.showMessage === "function"
+    ) {
+      window.thinginoFooter.showMessage(message, variant);
+      return;
+    }
+    const fallbackType = variant === "danger" ? "danger" : "info";
+    window.showAlert(fallbackType, message);
+  };
+
+  // ---- Shared helpers for tool-send2-*.js service modules ----
+  const _send2Endpoint = "/x/json-send2.cgi";
+
+  // Load send2 config and call populateFn(data) with the parsed JSON.
+  window.send2Load = async function (serviceName, populateFn) {
+    showBusy(`Loading ${serviceName} settings...`);
+    try {
+      const response = await fetch(_send2Endpoint, {
+        headers: { Accept: "application/json" },
+      });
+      if (!response.ok) throw new Error("Failed to load configuration");
+      const data = await response.json();
+      await populateFn(data);
+    } catch (err) {
+      console.error(`Failed to load ${serviceName} config:`, err);
+      showAlert(
+        "danger",
+        `Failed to load ${serviceName} settings: ${err.message || err}`,
+      );
+    } finally {
+      hideBusy();
+    }
+  };
+
+  // Handle form submit: validate, POST the payload returned by buildPayloadFn(), show result.
+  window.send2Save = async function (serviceName, form, event, buildPayloadFn) {
+    event.preventDefault();
+    if (!form.checkValidity()) {
+      event.stopPropagation();
+      form.classList.add("was-validated");
+      return;
+    }
+    showBusy(`Saving ${serviceName} settings...`);
+    try {
+      const payload = buildPayloadFn();
+      const response = await fetch(_send2Endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!response.ok) throw new Error("Failed to save settings");
+      const result = await response.json();
+      if (result.error)
+        throw new Error(result.error.message || "Failed to save settings");
+      showAlert("success", `${serviceName} settings saved successfully.`, 3000);
+      form.classList.remove("was-validated");
+    } catch (err) {
+      console.error(`Failed to save ${serviceName} settings:`, err);
+      showAlert("danger", `Failed to save settings: ${err.message || err}`);
+    } finally {
+      hideBusy();
+    }
+  };
+
+  // Wire up a reload button to re-run loadConfigFn and show a confirmation message.
+  window.send2SetupReload = function (button, serviceName, loadConfigFn) {
+    if (!button) return;
+    button.addEventListener("click", async () => {
+      try {
+        button.disabled = true;
+        await loadConfigFn();
+        showAlert(
+          "info",
+          `${serviceName} settings reloaded from camera.`,
+          3000,
+        );
+      } catch (err) {
+        showAlert("danger", `Failed to reload ${serviceName} settings.`);
+      } finally {
+        button.disabled = false;
+      }
+    });
+  };
+
+  window.addEventListener("load", initAll);
+  window.addEventListener("DOMContentLoaded", createAlertArea);
+
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden) {
+      if ($("#preview")) $("#preview").src = ImageNoStream;
+    } else if (typeof window.restartStreamPreview === "function") {
+      // preview.js owns the stream URL (direct-to-timps, token + channel)
+      window.restartStreamPreview();
+    }
+  });
+
+  // Global modal focus management - prevent aria-hidden focus conflicts for all modals
+  document.addEventListener("hide.bs.modal", (event) => {
+    const modal = event.target;
+
+    // Check if the modal element itself has focus
+    if (document.activeElement === modal) {
+      modal.blur();
+    }
+
+    // Also check for any focused elements within the modal
+    const focusedElement = modal.querySelector(":focus");
+    if (focusedElement) {
+      focusedElement.blur();
+    }
+  });
+
+  // Check session status and default password
+  async function checkSessionAndPassword() {
+    try {
+      const response = await fetch("/x/session-status.cgi", {
+        cache: "no-store",
+      });
+
+      if (!response.ok) {
+        // Session check failed - redirect to login
+        window.location.href = "/login.html";
+        return;
+      }
+
+      const data = await response.json();
+
+      if (!data.authenticated) {
+        // Not authenticated - redirect to login
+        window.location.href = "/login.html";
+        return;
+      }
+
+      // Check if using default password
+      if (data.is_default_password) {
+        isDefaultPassword = true;
+        passwordCheckComplete = true;
+        showPasswordWarningModal();
+      } else {
+        isDefaultPassword = false;
+        passwordCheckComplete = true;
+        heartbeat();
+      }
+    } catch (err) {
+      console.error("Session check failed:", err);
+      // On error, redirect to login
+      window.location.href = "/login.html";
+    }
+  }
+
+  function showPasswordWarningModal() {
+    // Don't show on password change page itself
+    if (window.location.pathname.includes("config-webui.html")) {
+      return;
+    }
+
+    const modalId = "passwordWarningModal";
+    let modal = $("#" + modalId);
+
+    if (!modal) {
+      modal = document.createElement("div");
+      modal.id = modalId;
+      modal.className = "modal fade";
+      modal.setAttribute("data-bs-backdrop", "static");
+      modal.setAttribute("data-bs-keyboard", "false");
+      modal.innerHTML = `
+				<div class="modal-dialog modal-dialog-centered">
+					<div class="modal-content border-warning">
+						<div class="modal-header bg-warning text-dark">
+							<h5 class="modal-title"><i class="bi bi-exclamation-triangle-fill me-2"></i>Security Warning</h5>
+						</div>
+						<div class="modal-body">
+							<div id="password-warning-message">
+								<p><strong>You are using the default password "root".</strong></p>
+								<p>For security reasons, you must change the password immediately.</p>
+							</div>
+							<div id="password-change-alert" class="alert d-none" role="alert"></div>
+							<form id="password-change-form">
+								<div class="mb-3">
+									<label for="new-password" class="form-label">New Password</label>
+									<input type="password" class="form-control" id="new-password" required minlength="4">
+									<div class="form-text">Minimum 4 characters</div>
+								</div>
+								<div class="mb-3">
+									<label for="confirm-password" class="form-label">Confirm Password</label>
+									<input type="password" class="form-control" id="confirm-password" required minlength="4">
+								</div>
+							</form>
+						</div>
+						<div class="modal-footer">
+							<button type="button" class="btn btn-warning" id="change-password-btn">Change Password</button>
+						</div>
+					</div>
+				</div>
+			`;
+      document.body.appendChild(modal);
+
+      // Add event handler for password change
+      const form = modal.querySelector("#password-change-form");
+      const newPasswordInput = modal.querySelector("#new-password");
+      const confirmPasswordInput = modal.querySelector("#confirm-password");
+      const changeBtn = modal.querySelector("#change-password-btn");
+      const alertDiv = modal.querySelector("#password-change-alert");
+
+      function showAlert(message, type) {
+        alertDiv.className = `alert alert-${type}`;
+        alertDiv.textContent = message;
+        alertDiv.classList.remove("d-none");
+      }
+
+      function hideAlert() {
+        alertDiv.classList.add("d-none");
+      }
+
+      changeBtn.addEventListener("click", async (e) => {
+        e.preventDefault();
+        hideAlert();
+
+        const newPassword = newPasswordInput.value;
+        const confirmPassword = confirmPasswordInput.value;
+
+        if (!newPassword || newPassword.length < 4) {
+          showAlert("Password must be at least 4 characters long.", "danger");
+          return;
+        }
+
+        if (newPassword !== confirmPassword) {
+          showAlert("Passwords do not match.", "danger");
+          return;
+        }
+
+        if (newPassword === "root") {
+          showAlert(
+            'Please choose a password different from "root".',
+            "danger",
+          );
+          return;
+        }
+
+        // Close SSE connection BEFORE changing password to prevent auth prompts
+        if (typeof cleanupHeartbeatResources === "function") {
+          cleanupHeartbeatResources();
+        }
+
+        // Disable button and show loading state
+        changeBtn.disabled = true;
+        changeBtn.innerHTML =
+          '<span class="spinner-border spinner-border-sm me-2"></span>Changing...';
+
+        try {
+          const response = await fetch("/x/json-config-webui.cgi", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ password: newPassword }),
+          });
+
+          const result = await response.json();
+
+          if (!response.ok || (result && result.error)) {
+            const message =
+              result && result.error && result.error.message
+                ? result.error.message
+                : "Failed to change password";
+            throw new Error(message);
+          }
+
+          // Success!
+          showAlert(
+            "Password changed successfully! Closing dialog...",
+            "success",
+          );
+          changeBtn.textContent = "Password Changed";
+
+          // Password changed - mark as secure and close modal
+          isDefaultPassword = false;
+
+          // Close modal and start heartbeat
+          setTimeout(() => {
+            const bsModal = bootstrap.Modal.getInstance(modal);
+            if (bsModal) bsModal.hide();
+            // Start heartbeat now that password is secure
+            if (!heartbeatSource) {
+              heartbeat();
+            }
+          }, 1500);
+        } catch (err) {
+          showAlert(err.message || "Failed to change password.", "danger");
+          changeBtn.disabled = false;
+          changeBtn.textContent = "Change Password";
+        }
+      });
+    }
+
+    const bsModal = new bootstrap.Modal(modal);
+    bsModal.show();
+  }
+
+  // Run session and password check after page loads
+  if (
+    window.location.pathname !== "/401.html" &&
+    window.location.pathname !== "/login.html"
+  ) {
+    window.addEventListener("load", () => {
+      setTimeout(checkSessionAndPassword, 100);
+    });
+  }
+})();

--- a/package/timps/files/www/a/navigation.js
+++ b/package/timps/files/www/a/navigation.js
@@ -1,0 +1,651 @@
+(function () {
+  "use strict";
+
+  const uiConfig = window.thinginoUIConfig || {};
+  const globalConfig =
+    uiConfig.nav || window.thinginoNavConfig || window.navConfig || {};
+  const assetTag =
+    (document.documentElement &&
+      document.documentElement.dataset &&
+      document.documentElement.dataset.assetTs) ||
+    "";
+
+  function withAssetTag(url) {
+    if (!assetTag || typeof url !== "string") {
+      return url;
+    }
+    if (!url.startsWith("/a/")) {
+      return url;
+    }
+    const qIndex = url.indexOf("?");
+    const base = qIndex === -1 ? url : url.slice(0, qIndex);
+    return base + "?ts=" + assetTag;
+  }
+
+  function buildDefaultMenu() {
+    const hasMotors = uiConfig.device && uiConfig.device.motors === true;
+    const flashOperationsEnabled =
+      uiConfig.device && uiConfig.device.flashOperations === true;
+    const settingsItems = [
+      { label: "Admin profile", href: "/config-admin.html" },
+      { label: "GPIO pins", href: "/config-gpio.html" },
+      {
+        label: "Doorbell Chime",
+        href: "/config-doorbell.html",
+        className: "doorbell-nav",
+        hidden: true,
+      },
+    ];
+
+    if (hasMotors) {
+      settingsItems.push({
+        label: "Pan/Tilt motors",
+        href: "/config-motors.html",
+      });
+    }
+
+    settingsItems.push(
+      { label: "Network", href: "/config-network.html" },
+      { label: "Audio", href: "/config-audio.html" },
+      { label: "Photosensing", href: "/config-photosensing.html" },
+      { label: "Dusk2Dawn", href: "/config-dusk2dawn.html" },
+      { label: "RTSP/ONVIF access", href: "/config-rtsp.html" },
+      { label: "Remote logging", href: "/config-syslog.html" },
+      { label: "Telegram Bot", href: "/config-telegrambot.html" },
+      { label: "Time", href: "/config-time.html" },
+      { label: "Web Interface", href: "/config-webui.html" },
+      { label: "WireGuard VPN", href: "/config-wireguard.html" },
+      { label: "ZeroTier VPN", href: "/config-zerotier.html" },
+      { type: "divider" },
+      { label: "Reset...", href: "/reset.html" },
+    );
+
+    const toolsItems = [
+      { label: "File manager", href: "/tool-file-manager.html" },
+      { label: "Network test", href: "/tool-ping-trace.html" },
+      { label: "SD card", href: "/tool-sdcard.html" },
+      { label: "Send to services", href: "/tool-send2.html" },
+    ];
+
+    if (flashOperationsEnabled) {
+      toolsItems.push({
+        label: "Flash operations",
+        href: "/tool-upgrade.html",
+      });
+    }
+
+    toolsItems.push(
+      { type: "divider" },
+      {
+        label: "Reboot camera",
+        href: "/x/reboot.cgi",
+        className: "text-danger confirm",
+      },
+    );
+
+    return [
+      {
+        type: "dropdown",
+        id: "ddInfo",
+        label: "Information",
+        items: [
+          { label: "File: crontab", href: "/info.html?crontab" },
+          { label: "File: onvif.json", href: "/info.html?onvif" },
+          { label: "File: timps.conf", href: "/streamer-config.html" },
+          { label: "File: thingino.json", href: "/info.html?thingino" },
+          { label: "Log: dmesg", href: "/info.html?dmesg" },
+          { label: "Log: logcat", href: "/info.html?logcat" },
+          { label: "Log: logread", href: "/info.html?logread" },
+          { label: "Info: lsmod", href: "/info.html?lsmod" },
+          { label: "Info: netstat", href: "/info.html?netstat" },
+          { label: "Info: os-release", href: "/info.html?release" },
+          { label: "Info: top", href: "/info.html?top" },
+          { label: "Info: status", href: "/info.html?status" },
+          { label: "Overlay partition", href: "/info-overlay.html" },
+          { label: "System usage", href: "/info-usage.html" },
+          { label: "Diagnostic info", href: "/info-diagnostic.html" },
+        ],
+      },
+      {
+        type: "dropdown",
+        id: "ddSettings",
+        label: "Settings",
+        items: settingsItems,
+      },
+      {
+        type: "dropdown",
+        id: "ddTools",
+        label: "Tools",
+        items: toolsItems,
+      },
+      {
+        type: "dropdown",
+        id: "ddServices",
+        label: "Services",
+        items: [
+          { label: "Timelapse Recorder", href: "/tool-timelapse.html" },
+          { label: "Video Recorder", href: "/tool-record.html" },
+          { label: "Home Assistant", href: "/config-ha.html" },
+          { label: "MQTT Subscriptions", href: "/tool-mqtt-sub.html" },
+        ],
+      },
+      {
+        type: "dropdown",
+        id: "ddStreamer",
+        label: "Streamer",
+        items: [
+          { label: "Image Quality", href: "/streamer-image.html" },
+          { label: "RTSP Main stream", href: "/streamer-main.html" },
+          { label: "Main stream OSD", href: "/streamer-osd0.html" },
+          { label: "RTSP Substream", href: "/streamer-substream.html" },
+          { label: "Substream OSD", href: "/streamer-osd1.html" },
+          { label: "Sensor IQ File", href: "/streamer-sensor.html" },
+          // timps IMP_IVS grid motion detection; the page greys itself out
+          // when the running streamer/SoC has no motion support
+          { label: "Motion Detection", href: "/config-motion.html" },
+          { label: "Privacy masks", href: "/config-privacy.html" },
+          { label: "Recordings", href: "/recordings.html" },
+          { type: "divider" },
+          { label: "Streamer config", href: "/streamer-config.html" },
+          { label: "Streamer log", href: "/info.html?logcat" },
+          {
+            label: "Restart streamer",
+            href: "#",
+            id: "restart-prudynt-nav",
+            className: "text-danger confirm",
+            trackActive: false,
+          },
+        ],
+      },
+      { type: "link", label: "Preview", href: "/preview.html" },
+      {
+        type: "dropdown",
+        id: "ddHelp",
+        label: "Help",
+        menuClass: "dropdown-menu dropdown-menu-lg-end",
+        items: [
+          {
+            label: "About thingino",
+            href: "https://thingino.com/",
+            target: "_blank",
+            rel: "noreferrer noopener",
+            trackActive: false,
+          },
+          {
+            label: "Thingino Wiki",
+            href: "https://github.com/themactep/thingino-firmware/wiki",
+            target: "_blank",
+            rel: "noreferrer noopener",
+            trackActive: false,
+          },
+          { type: "divider" },
+          {
+            label: "Logout",
+            href: "/x/logout.cgi",
+            className: "text-danger",
+            trackActive: false,
+          },
+        ],
+      },
+    ];
+  }
+
+  const menuData =
+    Array.isArray(globalConfig.items) && globalConfig.items.length
+      ? globalConfig.items
+      : buildDefaultMenu();
+
+  function ready(fn) {
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", fn, { once: true });
+    } else {
+      fn();
+    }
+  }
+
+  function normalizePath(input) {
+    if (!input) return "/";
+    let path = input;
+    let search = "";
+    try {
+      const url = new URL(input, window.location.origin);
+      path = url.pathname;
+      search = url.search;
+    } catch (err) {
+      // ignore and fall back to raw string
+      const qIndex = input.indexOf("?");
+      if (qIndex !== -1) {
+        path = input.slice(0, qIndex);
+        search = input.slice(qIndex);
+      }
+    }
+    if (!path) return "/";
+    path = path.split("#")[0];
+    if (path.length > 1 && path.endsWith("/")) {
+      path = path.replace(/\/+$/, "");
+    }
+    return (path || "/") + search;
+  }
+
+  function deriveBrandLabel(title) {
+    if (
+      typeof globalConfig.brandLabel === "string" &&
+      globalConfig.brandLabel.trim()
+    ) {
+      return globalConfig.brandLabel.trim();
+    }
+    if (
+      document.body &&
+      document.body.dataset &&
+      document.body.dataset.navLabel
+    ) {
+      return document.body.dataset.navLabel;
+    }
+    if (!title) return "thingino";
+    const parts = title
+      .split(/·|-|—/)
+      .map((part) => part.trim())
+      .filter(Boolean);
+    if (parts.length >= 2) {
+      return parts[1];
+    }
+    if (parts.length === 1) {
+      return parts[0];
+    }
+    return "thingino";
+  }
+
+  function createAnchor(item, defaultClass) {
+    const anchor = document.createElement("a");
+    const classes = [defaultClass];
+    if (item.className) {
+      classes.push(item.className);
+    }
+    anchor.className = classes.join(" ");
+    anchor.href = item.href;
+    anchor.textContent = item.label;
+    if (item.target) anchor.target = item.target;
+    if (item.rel) anchor.rel = item.rel;
+    if (item.title) anchor.title = item.title;
+    const shouldTrack =
+      item.trackActive !== false &&
+      typeof item.href === "string" &&
+      item.href.startsWith("/");
+    if (shouldTrack) {
+      anchor.dataset.navPath = normalizePath(item.href);
+    }
+    return anchor;
+  }
+
+  function createDropdown(section) {
+    const li = document.createElement("li");
+    li.className = "nav-item dropdown";
+
+    const toggle = document.createElement("a");
+    toggle.className = "nav-link dropdown-toggle";
+    toggle.href = "#";
+    toggle.id = section.id;
+    toggle.role = "button";
+    toggle.setAttribute("data-bs-toggle", "dropdown");
+    toggle.setAttribute("aria-expanded", "false");
+    toggle.textContent = section.label;
+
+    const menu = document.createElement("ul");
+    menu.className = section.menuClass || "dropdown-menu";
+    if (section.id) {
+      menu.setAttribute("aria-labelledby", section.id);
+    }
+
+    (section.items || []).forEach((item) => {
+      const itemLi = document.createElement("li");
+      if (item.hidden) itemLi.classList.add("d-none");
+      if (item.type === "divider") {
+        const divider = document.createElement("hr");
+        divider.className = item.className || "dropdown-divider";
+        itemLi.appendChild(divider);
+      } else {
+        const anchor = createAnchor(item, "dropdown-item");
+        itemLi.appendChild(anchor);
+      }
+      menu.appendChild(itemLi);
+    });
+
+    li.appendChild(toggle);
+    li.appendChild(menu);
+    return li;
+  }
+
+  function createLinkItem(item) {
+    const li = document.createElement("li");
+    li.className = "nav-item";
+    if (item.hidden) li.classList.add("d-none");
+    li.appendChild(createAnchor(item, "nav-link"));
+    return li;
+  }
+
+  function buildNav(menuItems) {
+    const nav = document.createElement("nav");
+    nav.className = "navbar navbar-expand-lg navbar-dark bg-dark sticky-top";
+    nav.setAttribute("data-generated-nav", "true");
+
+    const container = document.createElement("div");
+    container.className = "container";
+
+    const brand = document.createElement("a");
+    brand.className = "navbar-brand d-flex align-items-center gap-3";
+    brand.href =
+      typeof globalConfig.brandHref === "string" ? globalConfig.brandHref : "/";
+
+    const brandLogo = document.createElement("img");
+    brandLogo.alt = globalConfig.brandLogoAlt || "Thingino logo";
+    brandLogo.width = 150;
+    brandLogo.src = globalConfig.brandLogo || "/a/logo.svg";
+    brand.appendChild(brandLogo);
+
+    const brandText = document.createElement("span");
+    brandText.textContent = deriveBrandLabel(document.title || "");
+    brand.appendChild(brandText);
+
+    const toggler = document.createElement("button");
+    toggler.className = "navbar-toggler";
+    toggler.type = "button";
+    toggler.setAttribute("data-bs-toggle", "offcanvas");
+    toggler.setAttribute("data-bs-target", "#navOffcanvas");
+    toggler.setAttribute("aria-controls", "navOffcanvas");
+    toggler.setAttribute("aria-label", "Toggle navigation");
+    toggler.innerHTML = '<span class="navbar-toggler-icon"></span>';
+
+    const collapse = document.createElement("div");
+    collapse.className =
+      "collapse navbar-collapse justify-content-end d-none d-lg-flex";
+    collapse.id = "nbMain";
+
+    const list = document.createElement("ul");
+    list.className = "navbar-nav";
+
+    menuItems.forEach((item) => {
+      if (item.type === "dropdown") {
+        list.appendChild(createDropdown(item));
+      } else {
+        list.appendChild(createLinkItem(item));
+      }
+    });
+
+    collapse.appendChild(list);
+
+    // Offcanvas menu (visible on small screens)
+    const offcanvas = document.createElement("div");
+    offcanvas.className = "offcanvas offcanvas-end d-lg-none";
+    offcanvas.id = "navOffcanvas";
+    offcanvas.tabIndex = -1;
+    offcanvas.setAttribute("aria-labelledby", "navOffcanvasLabel");
+
+    const offcanvasHeader = document.createElement("div");
+    offcanvasHeader.className = "offcanvas-header";
+
+    const offcanvasTitle = document.createElement("h5");
+    offcanvasTitle.className = "offcanvas-title";
+    offcanvasTitle.id = "navOffcanvasLabel";
+    offcanvasTitle.textContent = "Menu";
+
+    const closeBtn = document.createElement("button");
+    closeBtn.type = "button";
+    closeBtn.className = "btn-close";
+    closeBtn.setAttribute("data-bs-dismiss", "offcanvas");
+    closeBtn.setAttribute("aria-label", "Close");
+
+    offcanvasHeader.appendChild(offcanvasTitle);
+    offcanvasHeader.appendChild(closeBtn);
+
+    const offcanvasBody = document.createElement("div");
+    offcanvasBody.className = "offcanvas-body";
+
+    const offcanvasList = createOffcanvasList(menuItems);
+    offcanvasBody.appendChild(offcanvasList);
+
+    offcanvas.appendChild(offcanvasHeader);
+    offcanvas.appendChild(offcanvasBody);
+
+    container.appendChild(brand);
+    container.appendChild(toggler);
+    container.appendChild(collapse);
+    container.appendChild(offcanvas);
+    nav.appendChild(container);
+    return nav;
+  }
+
+  function createOffcanvasList(menuItems) {
+    const list = document.createElement("ul");
+    list.className = "list-unstyled";
+
+    // Reorder items for offcanvas: Preview link first, then others
+    const reorderedItems = [];
+    const otherItems = [];
+
+    menuItems.forEach((item) => {
+      if (item.type === "link" && item.label === "Preview") {
+        reorderedItems.push(item);
+      } else {
+        otherItems.push(item);
+      }
+    });
+
+    // Combine with Preview first
+    const finalItems = [...reorderedItems, ...otherItems];
+
+    finalItems.forEach((item) => {
+      if (item.type === "dropdown") {
+        const section = document.createElement("li");
+        section.className = "mb-3";
+
+        const heading = document.createElement("h6");
+        heading.className = "text-uppercase text-secondary mb-2";
+        heading.textContent = item.label;
+        section.appendChild(heading);
+
+        const subList = document.createElement("ul");
+        subList.className = "list-unstyled ms-3";
+
+        item.items.forEach((subItem) => {
+          if (subItem.type === "divider") {
+            const divider = document.createElement("li");
+            divider.innerHTML = '<hr class="my-2">';
+            subList.appendChild(divider);
+          } else {
+            const li = document.createElement("li");
+            li.className = "mb-1";
+            const anchor = createAnchor(
+              subItem,
+              "d-block py-1 text-decoration-none",
+            );
+            if (subItem.id) anchor.id = subItem.id + "-offcanvas";
+
+            // Handle navigation after offcanvas closes
+            anchor.addEventListener("click", function (e) {
+              const href = this.getAttribute("href");
+              if (href && href !== "#") {
+                e.preventDefault();
+                const offcanvasEl = $("#navOffcanvas");
+                if (offcanvasEl && window.bootstrap) {
+                  const offcanvasInstance =
+                    bootstrap.Offcanvas.getInstance(offcanvasEl) ||
+                    new bootstrap.Offcanvas(offcanvasEl);
+                  offcanvasEl.addEventListener(
+                    "hidden.bs.offcanvas",
+                    function () {
+                      window.location.href = href;
+                    },
+                    { once: true },
+                  );
+                  offcanvasInstance.hide();
+                } else {
+                  window.location.href = href;
+                }
+              }
+            });
+
+            li.appendChild(anchor);
+            subList.appendChild(li);
+          }
+        });
+
+        section.appendChild(subList);
+        list.appendChild(section);
+      } else {
+        const li = document.createElement("li");
+        li.className = "mb-2";
+        const anchor = createAnchor(
+          item,
+          "d-block fw-bold text-decoration-none p-3",
+        );
+
+        // Handle navigation after offcanvas closes
+        anchor.addEventListener("click", function (e) {
+          const href = this.getAttribute("href");
+          if (href && href !== "#") {
+            e.preventDefault();
+            const offcanvasEl = $("#navOffcanvas");
+            if (offcanvasEl && window.bootstrap) {
+              const offcanvasInstance =
+                bootstrap.Offcanvas.getInstance(offcanvasEl) ||
+                new bootstrap.Offcanvas(offcanvasEl);
+              offcanvasEl.addEventListener(
+                "hidden.bs.offcanvas",
+                function () {
+                  window.location.href = href;
+                },
+                { once: true },
+              );
+              offcanvasInstance.hide();
+            } else {
+              window.location.href = href;
+            }
+          }
+        });
+
+        li.appendChild(anchor);
+        list.appendChild(li);
+      }
+    });
+
+    return list;
+  }
+
+  function highlightActive(nav, currentPath) {
+    const normalizedCurrent = normalizePath(
+      currentPath || window.location.pathname + window.location.search,
+    );
+    const anchors = nav.querySelectorAll("a[data-nav-path]");
+    anchors.forEach((anchor) => {
+      if (anchor.dataset.navPath === normalizedCurrent) {
+        anchor.classList.add("active");
+        const dropdown = anchor.closest(".dropdown");
+        if (dropdown) {
+          const toggle = dropdown.querySelector(".nav-link.dropdown-toggle");
+          if (toggle) toggle.classList.add("active");
+        }
+      }
+    });
+  }
+
+  function rebuildControlBarIfReady() {
+    if (
+      window.thinginoControlBar &&
+      typeof window.thinginoControlBar.rebuild === "function"
+    ) {
+      window.thinginoControlBar.rebuild();
+    }
+  }
+
+  function bindControlBarLoad(scriptEl) {
+    if (!scriptEl || scriptEl.dataset.controlBarBound === "true") return;
+    scriptEl.addEventListener("load", rebuildControlBarIfReady, { once: true });
+    scriptEl.dataset.controlBarBound = "true";
+  }
+
+  function ensureControlBarScript() {
+    if (!$("[data-app-controls]")) return;
+    if (
+      window.thinginoControlBar &&
+      typeof window.thinginoControlBar.rebuild === "function"
+    ) {
+      window.thinginoControlBar.rebuild();
+      return;
+    }
+    const existingScript = $(
+      'script[data-control-bar-autoload], script[src*="/a/control-bar.js"]',
+    );
+    if (existingScript) {
+      bindControlBarLoad(existingScript);
+      return;
+    }
+    const script = document.createElement("script");
+    script.src = withAssetTag(
+      globalConfig.controlBarSrc || "/a/control-bar.js",
+    );
+    script.defer = true;
+    script.dataset.controlBarAutoload = "true";
+    bindControlBarLoad(script);
+    (document.head || document.body || document.documentElement).appendChild(
+      script,
+    );
+  }
+
+  function attachPrudyntHandlers(nav) {
+    const restartPrudyntLink = nav.querySelector("#restart-prudynt-nav");
+    const restartPrudyntOffcanvas = nav.querySelector(
+      "#restart-prudynt-nav-offcanvas",
+    );
+
+    const restartHandler = function (e) {
+      // Let the confirmation system handle the dialog first
+      if (
+        this.classList &&
+        this.classList.contains("confirm") &&
+        this.dataset.confirmBypass !== "1"
+      ) {
+        return; // Let the confirmation system handle this click
+      }
+
+      e.preventDefault();
+      if (
+        window.thinginoFooter &&
+        typeof window.thinginoFooter.restartPrudynt === "function"
+      ) {
+        window.thinginoFooter.restartPrudynt();
+      } else {
+        console.warn("thinginoFooter.restartPrudynt not available yet");
+      }
+    };
+
+    if (restartPrudyntLink) {
+      restartPrudyntLink.addEventListener("click", restartHandler);
+    }
+    if (restartPrudyntOffcanvas) {
+      restartPrudyntOffcanvas.addEventListener("click", restartHandler);
+    }
+  }
+
+  function mountNavigation() {
+    const nav = buildNav(menuData);
+    const placeholder = $("[data-app-nav]");
+    const existing = $('nav[data-generated-nav="true"]');
+    if (placeholder && placeholder.parentNode) {
+      placeholder.parentNode.replaceChild(nav, placeholder);
+    } else if (existing && existing.parentNode) {
+      existing.parentNode.replaceChild(nav, existing);
+    } else if (document.body) {
+      document.body.insertAdjacentElement("afterbegin", nav);
+    }
+    highlightActive(nav, globalConfig.activePath);
+    attachPrudyntHandlers(nav);
+    ensureControlBarScript();
+  }
+
+  ready(mountNavigation);
+
+  window.thinginoNav = {
+    rebuild: mountNavigation,
+    menu: menuData,
+  };
+})();

--- a/package/timps/files/www/a/preview-motion.js
+++ b/package/timps/files/www/a/preview-motion.js
@@ -1,0 +1,313 @@
+/* preview-motion.js - live motion-grid overlay for the timps preview page.
+ *
+ * Draws the timps IMP_IVS detection grid over the video and highlights the
+ * cells that currently report motion. The page fetches the per-boot timps
+ * token once from /x/timps-token.cgi (authenticated WebUI session required)
+ * and then SUBSCRIBES to the timps push stream:
+ *   EventSource http://<host>:<port>/events?stream=motion&token=<tok>
+ * timps pushes an "event: motion" frame whenever the grid state changes
+ * (same JSON object as GET /control's "motion":
+ * {available,enabled,cols,rows,active:[0/1,...],...}; active is row-major,
+ * index = row*cols+col). EventSource cannot send custom headers, so the
+ * token goes as ?token= - it may show up in access logs, which is accepted
+ * on the LAN (the token unlocks /control + /events + viewing the HTTP media
+ * endpoints, never RTSP). CORS + the OPTIONS preflight are handled by timps.
+ * preview-timps.html primes window.timpsTokenInfo with a single shared
+ * token fetch (its /stream.mp4 fetch reuses the token); this script uses
+ * that when present and keeps its own fetch as a standalone fallback.
+ *
+ * FALLBACK: if EventSource is unavailable or keeps failing while /control
+ * still answers (e.g. an old timpsd without /events, or events.enabled=0),
+ * the overlay falls back to the previous behavior - polling GET /control at
+ * ~4 Hz with the X-Timps-Token header - so nothing regresses. EventSource
+ * reconnects by itself (the server sends "retry: 3000"); the stream is
+ * closed while the tab is hidden and reopened when it becomes visible.
+ *
+ * The canvas is aligned to the video's DISPLAYED content rectangle
+ * (object-fit: contain letterboxing is computed from videoWidth/videoHeight
+ * vs the element box), so the grid matches the picture, not the element.
+ * Fails soft: if the token/endpoint is unreachable or the build has no
+ * IMP_IVS move API, the toggle button stays hidden and nothing is drawn.
+ * The overlay auto-hides while motion detection is disabled and can be
+ * toggled with the grid button (state kept in sessionStorage). The motor
+ * joystick overlay is untouched (the canvas is pointer-events: none). */
+(function () {
+  "use strict";
+
+  const POLL_MS = 250; // fallback poll rate, ~4 Hz
+  const ES_MAX_ERRORS = 4; // consecutive EventSource errors before fallback
+  const video = document.getElementById("ms-video");
+  const canvas = document.getElementById("motion-overlay");
+  const btn = document.getElementById("ms-motion");
+  if (!video || !canvas || !btn) return;
+
+  let base = null;   // http://<host>:<port>
+  let token = null;
+  let es = null;     // EventSource (push mode)
+  let esErrors = 0;  // consecutive errors since the last successful open
+  let fellBack = false; // once true, stay in polling mode
+  let timer = null;  // polling fallback interval
+  let busy = false;
+  let last = null;   // last motion status object (or null)
+  let on = sessionStorage.getItem("ms.motionOverlay") !== "0";
+
+  function setBtn() {
+    btn.classList.toggle("active", on);
+    btn.title = on ? "Hide motion grid overlay" : "Show motion grid overlay";
+  }
+
+  /* displayed content rect of the object-fit:contain video inside its box */
+  function contentRect() {
+    // measure the display box from the (always-visible) video, falling back to
+    // the canvas; never rely on the canvas alone (it may still be display:none)
+    const bw = video.clientWidth || canvas.clientWidth;
+    const bh = video.clientHeight || canvas.clientHeight;
+    const vw = video.videoWidth, vh = video.videoHeight;
+    if (!bw || !bh) return null;
+    if (!vw || !vh) return { x: 0, y: 0, w: bw, h: bh }; // no metadata yet
+    const scale = Math.min(bw / vw, bh / vh);
+    const w = vw * scale, h = vh * scale;
+    return { x: (bw - w) / 2, y: (bh - h) / 2, w, h };
+  }
+
+  function clear() {
+    canvas.style.display = "none";
+    if (rafId != null) { cancelAnimationFrame(rafId); rafId = null; }
+  }
+
+  /* motion "afterglow": timps reports a cell active only on the frame it moved,
+   * then clears it, so raw highlights just flicker. Remember when each cell was
+   * last active and keep drawing it - fading out over HOLD_MS - so movement is
+   * actually visible. A rAF loop animates the fade between motion events. */
+  const HOLD_MS = 1200;
+  let holds = null;   // Float64Array: last-active timestamp per cell
+  let holdN = 0;
+  let rafId = null;
+
+  function noteActive(st) {
+    if (!st || !Array.isArray(st.active) || !(st.cols > 0) || !(st.rows > 0))
+      return;
+    const n = st.cols * st.rows;
+    if (!holds || holdN !== n) { holds = new Float64Array(n); holdN = n; }
+    const now = performance.now();
+    for (let i = 0; i < n && i < st.active.length; i++)
+      if (st.active[i]) holds[i] = now;
+  }
+
+  function anyLit(now) {
+    if (!holds) return false;
+    for (let i = 0; i < holdN; i++) if (now - holds[i] < HOLD_MS) return true;
+    return false;
+  }
+
+  // draw once and keep animating (via rAF) while any cell is still fading
+  function ensureAnim() {
+    if (rafId != null) return;
+    const step = () => {
+      rafId = null;
+      draw(last);
+      if (on && anyLit(performance.now())) rafId = requestAnimationFrame(step);
+    };
+    rafId = requestAnimationFrame(step);
+  }
+
+  function draw(st) {
+    if (!on || !st || !st.available || !st.enabled ||
+        !(st.cols > 0) || !(st.rows > 0)) {
+      clear();
+      return;
+    }
+    // show the canvas BEFORE measuring it: a display:none element reports
+    // clientWidth/Height 0, which made contentRect() bail so the overlay could
+    // never become visible (chicken-and-egg deadlock).
+    canvas.style.display = "";
+    const rect = contentRect();
+    if (!rect || rect.w < 8 || rect.h < 8) { clear(); return; }
+    // match the canvas backing store to its CSS size (device pixels)
+    const dpr = window.devicePixelRatio || 1;
+    const cw = Math.round(canvas.clientWidth * dpr);
+    const chh = Math.round(canvas.clientHeight * dpr);
+    if (canvas.width !== cw || canvas.height !== chh) {
+      canvas.width = cw;
+      canvas.height = chh;
+    }
+    const ctx = canvas.getContext("2d");
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, canvas.clientWidth, canvas.clientHeight);
+
+    const { cols, rows } = st;
+    // active cells with afterglow: full-strength when just triggered, fading to
+    // 0 over HOLD_MS (driven by holds[], not the momentary st.active)
+    const now = performance.now();
+    for (let r = 0; r < rows; r++) {
+      for (let c = 0; c < cols; c++) {
+        const idx = r * cols + c;
+        const age = holds && idx < holdN ? now - holds[idx] : Infinity;
+        if (age >= HOLD_MS) continue;
+        const k = 1 - age / HOLD_MS;            // 1 -> 0 fade factor
+        const x0 = rect.x + (c * rect.w) / cols;
+        const y0 = rect.y + (r * rect.h) / rows;
+        const w = rect.w / cols, h = rect.h / rows;
+        ctx.fillStyle = "rgba(255, 40, 40, " + (0.38 * k).toFixed(3) + ")";
+        ctx.fillRect(x0, y0, w, h);
+        ctx.strokeStyle = "rgba(255, 70, 70, " + (0.9 * k).toFixed(3) + ")";
+        ctx.lineWidth = 1.5;
+        ctx.strokeRect(x0 + 0.75, y0 + 0.75, w - 1.5, h - 1.5);
+      }
+    }
+    // faint raster lines so the grid is visible even without motion
+    ctx.strokeStyle = "rgba(255, 255, 255, 0.25)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    for (let c = 0; c <= cols; c++) {
+      const x = rect.x + (c * rect.w) / cols;
+      ctx.moveTo(x, rect.y);
+      ctx.lineTo(x, rect.y + rect.h);
+    }
+    for (let r = 0; r <= rows; r++) {
+      const y = rect.y + (r * rect.h) / rows;
+      ctx.moveTo(rect.x, y);
+      ctx.lineTo(rect.x + rect.w, y);
+    }
+    ctx.stroke();
+  }
+
+  /* ---- fallback path: 4 Hz GET /control polling (the pre-SSE behavior) */
+
+  async function poll() {
+    const res = await fetch(base + "/control", {
+      headers: { "X-Timps-Token": token },
+      cache: "no-store",
+    });
+    if (!res.ok) throw new Error("HTTP " + res.status);
+    const data = await res.json();
+    return data && data.motion ? data.motion : null;
+  }
+
+  async function tick() {
+    if (document.hidden) return;
+    if (!on) { clear(); return; }
+    if (busy) return;
+    busy = true;
+    try {
+      last = await poll();
+    } catch (e) {
+      last = null; // endpoint gone (streamer restart?): hide, keep trying
+    }
+    busy = false;
+    noteActive(last);
+    ensureAnim();
+  }
+
+  function startPoll() {
+    if (timer) return;
+    timer = setInterval(tick, POLL_MS);
+  }
+
+  function stopPoll() {
+    if (timer) { clearInterval(timer); timer = null; }
+  }
+
+  /* ---- push path: EventSource on /events?stream=motion ---- */
+
+  function stopPush() {
+    if (es) { es.close(); es = null; }
+  }
+
+  function startPush() {
+    if (es || fellBack || !window.EventSource) return;
+    es = new EventSource(base + "/events?stream=motion&token=" +
+                         encodeURIComponent(token));
+    es.addEventListener("motion", (e) => {
+      esErrors = 0;
+      try {
+        last = JSON.parse(e.data);
+      } catch (err) {
+        last = null;
+      }
+      noteActive(last);
+      ensureAnim();
+    });
+    es.onopen = () => { esErrors = 0; };
+    es.onerror = () => {
+      // EventSource reconnects on its own (server retry: 3000); only give
+      // up for good - old timpsd without /events, events.enabled=0 - after
+      // several consecutive failures without a single event in between
+      esErrors++;
+      if (esErrors >= ES_MAX_ERRORS || (es && es.readyState === EventSource.CLOSED)) {
+        fellBack = true;
+        stopPush();
+        startPoll(); // nothing regresses: back to the 4 Hz poller
+      }
+    };
+  }
+
+  function pause() {
+    stopPush();
+    // the poll timer keeps running but tick() no-ops while hidden (cheap)
+  }
+
+  function resume() {
+    if (fellBack) { tick(); return; }
+    startPush();
+    draw(last);
+  }
+
+  async function init() {
+    let info;
+    if (window.timpsTokenInfo) {
+      // shared single fetch (primed by preview-timps.html for the player)
+      info = await window.timpsTokenInfo;
+    } else {
+      try {
+        const res = await fetch("/x/timps-token.cgi", { cache: "no-store" });
+        if (!res.ok) return; // no bridge -> feature silently off
+        info = await res.json();
+      } catch (e) {
+        return;
+      }
+    }
+    if (!info || !info.token) return;
+    token = info.token;
+    let host = location.hostname || "127.0.0.1";
+    if (host.indexOf(":") >= 0 && host[0] !== "[") host = "[" + host + "]"; // raw IPv6
+    base = (info.tls ? "https" : "http") + "://" + host + ":" + (info.port || 8880);
+
+    // probe once: only offer the overlay when this build HAS motion support
+    let st;
+    try {
+      st = await poll();
+    } catch (e) {
+      return; // :8880 unreachable (HTTPS mixed content?) -> stay hidden
+    }
+    if (!st || !st.available) return;
+    last = st;
+
+    btn.style.display = "";
+    setBtn();
+    draw(last);
+    btn.addEventListener("click", () => {
+      on = !on;
+      sessionStorage.setItem("ms.motionOverlay", on ? "1" : "0");
+      setBtn();
+      draw(last);
+    });
+    window.addEventListener("resize", () => draw(last));
+    video.addEventListener("loadedmetadata", () => draw(last));
+
+    // prefer the push stream; fall back to polling when it cannot work
+    if (window.EventSource) startPush();
+    else { fellBack = true; startPoll(); }
+
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) pause();
+      else resume();
+    });
+    window.addEventListener("pagehide", () => {
+      stopPush();
+      stopPoll();
+    });
+  }
+
+  init();
+})();

--- a/package/timps/files/www/a/preview.js
+++ b/package/timps/files/www/a/preview.js
@@ -1,0 +1,1581 @@
+const ImageBlackMode = 1;
+const ImageColorMode = 0;
+
+// preview.js talks to timps directly now (window.timpsApi); the old
+// /x/json-prudynt.cgi bridge has been removed.
+
+// The Image Quality page is NATIVE: a/streamer-image.js drives every image
+// control straight against timps's own /control API (timps-api.js), so on
+// that page this script must not touch the legacy bridge CGIs
+// (json-imaging.cgi / json-prudynt.cgi) at all - it only keeps running the
+// live preview <img>. The other streamer pages still use the bridges until
+// they are converted too.
+const nativeImagePage =
+  document.body && document.body.id === "page-streamer-image";
+
+// The per-stream OSD pages are NATIVE too: a/streamer-osd.js drives every
+// OSD control straight against timps's own /control API (timps-api.js), so
+// on those pages this script must not touch the legacy bridge CGIs either -
+// it only keeps running the live preview <img>.
+const nativeOsdPage =
+  document.body && /^page-streamer-osd[01]$/.test(document.body.id);
+
+// The encoder pages (RTSP main/substream) are NATIVE too: a/streamer-encoder.js
+// wires the stream0/stream1 controls straight to timps /control. This script
+// must NOT also wire them (that would double-submit and re-introduce the
+// bridge), so it skips the stream editor + loadConfig on those pages.
+const nativeEncoderPage =
+  document.body && /^page-streamer-(main|substream)$/.test(document.body.id);
+
+// ---- direct-to-timps media URLs (no proxy CGIs) ----
+// The settings pages' small live preview <img>, the fullscreen modal and the
+// endpoint list load timps's own HTTP media endpoints directly:
+//   live:  http://<host>:<port>/stream.mjpeg?chn=<N>&token=<tok>
+//   still: http://<host>:<port>/snapshot.jpg?chn=<N>&token=<tok>
+// /x/timps-token.cgi hands the authenticated WebUI session the per-boot
+// timps token as {"token":"...","port":8880}. The token unlocks media
+// viewing + /control + /events on that port (never RTSP) and travels as
+// ?token= because an <img> cannot send headers - it can show up in access
+// logs, which is accepted on the LAN. The token is per-boot, so it is
+// fetched once and cached; when the stream errors (e.g. 401 after a camera
+// reboot minted a new token) it is re-fetched once and the <img> retried,
+// and if the token endpoint itself is unavailable the preview falls back to
+// the nostream placeholder. Without a token the URLs still work on open
+// timps configs (empty http.user) and from localhost.
+let timpsMediaInfo = null; // {token, port} after the first fetch
+let timpsMediaPending = null; // in-flight fetch (dedup)
+
+function fetchTimpsMediaInfo(force = false) {
+  if (timpsMediaInfo && !force) return Promise.resolve(timpsMediaInfo);
+  if (!timpsMediaPending) {
+    timpsMediaPending = fetch("/x/timps-token.cgi", { cache: "no-store" })
+      .then((res) => (res.ok ? res.json() : null))
+      .catch(() => null)
+      .then((data) => {
+        timpsMediaPending = null;
+        timpsMediaInfo = {
+          token: data && data.token ? String(data.token) : "",
+          port: data && data.port ? parseInt(data.port, 10) : 8880,
+          tls: !!(data && data.tls),
+        };
+        return timpsMediaInfo;
+      });
+  }
+  return timpsMediaPending;
+}
+
+// kind "live" -> /stream.mjpeg, "still" -> /snapshot.jpg; chn is the numeric
+// timps channel (data-stream "ch0" -> 0, "ch1" -> 1). host defaults to the
+// address the WebUI itself was opened on.
+function timpsMediaUrl(kind, chn, host) {
+  const h = wrapIpv6Host(host || window.location.hostname || "127.0.0.1");
+  const port = timpsMediaInfo ? timpsMediaInfo.port : 8880;
+  const scheme = timpsMediaInfo && timpsMediaInfo.tls ? "https" : "http";
+  const path = kind === "still" ? "/snapshot.jpg" : "/stream.mjpeg";
+  let url = `${scheme}://${h}:${port}${path}?chn=${chn}`;
+  if (timpsMediaInfo && timpsMediaInfo.token) {
+    url += `&token=${encodeURIComponent(timpsMediaInfo.token)}`;
+  }
+  return url;
+}
+
+// Create fullscreen preview modal dynamically if preview element exists
+(function createPreviewModal() {
+  const preview = $("#preview");
+  if (!preview) return;
+
+  // Create modal HTML
+  const modalHTML = `
+    <div class="modal fade" id="mdPreview" tabindex="-1" aria-labelledby="mdlPreview" aria-hidden="true">
+      <div class="modal-dialog modal-fullscreen">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h1 class="modal-title fs-4" id="mdlPreview">Full screen preview</h1>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body text-center">
+            <img id="preview_fullsize" src="/a/nostream.svg" alt="Image: Stream Preview" class="img-fluid">
+          </div>
+        </div>
+      </div>
+    </div>
+  `;
+
+  // Append modal to body
+  document.body.insertAdjacentHTML("beforeend", modalHTML);
+
+  // Add click event to preview image to open modal
+  preview.addEventListener("click", () => {
+    const previewModal = new bootstrap.Modal($("#mdPreview"));
+    previewModal.show();
+  });
+})();
+
+const stream_params = [
+  "enabled",
+  "width",
+  "height",
+  "fps",
+  "bitrate",
+  "gop",
+  "max_gop",
+  "format",
+  "mode",
+  "buffers",
+  "profile",
+  "rtsp_endpoint",
+  "audio_enabled",
+];
+const osd_params = ["enabled", "fontsize", "strokesize"];
+const previewEndpointState = {
+  rtsp: {
+    username: "thingino",
+    password: "thingino",
+    port: "554",
+  },
+  stream0: {
+    rtsp_endpoint: "ch0",
+  },
+  stream1: {
+    rtsp_endpoint: "ch1",
+  },
+};
+
+function rgba2color(hex8) {
+  return hex8.substring(0, 7);
+}
+
+function rgba2alpha(hex8) {
+  const alphaHex = hex8.substring(7, 9);
+  const alpha = parseInt(alphaHex, 16);
+  return alpha;
+}
+
+// set a color picker (+ its optional "-alpha" slider) from a "#rrggbbaa"
+// value. timps OSD colors carry a real alpha byte (0xAARRGGBB), so the alpha
+// slider is populated and enabled whenever the streamer echoes 8 hex digits.
+function setOsdColorInputs(streamIndex, name, hex8) {
+  const el = $(`#osd${streamIndex}_${name}`);
+  if (el) {
+    el.value = rgba2color(hex8);
+    el.disabled = false;
+  }
+  const alphaEl = $(`#osd${streamIndex}_${name}-alpha`);
+  if (alphaEl && hex8 && hex8.length >= 9) {
+    const a = rgba2alpha(hex8);
+    if (!Number.isNaN(a)) {
+      alphaEl.value = a;
+      alphaEl.disabled = false;
+    }
+  }
+}
+
+// combined color of one picker: "#rrggbb" + alpha from its "-alpha" slider
+// ("ff" when the slider is absent or still disabled) -> "#rrggbbaa"
+function osdColorValue(streamId, base) {
+  const colorEl = $(`#osd${streamId}_${base}`);
+  const alphaEl = $(`#osd${streamId}_${base}-alpha`);
+  let a = 255;
+  if (alphaEl && !alphaEl.disabled && alphaEl.value !== "") {
+    const parsed = parseInt(alphaEl.value, 10);
+    if (!Number.isNaN(parsed)) a = Math.min(255, Math.max(0, parsed));
+  }
+  const hex = a.toString(16).padStart(2, "0");
+  return (colorEl ? colorEl.value : "#ffffff") + hex;
+}
+
+function previewEndpointValue(value, fallback) {
+  return value === undefined || value === null || value === ""
+    ? fallback
+    : value;
+}
+
+function wrapIpv6Host(host) {
+  return host && host.includes(":") && !host.startsWith("[")
+    ? `[${host}]`
+    : host;
+}
+
+function formatPreviewHostWithPort(host, port, defaultPort) {
+  const numericPort = parseInt(port, 10);
+  if (!port || Number.isNaN(numericPort) || numericPort === defaultPort) {
+    return host;
+  }
+  return `${host}:${numericPort}`;
+}
+
+function buildRtspCredential(user, pass) {
+  return `${encodeURIComponent(user)}:${encodeURIComponent(pass)}`;
+}
+
+function markPreviewEndpointCopied(link) {
+  if (!link) return;
+  link.classList.add("copied");
+  if (link._copyTimer) {
+    clearTimeout(link._copyTimer);
+  }
+  link._copyTimer = window.setTimeout(() => {
+    link.classList.remove("copied");
+    link._copyTimer = null;
+  }, 1200);
+}
+
+async function copyPreviewEndpoint(ev) {
+  ev.preventDefault();
+  const link = ev.currentTarget;
+  const url = link?.dataset?.copyUrl || link?.href || "";
+  const clipboard = window.thinginoClipboard;
+  if (!url || !clipboard || typeof clipboard.copy !== "function") {
+    if (typeof window.showAlert === "function") {
+      window.showAlert("warning", "Clipboard copy is not available.", 3000);
+    }
+    return;
+  }
+  try {
+    await clipboard.copy(url);
+    markPreviewEndpointCopied(link);
+  } catch (err) {
+    if (typeof window.showAlert === "function") {
+      window.showAlert("danger", "Unable to copy the endpoint.", 3000);
+    }
+  }
+}
+
+function renderPreviewEndpoints() {
+  const list = $("#preview-endpoint-list");
+  if (!list) return;
+  const host =
+    window.network_address || window.location.hostname || "localhost";
+  const rtspHost = formatPreviewHostWithPort(
+    wrapIpv6Host(host),
+    previewEndpointState.rtsp.port,
+    554,
+  );
+  const rtspAuth = buildRtspCredential(
+    previewEndpointState.rtsp.username,
+    previewEndpointState.rtsp.password,
+  );
+  const entries = [
+    {
+      label: "RTSP Ch0",
+      url: `rtsp://${rtspAuth}@${rtspHost}/${previewEndpointState.stream0.rtsp_endpoint}`,
+    },
+    {
+      label: "RTSP Ch1",
+      url: `rtsp://${rtspAuth}@${rtspHost}/${previewEndpointState.stream1.rtsp_endpoint}`,
+    },
+    {
+      label: "MJPEG Ch0",
+      url: timpsMediaUrl("live", 0, host),
+    },
+    {
+      label: "MJPEG Ch1",
+      url: timpsMediaUrl("live", 1, host),
+    },
+    {
+      label: "Snapshot Ch0",
+      url: timpsMediaUrl("still", 0, host),
+    },
+    {
+      label: "Snapshot Ch1",
+      url: timpsMediaUrl("still", 1, host),
+    },
+  ];
+
+  list.innerHTML = "";
+  entries.forEach((entry) => {
+    const link = document.createElement("a");
+    link.className = "preview-endpoint-link";
+    link.href = entry.url;
+    link.rel = "noopener";
+    link.dataset.copyUrl = entry.url;
+    link.title = `${entry.label}: ${entry.url}`;
+    link.setAttribute("aria-label", `${entry.label} endpoint`);
+
+    const shortLabel = document.createElement("span");
+    shortLabel.className = "preview-endpoint-short";
+    shortLabel.textContent = entry.label;
+
+    const hint = document.createElement("span");
+    hint.className = "preview-endpoint-hint";
+    hint.innerHTML = '<i class="bi bi-clipboard"></i>';
+
+    link.appendChild(shortLabel);
+    link.appendChild(hint);
+    link.addEventListener("click", copyPreviewEndpoint);
+
+    list.appendChild(link);
+  });
+}
+
+function updatePreviewEndpointState(msg) {
+  if (msg.rtsp) {
+    previewEndpointState.rtsp.username = previewEndpointValue(
+      msg.rtsp.username,
+      previewEndpointState.rtsp.username,
+    );
+    previewEndpointState.rtsp.password = previewEndpointValue(
+      msg.rtsp.password,
+      previewEndpointState.rtsp.password,
+    );
+    previewEndpointState.rtsp.port = previewEndpointValue(
+      msg.rtsp.port,
+      previewEndpointState.rtsp.port,
+    );
+  }
+  if (msg.stream0) {
+    previewEndpointState.stream0.rtsp_endpoint = previewEndpointValue(
+      msg.stream0.rtsp_endpoint,
+      previewEndpointState.stream0.rtsp_endpoint,
+    );
+  }
+  if (msg.stream1) {
+    previewEndpointState.stream1.rtsp_endpoint = previewEndpointValue(
+      msg.stream1.rtsp_endpoint,
+      previewEndpointState.stream1.rtsp_endpoint,
+    );
+  }
+  renderPreviewEndpoints();
+}
+
+async function initPreviewEndpoints() {
+  await fetchTimpsMediaInfo(); // token + port for the direct media URLs
+  renderPreviewEndpoints();
+}
+
+initPreviewEndpoints();
+
+function handleOsdData(osd, streamIndex) {
+  if (!osd) return;
+
+  if (osd.enabled !== undefined) {
+    const el = $(`#osd${streamIndex}_enabled`);
+    if (el) {
+      el.checked = osd.enabled;
+      el.disabled = false;
+    }
+  }
+  if (osd.font_size !== undefined) {
+    const el = $(`#osd${streamIndex}_fontsize`);
+    if (el) {
+      el.value = osd.font_size;
+      el.disabled = false;
+    }
+  }
+  if (osd.stroke_size !== undefined) {
+    const el = $(`#osd${streamIndex}_strokesize`);
+    if (el) {
+      el.value = osd.stroke_size;
+      el.disabled = false;
+    }
+  }
+
+  // Logo element
+  if (osd.logo) {
+    if (osd.logo.enabled !== undefined) {
+      const el = $(`#osd${streamIndex}_logo_enabled`);
+      if (el) {
+        el.checked = osd.logo.enabled;
+        el.disabled = false;
+      }
+    }
+    if (osd.logo.position !== undefined) {
+      const el = $(`#osd${streamIndex}_logo_position`);
+      if (el) {
+        el.value = osd.logo.position;
+        el.disabled = false;
+      }
+    }
+  }
+
+  // Time element
+  if (osd.time) {
+    if (osd.time.enabled !== undefined) {
+      const el = $(`#osd${streamIndex}_time_enabled`);
+      if (el) {
+        el.checked = osd.time.enabled;
+        el.disabled = false;
+      }
+    }
+    if (osd.time.format !== undefined) {
+      const el = $(`#osd${streamIndex}_time_format`);
+      if (el) {
+        el.value = osd.time.format;
+        el.disabled = false;
+      }
+    }
+    if (osd.time.position !== undefined) {
+      const el = $(`#osd${streamIndex}_time_position`);
+      if (el) {
+        el.value = osd.time.position;
+        el.disabled = false;
+      }
+    }
+    if (osd.time.fill_color) {
+      setOsdColorInputs(streamIndex, "time_fillcolor", osd.time.fill_color);
+    }
+    if (osd.time.stroke_color) {
+      setOsdColorInputs(streamIndex, "time_strokecolor", osd.time.stroke_color);
+    }
+  }
+
+  // Uptime element
+  if (osd.uptime) {
+    if (osd.uptime.enabled !== undefined) {
+      const el = $(`#osd${streamIndex}_uptime_enabled`);
+      if (el) {
+        el.checked = osd.uptime.enabled;
+        el.disabled = false;
+      }
+    }
+    if (osd.uptime.position !== undefined) {
+      const el = $(`#osd${streamIndex}_uptime_position`);
+      if (el) {
+        el.value = osd.uptime.position;
+        el.disabled = false;
+      }
+    }
+    if (osd.uptime.fill_color) {
+      setOsdColorInputs(streamIndex, "uptime_fillcolor", osd.uptime.fill_color);
+    }
+    if (osd.uptime.stroke_color) {
+      setOsdColorInputs(
+        streamIndex,
+        "uptime_strokecolor",
+        osd.uptime.stroke_color,
+      );
+    }
+  }
+
+  // Usertext element
+  if (osd.usertext) {
+    if (osd.usertext.enabled !== undefined) {
+      const el = $(`#osd${streamIndex}_usertext_enabled`);
+      if (el) {
+        el.checked = osd.usertext.enabled;
+        el.disabled = false;
+      }
+    }
+    if (osd.usertext.format !== undefined) {
+      const el = $(`#osd${streamIndex}_usertext_format`);
+      if (el) {
+        el.value = osd.usertext.format;
+        el.disabled = false;
+      }
+    }
+    if (osd.usertext.position !== undefined) {
+      const el = $(`#osd${streamIndex}_usertext_position`);
+      if (el) {
+        el.value = osd.usertext.position;
+        el.disabled = false;
+      }
+    }
+    if (osd.usertext.fill_color) {
+      setOsdColorInputs(
+        streamIndex,
+        "usertext_fillcolor",
+        osd.usertext.fill_color,
+      );
+    }
+    if (osd.usertext.stroke_color) {
+      setOsdColorInputs(
+        streamIndex,
+        "usertext_strokecolor",
+        osd.usertext.stroke_color,
+      );
+    }
+  }
+}
+
+function handleMessage(msg) {
+  if (msg.motion && msg.motion.enabled !== undefined) {
+    $("#motion").checked = msg.motion.enabled;
+  }
+  if (msg.privacy && msg.privacy.enabled !== undefined) {
+    $("#privacy").checked = msg.privacy.enabled;
+  }
+
+  // if (msg.rtsp) {
+  //   const r = msg.rtsp;
+  //   if (r.username && r.password && r.port && msg.stream0?.rtsp_endpoint)
+  //     $('#playrtsp').innerHTML = `ffplay -hide_banner -rtsp_transport tcp rtsp://${r.username}:${r.password}@${document.location.hostname}:${r.port}/${msg.stream0.rtsp_endpoint}`;
+  // }
+
+  // Handle image params
+  if (msg.image) {
+    const imageParams = [
+      "hflip",
+      "vflip",
+      "wb_bgain",
+      "wb_rgain",
+      "ae_compensation",
+      "core_wb_mode",
+    ];
+    imageParams.forEach((param) => {
+      if (msg.image[param] !== undefined) {
+        setValue(msg.image, "image", param);
+      }
+    });
+  }
+
+  // Handle stream0 params
+  if (msg.stream0) {
+    stream_params.forEach((param) => {
+      if (msg.stream0[param] !== undefined) {
+        setValue(msg.stream0, "stream0", param);
+      }
+    });
+    handleOsdData(msg.stream0.osd, 0);
+  }
+
+  // Handle stream1 params
+  if (msg.stream1) {
+    stream_params.forEach((param) => {
+      if (msg.stream1[param] !== undefined) {
+        setValue(msg.stream1, "stream1", param);
+      }
+    });
+    handleOsdData(msg.stream1.osd, 1);
+  }
+
+  // timps: encoder/stream/sensor settings are persisted but only take effect
+  // after a streamer restart; the json-prudynt.cgi bridge flags this (same
+  // hint audio.js shows; prudynt restarts its threads itself and never sets
+  // the flag). "Restart streamer" in the menu calls /x/restart-prudynt.cgi.
+  if (msg.restart_required && typeof window.showAlert === "function") {
+    window.showAlert(
+      "warning",
+      "Setting saved. Restart the streamer (Restart streamer in the menu) for it to take effect.",
+      8000,
+    );
+  }
+
+  updatePreviewEndpointState(msg);
+}
+
+async function loadMotorParams() {
+  try {
+    const response = await fetch("/x/json-motor-params.cgi");
+    const motorParams = await response.json();
+    window.motorParams = motorParams;
+    console.log("Motor parameters loaded:", motorParams);
+  } catch (error) {
+    console.error("Failed to load motor parameters:", error);
+    window.motorParams = {
+      steps_pan: 0,
+      steps_tilt: 0,
+      pos_0_x: 0,
+      pos_0_y: 0,
+    };
+  }
+}
+
+// Map a timps GET /control snapshot to the prudynt-shaped message handleMessage
+// expects (only the fields the preview page consumes: image quick controls,
+// the motion/privacy control-bar flags, and the RTSP endpoint paths for the
+// endpoint list). timps has no RTSP creds/port in /control, so those are left
+// to the existing defaults.
+function buildPreviewMsg(c) {
+  const msg = { image: {}, stream0: {}, stream1: {} };
+  if (c.image) {
+    ["hflip", "vflip", "wb_bgain", "wb_rgain", "ae_compensation", "core_wb_mode"]
+      .forEach((k) => { if (c.image[k] !== undefined) msg.image[k] = c.image[k]; });
+  }
+  if (c.motion && c.motion.enabled !== undefined)
+    msg.motion = { enabled: c.motion.enabled };
+  // privacy is per-region in timps; the control-bar flag is "on" if any mask is
+  if (c.privacy) {
+    let on = false;
+    Object.keys(c.privacy).forEach((s) =>
+      Object.keys(c.privacy[s] || {}).forEach((n) => {
+        if (Number((c.privacy[s][n] || {}).enabled)) on = true;
+      }),
+    );
+    msg.privacy = { enabled: on ? 1 : 0 };
+  }
+  if (c.video) {
+    if (c.video[0]) msg.stream0.rtsp_endpoint = c.video[0].rtsp_path;
+    if (c.video[1]) msg.stream1.rtsp_endpoint = c.video[1].rtsp_path;
+  }
+  return msg;
+}
+
+async function loadConfig() {
+  // native image/OSD/encoder pages load their own state from timps GET /control
+  // via a/streamer-image.js / a/streamer-osd.js / a/streamer-encoder.js
+  if (nativeImagePage || nativeOsdPage || nativeEncoderPage) return;
+  if (!window.timpsApi) return;
+  showBusy("Loading camera configuration...");
+  try {
+    const c = await window.timpsApi.get();
+    handleMessage(buildPreviewMsg(c));
+  } catch (err) {
+    console.error("Load config error", err);
+  } finally {
+    hideBusy();
+  }
+}
+
+// NATIVE: apply a preview-page control change through timps /control. The old
+// callers produced prudynt-shaped payloads ({image:{}}, {motion:{}},
+// {streamN:{...}}); translate the ones the preview page still uses (image is
+// the main one - WB/AE/flip quick controls). Encoder + OSD editors live on the
+// native streamer-encoder.js / streamer-osd.js pages, so their shapes only
+// arrive here as a best-effort fallback. No json-prudynt.cgi bridge.
+async function sendToEndpoint(payload) {
+  if (!window.timpsApi || !payload || typeof payload !== "object") return;
+  const out = {};
+  if (payload.image && typeof payload.image === "object") out.image = payload.image;
+  if (payload.motion && typeof payload.motion === "object") out.motion = payload.motion;
+  [0, 1].forEach((n) => {
+    const s = payload["stream" + n];
+    if (s && typeof s === "object") {
+      const v = {};
+      Object.keys(s).forEach((k) => { if (k !== "osd") v[k] = s[k]; });
+      if (Object.keys(v).length) { out.video = out.video || {}; out.video[n] = v; }
+    }
+  });
+  if (!Object.keys(out).length) return;
+  try {
+    await window.timpsApi.set(out);
+  } catch (err) {
+    console.error("Send error", err);
+  }
+}
+
+async function loadInitialData() {
+  await Promise.all([loadConfig(), loadMotorParams()]);
+}
+
+// Init on load
+loadInitialData().then(async () => {
+  // Load webui config for focus tracking settings
+  let webuiConfig = {
+    track_focus: false,
+    focus_timeout: 0,
+  };
+
+  async function loadWebuiConfig() {
+    try {
+      const response = await fetch("/x/json-config-webui.cgi", {
+        headers: { Accept: "application/json" },
+      });
+      if (response.ok) {
+        const data = await response.json();
+        webuiConfig.track_focus = data.track_focus === true;
+        webuiConfig.focus_timeout = Math.max(
+          0,
+          parseInt(data.focus_timeout) || 0,
+        );
+      }
+    } catch (err) {
+      console.warn("Could not load webui config for focus tracking:", err);
+    }
+  }
+
+  // Load webui config before continuing
+  await loadWebuiConfig();
+
+  // Expose config reload function globally for use in config-webui.js
+  window.reloadPreviewFocusSettings = async () => {
+    await loadWebuiConfig();
+    // Update event listeners based on new settings
+    if (webuiConfig.track_focus) {
+      // Add listeners if not already added
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("focus", handleWindowFocus);
+      window.removeEventListener("blur", handleWindowBlur);
+      document.addEventListener("visibilitychange", handleVisibilityChange);
+      window.addEventListener("focus", handleWindowFocus);
+      window.addEventListener("blur", handleWindowBlur);
+    } else {
+      // Remove listeners if tracking is disabled
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+      window.removeEventListener("focus", handleWindowFocus);
+      window.removeEventListener("blur", handleWindowBlur);
+      // Clear any pending timeouts
+      if (focusTimeoutId) {
+        clearTimeout(focusTimeoutId);
+        focusTimeoutId = null;
+      }
+      // Ensure window is marked as visible and start preview
+      isWindowVisible = true;
+      startPreview();
+    }
+  };
+
+  // Get stream from data-stream attribute, default to ch0 if not specified;
+  // "chN" maps to timps channel N (ch0 -> 0, ch1 -> 1)
+  const preview = $("#preview");
+  const streamChannel = preview?.dataset?.stream || "ch0";
+  const streamChn = parseInt(streamChannel.replace(/^ch/, ""), 10) || 0;
+  // live MJPEG straight from timps; the cache-bust param forces the browser
+  // to reopen the multipart stream instead of showing a stale cached frame
+  const liveStreamUrl = (chn = streamChn) =>
+    `${timpsMediaUrl("live", chn)}&_=${Date.now()}`;
+
+  // Preview
+  const timeout = 15000;
+  const restartBackoffInitialMs = 15000;
+  const restartBackoffMaxMs = 60000;
+  let lastLoadTime = Date.now();
+  let isWindowVisible = true;
+  let focusTimeoutId = null;
+  let nextRestartAt = 0;
+  let restartBackoffMs = restartBackoffInitialMs;
+  let tokenRetried = false; // one re-fetch per failure (camera rebooted?)
+
+  // the direct media URLs need the timps token/port first
+  await fetchTimpsMediaInfo();
+
+  // Function to start the preview stream
+  function startPreview() {
+    if (focusTimeoutId) {
+      clearTimeout(focusTimeoutId);
+      focusTimeoutId = null;
+    }
+    if (isWindowVisible) {
+      preview.src = liveStreamUrl();
+      lastLoadTime = Date.now();
+      nextRestartAt = 0;
+    }
+  }
+  // let main.js's visibility handling restart the stream on any page
+  window.restartStreamPreview = startPreview;
+
+  // Function to stop the preview stream
+  function stopPreview() {
+    if (focusTimeoutId) {
+      clearTimeout(focusTimeoutId);
+      focusTimeoutId = null;
+    }
+    preview.src = ImageNoStream;
+    nextRestartAt = 0;
+  }
+
+  // Function to stop preview with delay
+  function stopPreviewWithDelay() {
+    if (!webuiConfig.track_focus) {
+      return; // Don't stop if tracking is disabled
+    }
+
+    if (focusTimeoutId) {
+      clearTimeout(focusTimeoutId);
+    }
+
+    if (webuiConfig.focus_timeout > 0) {
+      focusTimeoutId = setTimeout(() => {
+        if (!isWindowVisible) {
+          stopPreview();
+        }
+      }, webuiConfig.focus_timeout * 1000);
+    } else {
+      stopPreview();
+    }
+  }
+
+  // Start the preview stream
+  startPreview();
+
+  // preview.src comes back absolutized by the browser, so compare by suffix
+  const showsNoStream = () => (preview.src || "").endsWith(ImageNoStream);
+
+  preview.addEventListener("load", () => {
+    lastLoadTime = Date.now();
+    restartBackoffMs = restartBackoffInitialMs;
+    nextRestartAt = 0;
+    if (!showsNoStream()) tokenRetried = false;
+  });
+
+  // Stream error (connection refused / 401): the per-boot token changes on
+  // a camera reboot, so re-fetch it once and retry; if the stream still
+  // fails, fall back to the nostream placeholder (the watchdog keeps
+  // retrying with backoff).
+  preview.addEventListener("error", () => {
+    if (!isWindowVisible || showsNoStream() || !preview.src) return;
+    if (tokenRetried) {
+      preview.src = ImageNoStream;
+      return;
+    }
+    tokenRetried = true;
+    fetchTimpsMediaInfo(true).then(() => {
+      if (isWindowVisible) preview.src = liveStreamUrl();
+    });
+  });
+
+  // Stream watchdog - restart if no frames received
+  setInterval(() => {
+    const now = Date.now();
+    if (
+      isWindowVisible &&
+      now - lastLoadTime > timeout &&
+      now >= nextRestartAt
+    ) {
+      // Restart stream (fresh cache-bust + current token)
+      preview.src = liveStreamUrl();
+      lastLoadTime = now;
+      nextRestartAt = now + restartBackoffMs;
+      restartBackoffMs = Math.min(restartBackoffMs * 2, restartBackoffMaxMs);
+    }
+  }, 1000);
+
+  // Handle window visibility changes
+  function handleVisibilityChange() {
+    if (document.hidden) {
+      isWindowVisible = false;
+      stopPreview();
+    } else {
+      isWindowVisible = true;
+      startPreview();
+    }
+  }
+
+  // Handle window focus/blur events
+  function handleWindowFocus() {
+    isWindowVisible = true;
+    startPreview();
+  }
+
+  function handleWindowBlur() {
+    isWindowVisible = false;
+    stopPreviewWithDelay();
+  }
+
+  window.addEventListener("beforeunload", stopPreview);
+  window.addEventListener("pagehide", stopPreview);
+
+  // Add event listeners for visibility changes only if tracking is enabled
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+
+  if (webuiConfig.track_focus) {
+    window.addEventListener("focus", handleWindowFocus);
+    window.addEventListener("blur", handleWindowBlur);
+  }
+
+  // Full-screen preview modal
+  const previewModal = $("#mdPreview");
+  const previewFullsize = $("#preview_fullsize");
+  let savedPreviewSrc = "";
+
+  if (previewModal && previewFullsize) {
+    previewModal.addEventListener("show.bs.modal", () => {
+      // Save current small preview source
+      savedPreviewSrc = preview.src;
+      // Stop the small preview
+      preview.src = ImageNoStream;
+      // Load main stream (ch0) in full-screen modal, straight from timps
+      previewFullsize.src = liveStreamUrl(0);
+    });
+
+    previewModal.addEventListener("hidden.bs.modal", () => {
+      // Stop the full-screen stream
+      previewFullsize.src = ImageNoStream;
+      // Restart the small preview (fresh cache-bust + current token)
+      if (savedPreviewSrc && isWindowVisible) {
+        startPreview();
+      }
+    });
+  }
+});
+
+const imagingFields = [
+  "brightness",
+  "contrast",
+  "sharpness",
+  "saturation",
+  "backlight",
+  "wide_dynamic_range",
+  "tone",
+  "defog",
+  "noise_reduction",
+];
+
+const imageConfigKeyMap = {
+  brightness: "brightness",
+  contrast: "contrast",
+  sharpness: "sharpness",
+  saturation: "saturation",
+  backlight: "backlight_compensation",
+  wide_dynamic_range: "drc_strength",
+  tone: "highlight_depress",
+  defog: "defog_strength",
+  noise_reduction: "sinter_strength",
+};
+
+// Static per-field bounds, ported from the old json-imaging.cgi bridge (min 0,
+// max 255 except backlight 10; default 128 except backlight/tone 0). timps
+// GET /control reports the live value + caps.image (supported), but not the
+// UI bounds, so they live here now.
+const imageFieldBounds = {
+  brightness: { min: 0, max: 255, default: 128 },
+  contrast: { min: 0, max: 255, default: 128 },
+  sharpness: { min: 0, max: 255, default: 128 },
+  saturation: { min: 0, max: 255, default: 128 },
+  backlight: { min: 0, max: 10, default: 0 },
+  wide_dynamic_range: { min: 0, max: 255, default: 128 },
+  tone: { min: 0, max: 255, default: 0 },
+  defog: { min: 0, max: 255, default: 128 },
+  noise_reduction: { min: 0, max: 255, default: 128 },
+};
+
+const previewSliderIds = [
+  "brightness",
+  "contrast",
+  "sharpness",
+  "saturation",
+  "backlight",
+  "wide_dynamic_range",
+  "tone",
+  "defog",
+  "noise_reduction",
+  "image_wb_bgain",
+  "image_wb_rgain",
+  "image_ae_compensation",
+  "stream0_fps",
+  "stream1_fps",
+];
+
+(function initPreviewSliders() {
+  if (
+    typeof window === "undefined" ||
+    typeof window.initSliders !== "function"
+  ) {
+    return;
+  }
+  const run = () => window.initSliders(previewSliderIds);
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", () => run(), { once: true });
+  } else {
+    run();
+  }
+})();
+
+// Load sensor information on sensor page
+(function loadSensorInfo() {
+  if (!$("#sensor-info")) {
+    return; // Not on sensor page
+  }
+
+  const sensorLoading = $("#sensor-loading");
+  const sensorDetails = $("#sensor-details");
+  const sensorFilePath = $("#sensor-file-path");
+  const sensorMd5 = $("#sensor-md5");
+  const sensorSocFamily = $("#sensor-soc-family");
+  const sensorModel = $("#sensor-model");
+
+  async function fetchSensorInfo() {
+    try {
+      const response = await fetch("/x/json-sensor-info.cgi");
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = await response.json();
+
+      if (data.error) {
+        throw new Error(data.error.message || "Unknown error");
+      }
+
+      sensorFilePath.textContent = data.file_path || "Unknown";
+      sensorMd5.textContent = data.md5 || "Unknown";
+      if (sensorSocFamily)
+        sensorSocFamily.textContent = data.soc_family || "Unknown";
+      if (sensorModel) sensorModel.textContent = data.sensor_model || "Unknown";
+
+      sensorLoading.classList.add("d-none");
+      sensorDetails.classList.remove("d-none");
+    } catch (err) {
+      sensorLoading.textContent = `Error loading sensor info: ${err.message}`;
+    }
+  }
+
+  fetchSensorInfo();
+})();
+
+// Disable all imaging controls initially. Prefer the field's own <p> wrapper
+// so a single unsupported control never greys out a whole column.
+imagingFields.forEach((field) => {
+  const input = $(`#${field}`);
+  if (input) {
+    input.disabled = true;
+    const wrapper = input.closest("p, .number-range, .col");
+    if (wrapper) wrapper.classList.add("disabled");
+  }
+  // Also disable the modal slider if it exists
+  const slider = $(`#${field}-slider`);
+  if (slider) slider.disabled = true;
+});
+
+function updateImagingLabel(name, value) {
+  const input = $(`#${name}`);
+  if (input) {
+    input.value = value === undefined || value === null ? "" : value;
+  }
+  // Also update the slider value display in modal
+  const sliderValue = $(`#${name}-slider-value`);
+  if (sliderValue) {
+    const displayValue = value === undefined || value === null ? "—" : value;
+    sliderValue.textContent = displayValue;
+  }
+  // Update the actual slider
+  const slider = $(`#${name}-slider`);
+  if (slider && value !== undefined && value !== null) {
+    slider.value = value;
+  }
+}
+
+function setSliderBounds(input, slider, min, max, value, defaultValue) {
+  if (Number.isFinite(min)) {
+    if (input) input.dataset.min = min;
+    if (slider) slider.min = min;
+  }
+  if (Number.isFinite(max)) {
+    if (input) input.dataset.max = max;
+    if (slider) slider.max = max;
+  }
+  if (Number.isFinite(value)) {
+    if (input) input.value = value;
+    if (slider) slider.value = value;
+  }
+  if (Number.isFinite(defaultValue)) {
+    if (input) input.dataset.defaultValue = defaultValue;
+    if (slider) slider.dataset.defaultValue = defaultValue;
+  } else {
+    if (input) delete input.dataset.defaultValue;
+    if (slider) delete slider.dataset.defaultValue;
+  }
+}
+
+function applyFieldMetadata(field, data) {
+  const input = $(`#${field}`);
+  const slider = $(`#${field}-slider`);
+  if (!input) return;
+  const wrapper =
+    input.closest("p, .number-range, .col") || input.parentElement;
+  const isSupported = data && data.supported !== false;
+  if (!isSupported) {
+    input.disabled = true;
+    if (slider) slider.disabled = true;
+    if (wrapper) wrapper.classList.add("disabled");
+    delete input.dataset.defaultValue;
+    if (slider) delete slider.dataset.defaultValue;
+    updateImagingLabel(field, "—");
+    return;
+  }
+  input.disabled = false;
+  if (slider) slider.disabled = false;
+  if (wrapper) wrapper.classList.remove("disabled");
+  setSliderBounds(
+    input,
+    slider,
+    Number(data.min),
+    Number(data.max),
+    Number(data.value),
+    Number(data.default),
+  );
+  updateImagingLabel(field, data.value);
+}
+
+// NATIVE: read the live image values from timps GET /control (no
+// json-imaging.cgi bridge). Enable a field only when its timps key is in
+// caps.image; bounds come from the static imageFieldBounds table.
+async function fetchImagingState() {
+  if (!window.timpsApi) return;
+  showBusy("Loading imaging settings...");
+  try {
+    const json = await window.timpsApi.get();
+    const image = json.image || {};
+    const caps = (json.caps && json.caps.image) || [];
+    imagingFields.forEach((field) => {
+      const key = imageConfigKeyMap[field];
+      const b = imageFieldBounds[field] || { min: 0, max: 255, default: 128 };
+      const value = image[key];
+      applyFieldMetadata(field, {
+        supported: caps.indexOf(key) >= 0,
+        min: b.min,
+        max: b.max,
+        default: b.default,
+        value: value === undefined || value === null ? b.default : value,
+      });
+    });
+  } catch (err) {
+    console.warn("Unable to load imaging state", err);
+  } finally {
+    hideBusy();
+  }
+}
+
+// NATIVE: apply a changed field straight to timps /control (debounced; the
+// single noise-reduction knob drives both ISP noise reducers). timps applies
+// live AND persists immediately.
+async function sendImagingUpdate(field, value, element) {
+  const key = imageConfigKeyMap[field];
+  if (!key || !window.timpsApi) return;
+  const b = imageFieldBounds[field] || { min: 0, max: 255, default: 128 };
+  let v = parseInt(value, 10);
+  if (Number.isNaN(v)) return;
+  v = Math.max(b.min, Math.min(b.max, v));
+  const image = { [key]: v };
+  if (key === "sinter_strength") image.temper_strength = v;
+  element?.setAttribute("data-busy", "1");
+  element?.classList.add("opacity-75");
+  try {
+    await window.timpsApi.setDebounced({ image }, 150);
+    applyFieldMetadata(field, {
+      supported: true,
+      min: b.min,
+      max: b.max,
+      default: b.default,
+      value: v,
+    });
+  } catch (err) {
+    console.error("Failed to update imaging value", err);
+  } finally {
+    element?.removeAttribute("data-busy");
+    element?.classList.remove("opacity-75");
+  }
+}
+
+// Setup event handlers for imaging fields (number inputs and modal sliders).
+// Skipped on the native image page: a/streamer-image.js wires these controls
+// to timps /control directly (this handler would POST to json-imaging.cgi).
+if (!nativeImagePage)
+imagingFields.forEach((field) => {
+  const input = $(`#${field}`);
+  const slider = $(`#${field}-slider`);
+
+  // Handle text input changes
+  if (input) {
+    input.addEventListener("change", (ev) => {
+      const value = parseInt(ev.target.value);
+      if (!isNaN(value)) {
+        sendImagingUpdate(field, value, ev.target);
+      }
+    });
+
+    // Double-click on input to reset to default
+    input.addEventListener("dblclick", (ev) => {
+      const min = Number(ev.target.dataset.min ?? 0);
+      const max = Number(ev.target.dataset.max ?? 255);
+      const midpoint = Math.round((min + max) / 2);
+      const defaultValue = ev.target.dataset.defaultValue;
+      const targetValue = Number.isFinite(Number(defaultValue))
+        ? Number(defaultValue)
+        : midpoint;
+      ev.target.value = targetValue;
+      updateImagingLabel(field, targetValue);
+      sendImagingUpdate(field, targetValue, ev.target);
+    });
+  }
+
+  // Handle modal slider input (live update)
+  if (slider) {
+    slider.addEventListener("input", (ev) => {
+      updateImagingLabel(field, ev.target.value);
+    });
+
+    // Handle slider change (on release)
+    slider.addEventListener("change", (ev) => {
+      const value = parseInt(ev.target.value);
+      if (!isNaN(value)) {
+        sendImagingUpdate(field, value, ev.target);
+      }
+    });
+
+    // Double-click on slider to reset to default
+    slider.addEventListener("dblclick", (ev) => {
+      const min = Number(ev.target.min ?? 0);
+      const max = Number(ev.target.max ?? 255);
+      const midpoint = Math.round((min + max) / 2);
+      const defaultValue = ev.target.dataset.defaultValue;
+      const targetValue = Number.isFinite(Number(defaultValue))
+        ? Number(defaultValue)
+        : midpoint;
+      ev.target.value = targetValue;
+      updateImagingLabel(field, targetValue);
+      sendImagingUpdate(field, targetValue, ev.target);
+    });
+  }
+});
+
+// Streamer controls
+function coerceStreamValue(param, el) {
+  if (el.type === "checkbox") {
+    return el.checked;
+  }
+
+  const raw = typeof el.value === "string" ? el.value : "";
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    return "";
+  }
+
+  // Treat any purely numeric string as a number so prudynt gets the correct type.
+  if (/^-?\d+(?:\.\d+)?$/.test(trimmed)) {
+    return trimmed.includes(".")
+      ? Number.parseFloat(trimmed)
+      : Number.parseInt(trimmed, 10);
+  }
+
+  return trimmed;
+}
+
+function saveStreamValue(streamId, param) {
+  const el = $(`#stream${streamId}_${param}`);
+  if (!el) return;
+  const value = coerceStreamValue(param, el);
+  const payload = {
+    [`stream${streamId}`]: { [param]: value },
+    action: { restart_thread: ThreadRtsp | ThreadVideo },
+  };
+  sendToEndpoint(payload);
+}
+
+// Setup stream0 and stream1 controls. Skipped on the native encoder pages
+// (streamer-main/substream): a/streamer-encoder.js wires these controls to
+// timps /control directly, so this must not also wire them (double submit +
+// bridge). On other pages there are no stream fields, so this is inert.
+if (!nativeEncoderPage)
+[0, 1].forEach((streamId) => {
+  stream_params.forEach((param) => {
+    const el = $(`#stream${streamId}_${param}`);
+    if (el) {
+      el.addEventListener("change", () => saveStreamValue(streamId, param));
+      el.disabled = true;
+    }
+
+    // Also handle modal slider if it exists
+    const slider = $(`#stream${streamId}_${param}-slider`);
+    if (slider) {
+      slider.addEventListener("input", (ev) => {
+        // Update the text input while dragging
+        if (el) el.value = ev.target.value;
+        const sliderValue = $(`#stream${streamId}_${param}-slider-value`);
+        if (sliderValue) sliderValue.textContent = ev.target.value;
+      });
+      slider.addEventListener("change", () => saveStreamValue(streamId, param));
+      slider.disabled = true;
+    }
+  });
+});
+
+// OSD controls
+function sendOsdUpdate(streamId, osdPayload) {
+  // OSD changes require Video + OSD thread restart to take effect immediately
+  const payload = {
+    [`stream${streamId}`]: { osd: osdPayload },
+    action: { restart_thread: ThreadVideo | ThreadOSD },
+  };
+  sendToEndpoint(payload);
+}
+
+function setFont(streamId) {
+  const fontSizeInput = $(`#osd${streamId}_fontsize`);
+  const strokeSizeInput = $(`#osd${streamId}_strokesize`);
+  if (!fontSizeInput || !strokeSizeInput) return;
+
+  const payload = {};
+
+  const fontSize = Number(fontSizeInput.value);
+  if (!Number.isNaN(fontSize)) {
+    payload.font_size = fontSize;
+  }
+
+  const strokeSize = Number(strokeSizeInput.value);
+  if (!Number.isNaN(strokeSize)) {
+    payload.stroke_size = strokeSize;
+  }
+
+  if (Object.keys(payload).length === 0) return;
+  console.log(ts(), "setFont for stream", streamId, ":", payload);
+  // Font changes require Video + OSD thread restart for immediate effect
+  const fullPayload = {
+    [`stream${streamId}`]: { osd: payload },
+    action: { restart_thread: ThreadVideo | ThreadOSD },
+  };
+  sendToEndpoint(fullPayload);
+}
+
+// Setup OSD controls for both stream0 and stream1. Skipped on the native
+// OSD pages: a/streamer-osd.js wires these controls to timps /control
+// directly (these handlers would POST to the json-prudynt.cgi bridge).
+if (!nativeOsdPage)
+[0, 1].forEach((streamId) => {
+  // Configuration for OSD controls
+  const osdControls = [
+    {
+      id: "enabled",
+      handler: (e) => sendOsdUpdate(streamId, { enabled: e.target.checked }),
+    },
+    { id: "fontsize", handler: () => setFont(streamId) },
+    { id: "strokesize", handler: () => setFont(streamId) },
+    {
+      id: "logo_enabled",
+      handler: (e) =>
+        sendOsdUpdate(streamId, { logo: { enabled: e.target.checked } }),
+    },
+    {
+      id: "logo_position",
+      handler: (e) =>
+        sendOsdUpdate(streamId, { logo: { position: e.target.value } }),
+    },
+    {
+      id: "time_enabled",
+      handler: (e) =>
+        sendOsdUpdate(streamId, { time: { enabled: e.target.checked } }),
+    },
+    {
+      id: "time_format",
+      handler: (e) =>
+        sendOsdUpdate(streamId, { time: { format: e.target.value } }),
+    },
+    {
+      id: "time_position",
+      handler: (e) =>
+        sendOsdUpdate(streamId, { time: { position: e.target.value } }),
+    },
+    {
+      id: "time_fillcolor",
+      handler: () =>
+        sendOsdUpdate(streamId, {
+          time: { fill_color: osdColorValue(streamId, "time_fillcolor") },
+        }),
+    },
+    {
+      id: "time_fillcolor-alpha",
+      handler: () =>
+        sendOsdUpdate(streamId, {
+          time: { fill_color: osdColorValue(streamId, "time_fillcolor") },
+        }),
+    },
+    {
+      id: "time_strokecolor",
+      handler: () =>
+        sendOsdUpdate(streamId, {
+          time: { stroke_color: osdColorValue(streamId, "time_strokecolor") },
+        }),
+    },
+    {
+      id: "time_strokecolor-alpha",
+      handler: () =>
+        sendOsdUpdate(streamId, {
+          time: { stroke_color: osdColorValue(streamId, "time_strokecolor") },
+        }),
+    },
+    {
+      id: "uptime_enabled",
+      handler: (e) =>
+        sendOsdUpdate(streamId, { uptime: { enabled: e.target.checked } }),
+    },
+    {
+      id: "uptime_position",
+      handler: (e) =>
+        sendOsdUpdate(streamId, { uptime: { position: e.target.value } }),
+    },
+    {
+      id: "uptime_fillcolor",
+      handler: () =>
+        sendOsdUpdate(streamId, {
+          uptime: { fill_color: osdColorValue(streamId, "uptime_fillcolor") },
+        }),
+    },
+    {
+      id: "uptime_fillcolor-alpha",
+      handler: () =>
+        sendOsdUpdate(streamId, {
+          uptime: { fill_color: osdColorValue(streamId, "uptime_fillcolor") },
+        }),
+    },
+    {
+      id: "uptime_strokecolor",
+      handler: () =>
+        sendOsdUpdate(streamId, {
+          uptime: {
+            stroke_color: osdColorValue(streamId, "uptime_strokecolor"),
+          },
+        }),
+    },
+    {
+      id: "uptime_strokecolor-alpha",
+      handler: () =>
+        sendOsdUpdate(streamId, {
+          uptime: {
+            stroke_color: osdColorValue(streamId, "uptime_strokecolor"),
+          },
+        }),
+    },
+    {
+      id: "usertext_enabled",
+      handler: (e) =>
+        sendOsdUpdate(streamId, { usertext: { enabled: e.target.checked } }),
+    },
+    {
+      id: "usertext_format",
+      handler: (e) =>
+        sendOsdUpdate(streamId, { usertext: { format: e.target.value } }),
+    },
+    {
+      id: "usertext_position",
+      handler: (e) =>
+        sendOsdUpdate(streamId, { usertext: { position: e.target.value } }),
+    },
+    {
+      id: "usertext_fillcolor",
+      handler: () =>
+        sendOsdUpdate(streamId, {
+          usertext: {
+            fill_color: osdColorValue(streamId, "usertext_fillcolor"),
+          },
+        }),
+    },
+    {
+      id: "usertext_fillcolor-alpha",
+      handler: () =>
+        sendOsdUpdate(streamId, {
+          usertext: {
+            fill_color: osdColorValue(streamId, "usertext_fillcolor"),
+          },
+        }),
+    },
+    {
+      id: "usertext_strokecolor",
+      handler: () =>
+        sendOsdUpdate(streamId, {
+          usertext: {
+            stroke_color: osdColorValue(streamId, "usertext_strokecolor"),
+          },
+        }),
+    },
+    {
+      id: "usertext_strokecolor-alpha",
+      handler: () =>
+        sendOsdUpdate(streamId, {
+          usertext: {
+            stroke_color: osdColorValue(streamId, "usertext_strokecolor"),
+          },
+        }),
+    },
+  ];
+
+  // Fields start disabled and are only re-enabled when the streamer's echo
+  // contains them. The timps json-prudynt.cgi bridge echoes each stream's
+  // OWN overlay set (timps keeps them per-stream) including
+  // stroke_size/stroke_color (mapped to the timps text outline), so all
+  // controls un-grey. With prudynt every field is echoed as before.
+  osdControls.forEach(({ id, handler }) => {
+    const el = $(`#osd${streamId}_${id}`);
+    if (el) {
+      el.addEventListener("change", handler);
+      el.disabled = true;
+    }
+  });
+});
+
+// Image controls (WB and AE)
+function saveImageValue(param) {
+  const el = $("#image_" + param);
+  if (!el) return;
+
+  let value;
+  if (el.type === "checkbox") {
+    value = el.checked;
+  } else if (el.type === "select-one") {
+    value = parseInt(el.value);
+  } else {
+    value = parseInt(el.value);
+  }
+
+  const payload = { image: { [param]: value } };
+  console.log(ts(), "Sending image param:", param, "=", value);
+  sendToEndpoint(payload);
+}
+
+const imageParams = [
+  "hflip",
+  "vflip",
+  "wb_bgain",
+  "wb_rgain",
+  "ae_compensation",
+  "core_wb_mode",
+];
+imageParams.forEach((param) => {
+  const el = $("#image_" + param);
+  if (el) {
+    // native image page: a/streamer-image.js owns these controls (they go
+    // straight to timps /control, not through the json-prudynt.cgi bridge)
+    if (nativeImagePage) return;
+    el.addEventListener("change", () => {
+      console.log("Image param changed:", param);
+      saveImageValue(param);
+    });
+    // Disabled until the streamer's echo confirms the key: the timps
+    // json-prudynt.cgi bridge only echoes image.* keys listed in the
+    // caps.image capability array of GET /control, so controls the SoC
+    // cannot drive never get re-enabled by setValue().
+    el.disabled = true;
+    const wrapper = el.closest(
+      ".range, .number-range, .number, .select, .boolean, .file",
+    );
+    if (wrapper) wrapper.classList.add("disabled");
+  }
+});
+
+// Export configuration button
+const exportConfigBtn = $("#export-config");
+if (exportConfigBtn) {
+  exportConfigBtn.addEventListener("click", async () => {
+    exportConfigBtn.disabled = true;
+    try {
+      // NATIVE: download the live timps /control snapshot as JSON (no
+      // json-prudynt-config.cgi bridge).
+      const json = window.timpsApi ? await window.timpsApi.get() : {};
+      const blob = new Blob([JSON.stringify(json, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "timps-control.json";
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      console.error("Export failed", err);
+    } finally {
+      exportConfigBtn.disabled = false;
+    }
+  });
+}
+
+// Save configuration button. timps persists every /control change to
+// /etc/timps.conf immediately, so there is nothing to save explicitly - the
+// button just confirms (no json-prudynt.cgi bridge).
+const saveConfigBtn = $("#save-config");
+if (saveConfigBtn) {
+  saveConfigBtn.addEventListener("click", () => {
+    if (typeof window.showAlert === "function") {
+      window.showAlert(
+        "success",
+        "Nothing to do: settings are applied live and already saved to the streamer configuration.",
+        4000,
+      );
+    } else {
+      alert("Settings are applied live and already saved to the streamer configuration.");
+    }
+  });
+}
+
+// native image/OSD pages: the page scripts load their state from timps
+// GET /control instead of the json-imaging.cgi bridge (the OSD pages have
+// no imaging fields at all - skip the pointless bridge call there too)
+if (!nativeImagePage && !nativeOsdPage) fetchImagingState();
+
+// Add reload button handler
+const reloadBtn = $("#preview-reload");
+if (reloadBtn) {
+  reloadBtn.addEventListener("click", () => {
+    Promise.all([loadConfig(), loadMotorParams()]).then(() => {
+      console.log("Configuration and motor parameters reloaded");
+    });
+  });
+}

--- a/package/timps/files/www/a/privacy.js
+++ b/package/timps/files/www/a/privacy.js
@@ -1,0 +1,314 @@
+/* privacy.js - NATIVE privacy-mask VISUAL editor. Talks directly to the timps
+ * streamer over window.timpsApi (GET/POST /control, per-boot token) - no bridge.
+ *
+ * Privacy masks are solid cover rectangles per video stream (timps "privacy"
+ * section: privacy<S>.<N>.{enabled,x,y,w,h,color}, caps.privacy = {available,
+ * max_regions}). This page shows a live snapshot of the selected stream and
+ * lets you drag/resize the mask rectangles directly on it; every change is
+ * applied LIVE via timpsApi.set({privacy:{<s>:{<n>:{...}}}}). A side list gives
+ * per-mask enable / colour / alpha / exact coordinates / delete.
+ *
+ * Coordinates are the stream's own pixels; the editor scales them to the
+ * displayed snapshot. Dependency-free, pointer events (mouse + touch).
+ */
+(function () {
+  "use strict";
+
+  if (!document.body || document.body.id !== "page-config-privacy") return;
+
+  var MIN = 8;                 // smallest mask edge, stream px
+  var maxRegions = 4;
+  var streamIdx = 0;
+  var streamW = 1920, streamH = 1080;
+  var regions = [];            // [{enabled,x,y,w,h,color}] in STREAM coords
+  var selected = -1;
+
+  var stage = document.getElementById("pm-stage");
+  var img = document.getElementById("pm-img");
+  var noimg = document.getElementById("pm-noimg");
+  var list = document.getElementById("pm-list");
+  var streamSel = document.getElementById("pm-stream");
+  var addBtn = document.getElementById("pm-add");
+  var reloadBtn = document.getElementById("pm-reload");
+
+  function toast(type, msg, ms) {
+    if (typeof window.showAlert === "function") window.showAlert(type, msg, ms);
+    else console.log("[privacy]", type + ":", msg);
+  }
+
+  // timps color 0xAARRGGBB <-> {rgb:"#RRGGBB", alpha:0..255}
+  function colorToTimps(rgb, alpha) {
+    var m = /^#([0-9a-fA-F]{6})$/.exec(String(rgb || ""));
+    var body = m ? m[1].toUpperCase() : "000000";
+    var a = Math.max(0, Math.min(255, parseInt(alpha, 10)));
+    if (isNaN(a)) a = 255;
+    return "0x" + a.toString(16).padStart(2, "0").toUpperCase() + body;
+  }
+  function colorFromTimps(v) {
+    var m = /^0x([0-9a-fA-F]{2})([0-9a-fA-F]{6})$/.exec(String(v || ""));
+    if (!m) return { rgb: "#000000", alpha: 255 };
+    return { rgb: "#" + m[2].toUpperCase(), alpha: parseInt(m[1], 16) };
+  }
+
+  function scale() {
+    var dw = img.clientWidth || stage.clientWidth || 1;
+    var dh = img.clientHeight || (dw * streamH / streamW);
+    return { sx: dw / streamW, sy: dh / streamH, dw: dw, dh: dh };
+  }
+
+  function clampRegion(r) {
+    r.w = Math.max(MIN, Math.min(streamW, Math.round(r.w)));
+    r.h = Math.max(MIN, Math.min(streamH, Math.round(r.h)));
+    r.x = Math.max(0, Math.min(streamW - r.w, Math.round(r.x)));
+    r.y = Math.max(0, Math.min(streamH - r.h, Math.round(r.y)));
+  }
+
+  function send(n) {
+    var r = regions[n];
+    var payload = {}; payload[streamIdx] = {};
+    payload[streamIdx][n] = {
+      enabled: r.enabled ? 1 : 0,
+      x: r.x, y: r.y, w: r.w, h: r.h, color: r.color,
+    };
+    window.timpsApi.set({ privacy: payload }).catch(function (err) {
+      console.error("privacy set failed:", err);
+      toast("danger", "Failed to update mask: " + (err.message || err));
+    });
+  }
+
+  /* ---- rendering ---- */
+
+  function renderBoxes() {
+    // drop existing boxes (keep img + noimg)
+    Array.prototype.slice.call(stage.querySelectorAll(".pm-box")).forEach(function (b) { b.remove(); });
+    var s = scale();
+    regions.forEach(function (r, n) {
+      if (!r.enabled || r.w <= 0 || r.h <= 0) return;
+      var box = document.createElement("div");
+      box.className = "pm-box" + (n === selected ? " sel" : "");
+      box.dataset.n = String(n);
+      positionBox(box, r, s);
+      box.innerHTML =
+        '<span class="pm-tag">Mask ' + (n + 1) + "</span>" +
+        '<div class="pm-handle"></div>';
+      stage.appendChild(box);
+      wireBox(box, n);
+    });
+  }
+
+  function positionBox(box, r, s) {
+    box.style.left = r.x * s.sx + "px";
+    box.style.top = r.y * s.sy + "px";
+    box.style.width = r.w * s.sx + "px";
+    box.style.height = r.h * s.sy + "px";
+  }
+
+  function renderList() {
+    list.innerHTML = "";
+    regions.forEach(function (r, n) {
+      var c = colorFromTimps(r.color);
+      var card = document.createElement("div");
+      card.className = "card mb-2" + (n === selected ? " border-warning" : "");
+      card.innerHTML =
+        '<div class="card-body p-2">' +
+        '<div class="d-flex align-items-center gap-2 mb-1">' +
+        '<div class="form-check form-switch mb-0">' +
+        '<input class="form-check-input" type="checkbox" id="pm-en-' + n + '"' + (r.enabled ? " checked" : "") + ">" +
+        '<label class="form-check-label small" for="pm-en-' + n + '">Mask ' + (n + 1) + "</label></div>" +
+        '<input type="color" class="form-control form-control-color form-control-sm" id="pm-col-' + n + '" value="' + c.rgb + '" title="Fill color">' +
+        '<input type="number" class="form-control form-control-sm" style="max-width:5rem" id="pm-al-' + n + '" min="0" max="255" value="' + c.alpha + '" title="Alpha">' +
+        '<button type="button" class="btn btn-outline-danger btn-sm ms-auto" id="pm-del-' + n + '" title="Disable mask"><i class="bi bi-trash"></i></button>' +
+        "</div>" +
+        '<div class="row g-1">' +
+        coord("pm-x-" + n, "X", r.x) + coord("pm-y-" + n, "Y", r.y) +
+        coord("pm-w-" + n, "W", r.w) + coord("pm-h-" + n, "H", r.h) +
+        "</div></div>";
+      list.appendChild(card);
+      wireListRow(n);
+    });
+  }
+
+  function coord(id, label, val) {
+    return '<div class="col-3"><label class="form-label small mb-0" for="' + id + '">' + label +
+      '</label><input type="number" min="0" class="form-control form-control-sm" id="' + id + '" value="' + val + '"></div>';
+  }
+
+  function render() {
+    renderBoxes();
+    renderList();
+  }
+
+  /* ---- interaction: drag to move, corner handle to resize ---- */
+
+  function wireBox(box, n) {
+    box.addEventListener("pointerdown", function (ev) {
+      if (ev.target.classList.contains("pm-handle")) return; // handled below
+      startDrag(ev, n, "move");
+    });
+    var handle = box.querySelector(".pm-handle");
+    handle.addEventListener("pointerdown", function (ev) {
+      ev.stopPropagation();
+      startDrag(ev, n, "resize");
+    });
+  }
+
+  function startDrag(ev, n, mode) {
+    ev.preventDefault();
+    select(n);
+    var s = scale();
+    var r = regions[n];
+    var start = { px: ev.clientX, py: ev.clientY, x: r.x, y: r.y, w: r.w, h: r.h };
+    var box = stage.querySelector('.pm-box[data-n="' + n + '"]');
+    try { ev.target.setPointerCapture(ev.pointerId); } catch (e) { /* ok */ }
+
+    function move(e) {
+      var ddx = (e.clientX - start.px) / s.sx;
+      var ddy = (e.clientY - start.py) / s.sy;
+      if (mode === "move") { r.x = start.x + ddx; r.y = start.y + ddy; }
+      else { r.w = start.w + ddx; r.h = start.h + ddy; }
+      clampRegion(r);
+      if (box) positionBox(box, r, s);
+      syncCoordInputs(n);
+    }
+    function up(e) {
+      window.removeEventListener("pointermove", move);
+      window.removeEventListener("pointerup", up);
+      try { ev.target.releasePointerCapture(e.pointerId); } catch (er) { /* ok */ }
+      send(n);
+    }
+    window.addEventListener("pointermove", move);
+    window.addEventListener("pointerup", up);
+  }
+
+  function syncCoordInputs(n) {
+    var r = regions[n];
+    setVal("pm-x-" + n, r.x); setVal("pm-y-" + n, r.y);
+    setVal("pm-w-" + n, r.w); setVal("pm-h-" + n, r.h);
+  }
+  function setVal(id, v) { var el = document.getElementById(id); if (el) el.value = v; }
+
+  function select(n) {
+    selected = n;
+    Array.prototype.slice.call(stage.querySelectorAll(".pm-box")).forEach(function (b) {
+      b.classList.toggle("sel", b.dataset.n === String(n));
+    });
+    Array.prototype.slice.call(list.querySelectorAll(".card")).forEach(function (c, i) {
+      c.classList.toggle("border-warning", i === n);
+    });
+  }
+
+  function wireListRow(n) {
+    var r = regions[n];
+    var en = document.getElementById("pm-en-" + n);
+    if (en) en.addEventListener("change", function () {
+      r.enabled = en.checked ? 1 : 0;
+      if (r.enabled && (r.w < MIN || r.h < MIN)) defaultRect(r);
+      send(n); render(); select(n);
+    });
+    var colEl = document.getElementById("pm-col-" + n);
+    var alEl = document.getElementById("pm-al-" + n);
+    function colorChanged() {
+      r.color = colorToTimps(colEl && colEl.value, alEl && alEl.value);
+      send(n); renderBoxes();
+    }
+    if (colEl) colEl.addEventListener("change", colorChanged);
+    if (alEl) alEl.addEventListener("change", colorChanged);
+    var del = document.getElementById("pm-del-" + n);
+    if (del) del.addEventListener("click", function () {
+      r.enabled = 0; send(n); render();
+    });
+    ["x", "y", "w", "h"].forEach(function (k) {
+      var el = document.getElementById("pm-" + k + "-" + n);
+      if (!el) return;
+      el.addEventListener("change", function () {
+        var v = parseInt(el.value, 10); if (isNaN(v)) return;
+        r[k] = v; clampRegion(r); send(n); render(); select(n);
+      });
+    });
+  }
+
+  function defaultRect(r) {
+    r.w = Math.round(streamW * 0.25);
+    r.h = Math.round(streamH * 0.25);
+    r.x = Math.round((streamW - r.w) / 2);
+    r.y = Math.round((streamH - r.h) / 2);
+  }
+
+  function addMask() {
+    var n = regions.findIndex(function (r) { return !r.enabled; });
+    if (n < 0) { toast("warning", "All " + maxRegions + " masks are in use on this stream."); return; }
+    var r = regions[n];
+    r.enabled = 1;
+    if (!r.color) r.color = "0xFF000000";
+    defaultRect(r);
+    send(n); render(); select(n);
+  }
+
+  /* ---- snapshot ---- */
+
+  function setSnapshot() {
+    window.timpsApi.token().then(function (tok) {
+      var url = window.timpsApi.base() + "/snapshot.jpg?chn=" + streamIdx +
+        (tok ? "&token=" + encodeURIComponent(tok) : "") + "&_=" + Date.now();
+      img.onload = function () { if (noimg) noimg.classList.add("d-none"); renderBoxes(); };
+      img.onerror = function () { if (noimg) noimg.classList.remove("d-none"); };
+      img.src = url;
+    });
+  }
+
+  /* ---- load ---- */
+
+  function markUnavailable(msg) {
+    var el = document.getElementById("privacy-unavailable");
+    if (el) { el.classList.remove("d-none"); if (msg) el.textContent = msg; }
+    if (addBtn) addBtn.disabled = true;
+    if (streamSel) streamSel.disabled = true;
+  }
+
+  function load() {
+    if (!window.timpsApi) { markUnavailable("timps-api.js not loaded."); return; }
+    window.timpsApi.get().then(function (json) {
+      var caps = (json.caps && json.caps.privacy) || null;
+      if (caps && caps.available === 0) { markUnavailable(); return; }
+      if (caps && caps.max_regions > 0) maxRegions = Math.min(caps.max_regions, 8);
+      var maxSpan = document.getElementById("privacy-max");
+      if (maxSpan) maxSpan.textContent = String(maxRegions);
+
+      var v = (json.video && (json.video[streamIdx] || json.video[String(streamIdx)])) || {};
+      if (v.width > 0 && v.height > 0) { streamW = v.width; streamH = v.height; }
+      stage.style.aspectRatio = streamW + " / " + streamH;
+
+      var priv = (json.privacy && (json.privacy[streamIdx] || json.privacy[String(streamIdx)])) || {};
+      regions = [];
+      for (var n = 0; n < maxRegions; n++) {
+        var r = priv[n] || priv[String(n)] || {};
+        regions.push({
+          enabled: Number(r.enabled) || 0,
+          x: Number(r.x) || 0, y: Number(r.y) || 0,
+          w: Number(r.w) || 0, h: Number(r.h) || 0,
+          color: r.color || "0xFF000000",
+        });
+      }
+      selected = regions.findIndex(function (r) { return r.enabled; });
+      var off = document.getElementById("privacy-unavailable");
+      if (off) off.classList.add("d-none");
+      setSnapshot();
+      render();
+    }).catch(function (err) {
+      console.warn("timps unreachable:", err);
+      markUnavailable("The streamer is not reachable; reload once it is running.");
+    });
+  }
+
+  if (streamSel) streamSel.addEventListener("change", function () {
+    streamIdx = parseInt(streamSel.value, 10) || 0;
+    load();
+  });
+  if (addBtn) addBtn.addEventListener("click", addMask);
+  if (reloadBtn) reloadBtn.addEventListener("click", load);
+  window.addEventListener("resize", renderBoxes);
+
+  if (document.readyState === "loading")
+    document.addEventListener("DOMContentLoaded", load, { once: true });
+  else load();
+})();

--- a/package/timps/files/www/a/recordings.js
+++ b/package/timps/files/www/a/recordings.js
@@ -1,0 +1,138 @@
+/* recordings.js - browse/play/download/delete the timps SD recordings listed
+ * by /x/json-recordings.cgi (a filesystem helper). Playback + download stream
+ * the segment from the same CGI (?file=<rel>). Free-space is read from timps
+ * GET /control (record.free_mb) when available. Dependency-free. */
+(function () {
+  "use strict";
+
+  if (!document.body || document.body.id !== "page-recordings") return;
+
+  var LIST = "/x/json-recordings.cgi";
+  var listEl = document.getElementById("rec-list");
+  var infoEl = document.getElementById("rec-info");
+  var reloadBtn = document.getElementById("rec-reload");
+  var video = document.getElementById("rec-video");
+  var modalEl = document.getElementById("recModal");
+  var modal = null;
+
+  function toast(type, msg, ms) {
+    if (typeof window.showAlert === "function") window.showAlert(type, msg, ms);
+    else console.log("[recordings]", type + ":", msg);
+  }
+
+  function human(bytes) {
+    var b = Number(bytes) || 0;
+    if (b < 1024) return b + " B";
+    if (b < 1048576) return (b / 1024).toFixed(0) + " KB";
+    if (b < 1073741824) return (b / 1048576).toFixed(1) + " MB";
+    return (b / 1073741824).toFixed(2) + " GB";
+  }
+
+  // "20260712/09/20260712T095252" -> a readable local timestamp; fall back to
+  // the file mtime when the name isn't the default pattern.
+  function labelFor(rel, mtime) {
+    var m = /(\d{8})T(\d{2})(\d{2})(\d{2})/.exec(rel);
+    if (m) {
+      var d = m[1], H = m[3] ? m[2] : "";
+      return d.slice(0, 4) + "-" + d.slice(4, 6) + "-" + d.slice(6, 8) +
+        " " + m[2] + ":" + m[3] + ":" + m[4];
+    }
+    if (mtime) return new Date(Number(mtime) * 1000).toLocaleString();
+    return rel;
+  }
+
+  function url(action, rel) {
+    return LIST + "?" + action + "=" + encodeURIComponent(rel);
+  }
+
+  function play(rel, label) {
+    if (!video) return;
+    video.src = url("file", rel);
+    var title = document.getElementById("recModalTitle");
+    if (title) title.textContent = label;
+    if (!modal && window.bootstrap) modal = new window.bootstrap.Modal(modalEl);
+    if (modal) modal.show();
+    video.play().catch(function () { /* user can press play */ });
+  }
+
+  function del(rel, tr) {
+    if (!window.confirm("Delete this recording?\n" + rel)) return;
+    fetch(url("del", rel), { cache: "no-store" })
+      .then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
+      .then(function () { if (tr) tr.remove(); toast("success", "Recording deleted.", 2500); })
+      .catch(function (e) { toast("danger", "Delete failed: " + (e.message || e)); });
+  }
+
+  function render(files) {
+    listEl.innerHTML = "";
+    if (!files.length) {
+      listEl.innerHTML = '<tr><td colspan="4" class="text-secondary">No recordings found.</td></tr>';
+      return;
+    }
+    files.forEach(function (f) {
+      var label = labelFor(f.file, f.mtime);
+      var tr = document.createElement("tr");
+      var actions = document.createElement("td");
+      actions.className = "text-end";
+
+      var playBtn = document.createElement("button");
+      playBtn.className = "btn btn-sm btn-primary me-1";
+      playBtn.innerHTML = '<i class="bi bi-play-fill"></i>';
+      playBtn.title = "Play";
+      playBtn.addEventListener("click", function () { play(f.file, label); });
+
+      var dl = document.createElement("a");
+      dl.className = "btn btn-sm btn-outline-secondary me-1";
+      dl.href = url("file", f.file);
+      dl.setAttribute("download", f.file.replace(/\//g, "_"));
+      dl.title = "Download";
+      dl.innerHTML = '<i class="bi bi-download"></i>';
+
+      var delBtn = document.createElement("button");
+      delBtn.className = "btn btn-sm btn-outline-danger";
+      delBtn.innerHTML = '<i class="bi bi-trash"></i>';
+      delBtn.title = "Delete";
+      delBtn.addEventListener("click", function () { del(f.file, tr); });
+
+      actions.appendChild(playBtn); actions.appendChild(dl); actions.appendChild(delBtn);
+
+      var tdWhen = document.createElement("td"); tdWhen.textContent = label;
+      var tdSeg = document.createElement("td");
+      tdSeg.innerHTML = '<span class="text-secondary small">' + f.file + "</span>";
+      var tdSize = document.createElement("td"); tdSize.className = "text-end"; tdSize.textContent = human(f.size);
+
+      tr.appendChild(tdWhen); tr.appendChild(tdSeg); tr.appendChild(tdSize); tr.appendChild(actions);
+      listEl.appendChild(tr);
+    });
+  }
+
+  function load() {
+    listEl.innerHTML = '<tr><td colspan="4" class="text-secondary">Loading…</td></tr>';
+    fetch(LIST, { cache: "no-store" })
+      .then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
+      .then(function (data) {
+        render(data.files || []);
+        if (infoEl) infoEl.textContent = (data.files || []).length + " segment(s) · " + (data.base || "");
+      })
+      .catch(function (e) {
+        listEl.innerHTML = '<tr><td colspan="4" class="text-danger">Failed to list recordings: ' +
+          (e.message || e) + "</td></tr>";
+      });
+    // free space (best effort)
+    if (window.timpsApi) {
+      window.timpsApi.get().then(function (j) {
+        var fm = j && j.record && j.record.free_mb;
+        if (infoEl && fm != null && fm >= 0) infoEl.textContent += " · " + fm + " MB free";
+      }).catch(function () {});
+    }
+  }
+
+  if (modalEl) modalEl.addEventListener("hidden.bs.modal", function () {
+    if (video) { video.pause(); video.removeAttribute("src"); video.load(); }
+  });
+  if (reloadBtn) reloadBtn.addEventListener("click", load);
+
+  if (document.readyState === "loading")
+    document.addEventListener("DOMContentLoaded", load, { once: true });
+  else load();
+})();

--- a/package/timps/files/www/a/streamer-encoder.js
+++ b/package/timps/files/www/a/streamer-encoder.js
@@ -1,0 +1,262 @@
+/* streamer-encoder.js - NATIVE RTSP main/substream encoder page. Talks directly
+ * to the timps streamer over window.timpsApi (GET/POST /control on timps's own
+ * port, per-boot token) - no /x/json-prudynt.cgi bridge (a/streamer-config.js
+ * is no longer loaded here). One file drives both pages; the stream index is
+ * derived from the body id (page-streamer-main -> 0, page-streamer-substream
+ * -> 1).
+ *
+ * Load:  timpsApi.get() -> populate from json.video[idx] (+ the global
+ *        json.audio.enabled for the "Audio in stream" switch).
+ * Save:  every change goes to timpsApi.set({video:{idx:{key:val}}}) (audio
+ *        switch -> {audio:{enabled}}). timps persists immediately, but ALL
+ *        video/sensor keys are restart-required (caps.restart lists "video"),
+ *        so each change shows the "restart the streamer" hint.
+ * Offline: if timps is unreachable the controls stay disabled + a notice.
+ *
+ * Kept lean on purpose (embedded target): no libraries, no polling, changes
+ * fire on 'change' only, text fields are debounced through timpsApi.
+ */
+(function () {
+  "use strict";
+
+  var body = document.body;
+  if (!body) return;
+  var idx =
+    body.id === "page-streamer-main" ? 0 :
+    body.id === "page-streamer-substream" ? 1 : -1;
+  if (idx < 0) return;
+
+  var P = "stream" + idx + "_"; // page field id prefix
+
+  // page field id (without prefix) -> timps video.* key + value type.
+  // "int": parseInt, "str": raw string, "bool": checkbox 0/1.
+  var FIELD_MAP = {
+    width: { key: "width", type: "int" },
+    height: { key: "height", type: "int" },
+    format: { key: "codec", type: "codec" },
+    fps: { key: "fps", type: "int" },
+    gop: { key: "gop", type: "int" },
+    max_gop: { key: "max_gop", type: "int" },
+    mode: { key: "rc_mode", type: "rc" },
+    bitrate: { key: "bitrate", type: "int" },
+    profile: { key: "profile", type: "int" },
+    buffers: { key: "buffers", type: "int" },
+    rtsp_endpoint: { key: "rtsp_path", type: "str" },
+    enabled: { key: "enabled", type: "bool" },
+  };
+
+  // page codec/mode spelling <-> timps canonical (lowercase) spelling
+  function codecToTimps(v) { return String(v).toLowerCase(); }        // H264 -> h264
+  function codecFromTimps(v) { return String(v).toUpperCase(); }      // h264 -> H264
+  function rcToTimps(v) { return String(v).toLowerCase(); }           // CAPPED_VBR -> capped_vbr
+  function rcFromTimps(v) { return String(v).toUpperCase(); }         // capped_vbr -> CAPPED_VBR
+
+  // per-SoC encoder capability (same matrix streamer-config.js used)
+  var SOC_MODE = {
+    t10: ["CBR", "VBR", "FIXQP", "SMART"],
+    t20: ["CBR", "VBR", "FIXQP", "SMART"],
+    t21: ["CBR", "VBR", "FIXQP", "SMART"],
+    t23: ["CBR", "VBR", "FIXQP", "SMART"],
+    t30: ["CBR", "VBR", "FIXQP", "SMART"],
+    t31: ["CBR", "VBR", "FIXQP", "CAPPED_VBR", "CAPPED_QUALITY"],
+    t40: ["CBR", "VBR", "FIXQP", "CAPPED_VBR", "CAPPED_QUALITY"],
+    t41: ["CBR", "VBR", "FIXQP", "CAPPED_VBR", "CAPPED_QUALITY"],
+    c100: ["CBR", "VBR", "FIXQP", "CAPPED_VBR", "CAPPED_QUALITY"],
+  };
+  var SOC_FMT = {
+    t10: ["H264"], t20: ["H264"], t21: ["H264"], t23: ["H264"],
+    t30: ["H264", "H265"], t31: ["H264", "H265"], t40: ["H264", "H265"],
+    t41: ["H264", "H265"], c100: ["H264", "H265"],
+  };
+  var DEF_MODE = ["CBR", "VBR", "FIXQP", "CAPPED_VBR", "CAPPED_QUALITY"];
+  var DEF_FMT = ["H264", "H265"];
+
+  function socFamily(soc) {
+    if (!soc) return null;
+    var m = String(soc).toLowerCase().match(/^(t\d+|c\d+)/);
+    return m ? m[1] : null;
+  }
+
+  function $id(id) { return document.getElementById(id); }
+
+  function toast(type, message, ms) {
+    if (typeof window.showAlert === "function") window.showAlert(type, message, ms);
+    else console.log("[streamer-encoder]", type + ":", message);
+  }
+
+  function restartHint() {
+    toast(
+      "warning",
+      "Setting saved. Encoder changes take effect after a streamer restart (Restart streamer in the menu).",
+      8000,
+    );
+  }
+
+  function setEnabled(id, on) {
+    var el = $id(id);
+    if (!el) return;
+    el.disabled = !on;
+    var wrap = el.closest("p, .col, .form-switch, .select") || el.parentElement;
+    if (wrap) wrap.classList.toggle("disabled", !on);
+  }
+
+  function fillSelect(select, values, current) {
+    if (!select) return;
+    select.innerHTML = "";
+    values.forEach(function (v) {
+      var o = document.createElement("option");
+      o.value = v;
+      o.textContent = v.replace(/_/g, " ");
+      select.appendChild(o);
+    });
+    if (current && values.indexOf(current) >= 0) select.value = current;
+  }
+
+  function populateSelectors() {
+    var soc =
+      (window.thinginoUIConfig &&
+        window.thinginoUIConfig.device &&
+        window.thinginoUIConfig.device.soc) || null;
+    var fam = socFamily(soc);
+    fillSelect($id(P + "mode"), (fam && SOC_MODE[fam]) || DEF_MODE);
+    fillSelect($id(P + "format"), (fam && SOC_FMT[fam]) || DEF_FMT);
+  }
+
+  // read one field's timps value; returns undefined when it should be skipped
+  function readValue(suffix, map) {
+    var el = $id(P + suffix);
+    if (!el) return undefined;
+    if (map.type === "bool") return el.checked ? 1 : 0;
+    if (map.type === "codec") return el.value ? codecToTimps(el.value) : undefined;
+    if (map.type === "rc") return el.value ? rcToTimps(el.value) : undefined;
+    if (map.type === "str") return el.value;
+    var n = parseInt(el.value, 10);
+    return isNaN(n) ? undefined : n;
+  }
+
+  function send(suffix, map) {
+    var value = readValue(suffix, map);
+    if (value === undefined) return;
+    var el = $id(P + suffix);
+    var inner = {};
+    inner[map.key] = value;
+    var video = {};
+    video[idx] = inner;
+    if (el) el.classList.add("opacity-75");
+    window.timpsApi
+      .set({ video: video })
+      .then(restartHint, function (err) {
+        console.error("timps set failed:", err);
+        toast("danger", "Failed to save setting: " + (err.message || err));
+      })
+      .then(function () { if (el) el.classList.remove("opacity-75"); });
+  }
+
+  function sendAudio() {
+    var el = $id(P + "audio_enabled");
+    if (!el) return;
+    el.classList.add("opacity-75");
+    window.timpsApi
+      .set({ audio: { enabled: el.checked ? 1 : 0 } })
+      .then(restartHint, function (err) {
+        console.error("timps set failed:", err);
+        toast("danger", "Failed to save setting: " + (err.message || err));
+      })
+      .then(function () { el.classList.remove("opacity-75"); });
+  }
+
+  function populate(suffix, map, video) {
+    var el = $id(P + suffix);
+    if (!el) return;
+    var v = video[map.key];
+    if (v === undefined || v === null) return;
+    if (map.type === "bool") el.checked = !!Number(v);
+    else if (map.type === "codec") el.value = codecFromTimps(v);
+    else if (map.type === "rc") el.value = rcFromTimps(v);
+    else el.value = v;
+  }
+
+  function wireControls() {
+    populateSelectors();
+    Object.keys(FIELD_MAP).forEach(function (suffix) {
+      var el = $id(P + suffix);
+      if (!el) return;
+      setEnabled(P + suffix, false); // enabled once timps answers
+      el.addEventListener("change", function () { send(suffix, FIELD_MAP[suffix]); });
+    });
+
+    // "Audio in stream" has no per-stream key in timps (audio is global);
+    // bind it to the global audio.enabled switch.
+    var au = $id(P + "audio_enabled");
+    if (au) {
+      setEnabled(P + "audio_enabled", false);
+      au.addEventListener("change", sendAudio);
+    }
+
+    var saveBtn = $id("save-prudynt-config");
+    if (saveBtn) {
+      saveBtn.addEventListener("click", function () {
+        toast(
+          "success",
+          "Encoder settings are saved live to the streamer configuration; restart the streamer to apply them.",
+          5000,
+        );
+      });
+    }
+  }
+
+  function offlineNotice() {
+    if ($id("timps-offline-notice")) return;
+    var div = document.createElement("div");
+    div.id = "timps-offline-notice";
+    div.className = "alert alert-warning mt-2";
+    div.innerHTML =
+      '<i class="bi bi-exclamation-triangle me-1"></i>' +
+      "The streamer is not reachable, encoder controls are disabled. " +
+      "Check that the timps service is running, then reload this page.";
+    var h3 = document.querySelector("main h3");
+    if (h3 && h3.parentNode) h3.parentNode.insertBefore(div, h3.nextSibling);
+    else {
+      var c = document.querySelector("main .container");
+      if (c) c.appendChild(div);
+    }
+  }
+
+  function load() {
+    if (!window.timpsApi) {
+      console.error("timps-api.js not loaded");
+      offlineNotice();
+      return;
+    }
+    window.timpsApi
+      .get()
+      .then(function (json) {
+        var video = (json.video && json.video[idx]) || {};
+        var audio = json.audio || {};
+        Object.keys(FIELD_MAP).forEach(function (suffix) {
+          populate(suffix, FIELD_MAP[suffix], video);
+          setEnabled(P + suffix, true);
+        });
+        var au = $id(P + "audio_enabled");
+        if (au) {
+          if (audio.enabled !== undefined) au.checked = !!Number(audio.enabled);
+          setEnabled(P + "audio_enabled", true);
+        }
+        var offline = $id("timps-offline-notice");
+        if (offline) offline.remove();
+      })
+      .catch(function (err) {
+        console.warn("timps unreachable, encoder controls stay disabled:", err);
+        offlineNotice();
+      });
+  }
+
+  function init() {
+    wireControls();
+    load();
+  }
+
+  if (document.readyState === "loading")
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  else init();
+})();

--- a/package/timps/files/www/a/streamer-image.js
+++ b/package/timps/files/www/a/streamer-image.js
@@ -1,0 +1,169 @@
+/* streamer-image.js - NATIVE Image Quality page. Talks directly to the timps
+ * streamer over window.timpsApi (GET/POST /control on timps's own port, per-
+ * boot token) - no json-imaging.cgi / json-prudynt*.cgi bridge for this page.
+ *
+ * Load:  timpsApi.get() -> populate every control from the "image" object and
+ *        enable ONLY the controls whose timps key is listed in caps.image
+ *        (the SoC capability matrix); everything else stays greyed out.
+ * Save:  every change goes straight to timpsApi.set({image:{key:val}}) -
+ *        debounced, so a burst of quick changes coalesces into one POST.
+ *        timps applies live AND persists to its config file immediately, so
+ *        the "Save configuration" button is just a confirmation toast.
+ * Offline: if timps is unreachable the controls stay disabled and a small
+ *        notice appears; nothing throws.
+ */
+(function () {
+  "use strict";
+
+  if (!document.body || document.body.id !== "page-streamer-image") return;
+
+  // page field id -> timps image.* key (ids are prudynt-era names)
+  var FIELD_MAP = {
+    brightness: "brightness",
+    contrast: "contrast",
+    sharpness: "sharpness",
+    saturation: "saturation",
+    backlight: "backlight_compensation",
+    wide_dynamic_range: "drc_strength",
+    tone: "highlight_depress",
+    defog: "defog_strength",
+    noise_reduction: "sinter_strength", // set() also mirrors temper_strength
+    image_core_wb_mode: "core_wb_mode",
+    image_wb_bgain: "wb_bgain",
+    image_wb_rgain: "wb_rgain",
+    image_ae_compensation: "ae_compensation",
+    image_hflip: "hflip",
+    image_vflip: "vflip",
+  };
+
+  function $id(id) { return document.getElementById(id); }
+
+  function toast(type, message, ms) {
+    if (typeof window.showAlert === "function")
+      window.showAlert(type, message, ms);
+    else console.log("[streamer-image]", type + ":", message);
+  }
+
+  // same disabled styling the page always used: input.disabled + a
+  // "disabled" class on the wrapping <p>/.select/.boolean block
+  function setEnabled(id, on) {
+    var el = $id(id);
+    if (!el) return;
+    el.disabled = !on;
+    var wrap =
+      el.closest("p, .number-range, .select, .boolean, .col") ||
+      el.parentElement;
+    if (wrap) wrap.classList.toggle("disabled", !on);
+  }
+
+  function populate(id, value) {
+    var el = $id(id);
+    if (!el || value === undefined || value === null) return;
+    if (el.type === "checkbox") el.checked = !!Number(value);
+    else el.value = value;
+  }
+
+  // one changed control -> debounced POST {"image":{key:val}} to timps.
+  // The page's single NR slider drives both spatial+temporal NR strengths.
+  function send(id) {
+    var el = $id(id);
+    var key = FIELD_MAP[id];
+    if (!el || !key) return;
+    var value;
+    if (el.type === "checkbox") value = el.checked ? 1 : 0;
+    else {
+      value = parseInt(el.value, 10);
+      if (isNaN(value)) return;
+    }
+    var image = {};
+    image[key] = value;
+    if (id === "noise_reduction") image.temper_strength = value;
+    el.classList.add("opacity-75");
+    window.timpsApi
+      .setDebounced({ image: image }, 150)
+      .catch(function (err) {
+        console.error("timps set failed:", err);
+        toast("danger", "Failed to apply setting: " + (err.message || err));
+      })
+      .then(function () {
+        el.classList.remove("opacity-75");
+      });
+  }
+
+  function wireControls() {
+    Object.keys(FIELD_MAP).forEach(function (id) {
+      var el = $id(id);
+      if (!el) return;
+      setEnabled(id, false); // disabled until caps confirm support
+      el.addEventListener("change", function () { send(id); });
+      // double-click resets a numeric field to the midpoint of its range
+      if (el.type !== "checkbox" && el.tagName !== "SELECT") {
+        el.addEventListener("dblclick", function () {
+          var min = Number(el.dataset.min || 0);
+          var max = Number(el.dataset.max || 255);
+          el.value = Math.round((min + max) / 2);
+          send(id);
+        });
+      }
+    });
+
+    // timps applies + persists every change immediately; the button is
+    // kept only to reassure users trained on the old save-to-file step.
+    var saveBtn = $id("save-prudynt-config");
+    if (saveBtn) {
+      saveBtn.addEventListener("click", function () {
+        toast(
+          "success",
+          "Nothing to do: image settings are applied live and already saved to the streamer configuration.",
+          4000,
+        );
+      });
+    }
+  }
+
+  function offlineNotice() {
+    if ($id("timps-offline-notice")) return;
+    var div = document.createElement("div");
+    div.id = "timps-offline-notice";
+    div.className = "alert alert-warning mt-2";
+    div.innerHTML =
+      '<i class="bi bi-exclamation-triangle me-1"></i>' +
+      "The streamer is not reachable, image controls are disabled. " +
+      "Check that the timps service is running, then reload this page.";
+    var h3 = document.querySelector("main h3");
+    if (h3 && h3.parentNode) h3.parentNode.insertBefore(div, h3.nextSibling);
+    else document.querySelector("main .container")?.appendChild(div);
+  }
+
+  function load() {
+    if (!window.timpsApi) {
+      console.error("timps-api.js not loaded");
+      offlineNotice();
+      return;
+    }
+    window.timpsApi
+      .get()
+      .then(function (json) {
+        var image = json.image || {};
+        var capsImage = (json.caps && json.caps.image) || [];
+        Object.keys(FIELD_MAP).forEach(function (id) {
+          var key = FIELD_MAP[id];
+          populate(id, image[key]);
+          setEnabled(id, capsImage.indexOf(key) >= 0);
+        });
+      })
+      .catch(function (err) {
+        console.warn("timps unreachable, image controls stay disabled:", err);
+        offlineNotice();
+      });
+  }
+
+  function init() {
+    wireControls();
+    load();
+  }
+
+  if (document.readyState === "loading")
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  else init();
+})();

--- a/package/timps/files/www/a/streamer-osd.js
+++ b/package/timps/files/www/a/streamer-osd.js
@@ -1,0 +1,363 @@
+/* streamer-osd.js - NATIVE per-stream OSD pages (streamer-osd0.html and
+ * streamer-osd1.html share this script). Talks directly to the timps
+ * streamer over window.timpsApi (GET/POST /control on timps's own port,
+ * per-boot token) - no json-prudynt.cgi bridge for these pages (the OSD
+ * wiring in a/preview.js is gated off here; preview.js keeps only the live
+ * preview <img>, which already loads straight from timps).
+ *
+ * Stream:  detected from the page's body id (page-streamer-osd0 -> timps
+ *          section "osd0", page-streamer-osd1 -> "osd1"). Each video stream
+ *          carries its own independent overlay item set. Item layout (the
+ *          timps default, same one the bridge used):
+ *            0 = time, 1 = user text, 2 = uptime, 3 = logo
+ * Load:    timpsApi.get() -> populate every control from this page's osdS
+ *          object + the global "osd" master switch; enable only the controls
+ *          whose timps item leaf key is listed in caps.osd.
+ * Save:    per-item leaves (enabled/text/x/y/font_size/color/transparency/
+ *          outline/outline_color) apply LIVE via timpsApi.set({osdS:{N:{..}}})
+ *          and persist immediately. The global osd.enabled master switch is
+ *          persist+restart, and enabling an overlay that was off when the
+ *          streamer started cannot be applied live either (its region only
+ *          exists when it was enabled at startup) - both show the existing
+ *          "Restart streamer" hint (the menu entry calls
+ *          /x/restart-prudynt.cgi).
+ * Colors:  the page's <input type=color> (#rrggbb) plus its "-alpha" range
+ *          slider make up the timps color "0xAARRGGBB" and back.
+ * Offline: if timps is unreachable the controls stay disabled and a small
+ *          notice appears; nothing throws.
+ */
+(function () {
+  "use strict";
+
+  var m = document.body && /^page-streamer-osd([01])$/.exec(document.body.id);
+  if (!m) return;
+  var S = m[1]; // "0" or "1": this page's stream
+  var SEC = "osd" + S; // timps /control section (and the page id prefix)
+
+  // page element groups -> timps item indexes (the timps default layout)
+  var ITEMS = { time: 0, usertext: 1, uptime: 2, logo: 3 };
+  var TEXT_ITEMS = [0, 1, 2]; // items driven by the page-level size/shadow
+
+  function $id(id) { return document.getElementById(id); }
+  function el(name) { return $id(SEC + "_" + name); }
+
+  function toast(type, message, ms) {
+    if (typeof window.showAlert === "function")
+      window.showAlert(type, message, ms);
+    else console.log("[streamer-osd]", type + ":", message);
+  }
+
+  function restartHint() {
+    toast(
+      "warning",
+      "Setting saved. Restart the streamer (Restart streamer in the menu) for it to take effect.",
+      8000,
+    );
+  }
+
+  // ---- conversions ----
+
+  // timps "0xAARRGGBB" -> {color:"#rrggbb", alpha:0..255}
+  function fromTimpsColor(v) {
+    var n = parseInt(String(v), 16);
+    if (isNaN(n)) return null;
+    var rgb = (n & 0xffffff).toString(16).padStart(6, "0");
+    return { color: "#" + rgb, alpha: (n >>> 24) & 0xff };
+  }
+
+  // "#rrggbb" + alpha 0..255 -> timps "0xAARRGGBB"
+  function toTimpsColor(hex, alpha) {
+    var rgb = /^#?([0-9a-f]{6})/i.exec(hex || "");
+    if (!rgb) return null;
+    var a = Math.min(255, Math.max(0, isNaN(alpha) ? 255 : alpha));
+    return (
+      "0x" + a.toString(16).padStart(2, "0").toUpperCase() +
+      rgb[1].toUpperCase()
+    );
+  }
+
+  // one color picker + its "-alpha" slider -> timps color string
+  function colorValue(name) {
+    var picker = el(name);
+    var alphaEl = el(name + "-alpha");
+    var a = 255;
+    if (alphaEl && alphaEl.value !== "") {
+      var parsed = parseInt(alphaEl.value, 10);
+      if (!isNaN(parsed)) a = parsed;
+    }
+    return toTimpsColor(picker ? picker.value : "#ffffff", a);
+  }
+
+  // "x,y" (negative = from the right/bottom edge, same convention on both
+  // sides) -> {x,y}, or null when the field does not parse
+  function parsePosition(v) {
+    var p = /^\s*(-?\d+)\s*,\s*(-?\d+)\s*$/.exec(String(v || ""));
+    return p ? { x: parseInt(p[1], 10), y: parseInt(p[2], 10) } : null;
+  }
+
+  // ---- state / wiring ----
+
+  // item enabled state as loaded from timps: enabling an item that this
+  // snapshot says is off gets the restart hint (its region only exists when
+  // the item was enabled when the streamer started; timps refuses the live
+  // enable and applies it on the next restart)
+  var loadedEnabled = {};
+
+  function setEnabled(id, on) {
+    var e = $id(id);
+    if (!e) return;
+    e.disabled = !on;
+    var wrap =
+      e.closest("p, .number-range, .select, .boolean, .file, .form-switch") ||
+      e.parentElement;
+    if (wrap) wrap.classList.toggle("disabled", !on);
+  }
+
+  // POST one item's changed leaves: {"osdS":{"N":{key:val,...}}}
+  function sendItem(item, leaves, busyEl) {
+    var body = {};
+    body[SEC] = {};
+    body[SEC][String(item)] = leaves;
+    return sendBody(body, busyEl);
+  }
+
+  function sendBody(body, busyEl) {
+    if (busyEl) busyEl.classList.add("opacity-75");
+    return window.timpsApi
+      .set(body)
+      .catch(function (err) {
+        console.error("timps set failed:", err);
+        toast("danger", "Failed to apply setting: " + (err.message || err));
+      })
+      .then(function () {
+        if (busyEl) busyEl.classList.remove("opacity-75");
+      });
+  }
+
+  // per-element control wiring: name = page control suffix, item = timps
+  // item index, build(el) = item leaves for the POST (null = ignore input)
+  function wire(name, item, build) {
+    var e = el(name);
+    if (!e) return;
+    e.addEventListener("change", function () {
+      var leaves = build(e);
+      if (!leaves) return;
+      var p = sendItem(item, leaves, e);
+      // enabling an overlay that was off when the state was loaded:
+      // persisted, but the live enable is refused without a region
+      if (
+        leaves.enabled === 1 &&
+        !loadedEnabled[item]
+      )
+        p.then(restartHint);
+    });
+  }
+
+  function wireControls() {
+    // everything starts greyed out until timps confirms support
+    ALL_CONTROLS.forEach(function (name) {
+      setEnabled(SEC + "_" + name, false);
+    });
+
+    // global master switch: config-only in timps (imp_osd_setup runs once at
+    // startup), so it always gets the restart hint
+    var master = el("enabled");
+    if (master) {
+      master.addEventListener("change", function () {
+        sendBody({ osd: { enabled: master.checked ? 1 : 0 } }, master).then(
+          restartHint,
+        );
+      });
+    }
+
+    // page-level font size / shadow width drive every text item (timps
+    // keeps font_size/outline per item) - applied live
+    var fontsize = el("fontsize");
+    if (fontsize) {
+      fontsize.addEventListener("change", function () {
+        var v = parseInt(fontsize.value, 10);
+        if (isNaN(v)) return;
+        var body = {};
+        body[SEC] = {};
+        TEXT_ITEMS.forEach(function (i) {
+          body[SEC][String(i)] = { font_size: v };
+        });
+        sendBody(body, fontsize);
+      });
+    }
+    var strokesize = el("strokesize");
+    if (strokesize) {
+      strokesize.addEventListener("change", function () {
+        var v = parseInt(strokesize.value, 10);
+        if (isNaN(v)) return;
+        var body = {};
+        body[SEC] = {};
+        TEXT_ITEMS.forEach(function (i) {
+          body[SEC][String(i)] = { outline: v };
+        });
+        sendBody(body, strokesize);
+      });
+    }
+
+    Object.keys(ITEMS).forEach(function (group) {
+      var item = ITEMS[group];
+      wire(group + "_enabled", item, function (e) {
+        return { enabled: e.checked ? 1 : 0 };
+      });
+      wire(group + "_position", item, function (e) {
+        return parsePosition(e.value);
+      });
+      if (group === "logo") return; // colors/format are text-item-only
+      wire(group + "_fillcolor", item, function () {
+        var c = colorValue(group + "_fillcolor");
+        return c ? { color: c } : null;
+      });
+      wire(group + "_fillcolor-alpha", item, function () {
+        var c = colorValue(group + "_fillcolor");
+        return c ? { color: c } : null;
+      });
+      wire(group + "_strokecolor", item, function () {
+        var c = colorValue(group + "_strokecolor");
+        return c ? { outline_color: c } : null;
+      });
+      wire(group + "_strokecolor-alpha", item, function () {
+        var c = colorValue(group + "_strokecolor");
+        return c ? { outline_color: c } : null;
+      });
+      if (group === "uptime") return; // no format field on the page
+      wire(group + "_format", item, function (e) {
+        // timps text template: strftime %.. plus {hostname}/{ip}/{uptime}/
+        // {fps}/... placeholders - passed through unchanged
+        return { text: e.value };
+      });
+    });
+
+    // timps applies + persists every change immediately; the button is
+    // kept only to reassure users trained on the old save-to-file step.
+    var saveBtn = $id("save-prudynt-config");
+    if (saveBtn) {
+      saveBtn.addEventListener("click", function () {
+        toast(
+          "success",
+          "Nothing to do: OSD settings are applied live and already saved to the streamer configuration.",
+          4000,
+        );
+      });
+    }
+  }
+
+  // every page control suffix (for the initial grey-out + caps mapping)
+  var ALL_CONTROLS = [
+    "enabled", "fontsize", "strokesize",
+    "logo_enabled", "logo_position",
+    "time_enabled", "time_position", "time_fillcolor", "time_fillcolor-alpha",
+    "time_strokecolor", "time_strokecolor-alpha", "time_format",
+    "uptime_enabled", "uptime_position", "uptime_fillcolor",
+    "uptime_fillcolor-alpha", "uptime_strokecolor", "uptime_strokecolor-alpha",
+    "usertext_enabled", "usertext_position", "usertext_fillcolor",
+    "usertext_fillcolor-alpha", "usertext_strokecolor",
+    "usertext_strokecolor-alpha", "usertext_format",
+  ];
+
+  // control suffix pattern -> the timps item leaf key that must be in
+  // caps.osd for the control to enable
+  function capsKeyFor(name) {
+    if (name === "enabled") return "enabled"; // master switch
+    if (name === "fontsize") return "font_size";
+    if (name === "strokesize") return "outline";
+    if (/_enabled$/.test(name)) return "enabled";
+    if (/_position$/.test(name)) return "x";
+    if (/_fillcolor(-alpha)?$/.test(name)) return "color";
+    if (/_strokecolor(-alpha)?$/.test(name)) return "outline_color";
+    if (/_format$/.test(name)) return "text";
+    return null;
+  }
+
+  function populateColor(name, timpsColor) {
+    var c = fromTimpsColor(timpsColor);
+    if (!c) return;
+    var picker = el(name);
+    if (picker) picker.value = c.color;
+    var alphaEl = el(name + "-alpha");
+    if (alphaEl) alphaEl.value = c.alpha;
+  }
+
+  function populateItem(group, item) {
+    if (!item) return;
+    var checkbox = el(group + "_enabled");
+    if (checkbox) checkbox.checked = !!Number(item.enabled);
+    var pos = el(group + "_position");
+    if (pos && item.x !== undefined && item.y !== undefined)
+      pos.value = item.x + "," + item.y;
+    if (group === "logo") return;
+    populateColor(group + "_fillcolor", item.color);
+    populateColor(group + "_strokecolor", item.outline_color);
+    var format = el(group + "_format");
+    if (format && item.text !== undefined) format.value = item.text;
+  }
+
+  function offlineNotice() {
+    if ($id("timps-offline-notice")) return;
+    var div = document.createElement("div");
+    div.id = "timps-offline-notice";
+    div.className = "alert alert-warning mt-2";
+    div.innerHTML =
+      '<i class="bi bi-exclamation-triangle me-1"></i>' +
+      "The streamer is not reachable, OSD controls are disabled. " +
+      "Check that the timps service is running, then reload this page.";
+    var h3 = document.querySelector("main h3");
+    if (h3 && h3.parentNode) h3.parentNode.insertBefore(div, h3.nextSibling);
+    else document.querySelector("main .container")?.appendChild(div);
+  }
+
+  function load() {
+    if (!window.timpsApi) {
+      console.error("timps-api.js not loaded");
+      offlineNotice();
+      return;
+    }
+    window.timpsApi
+      .get()
+      .then(function (json) {
+        var set = json[SEC] || {}; // THIS stream's independent item set
+        var capsOsd = (json.caps && json.caps.osd) || [];
+
+        Object.keys(ITEMS).forEach(function (group) {
+          var item = set[String(ITEMS[group])];
+          populateItem(group, item);
+          loadedEnabled[ITEMS[group]] = !!(item && Number(item.enabled));
+        });
+
+        // master switch + the page-level size/shadow (mirrors of the first
+        // text item; timps keeps them per item)
+        var master = el("enabled");
+        if (master && json.osd && json.osd.enabled !== undefined)
+          master.checked = !!Number(json.osd.enabled);
+        var first = set["0"] || {};
+        var fontsize = el("fontsize");
+        if (fontsize && first.font_size !== undefined)
+          fontsize.value = first.font_size;
+        var strokesize = el("strokesize");
+        if (strokesize && first.outline !== undefined)
+          strokesize.value = first.outline;
+
+        ALL_CONTROLS.forEach(function (name) {
+          var key = capsKeyFor(name);
+          setEnabled(SEC + "_" + name, !!key && capsOsd.indexOf(key) >= 0);
+        });
+      })
+      .catch(function (err) {
+        console.warn("timps unreachable, OSD controls stay disabled:", err);
+        offlineNotice();
+      });
+  }
+
+  function init() {
+    wireControls();
+    load();
+  }
+
+  if (document.readyState === "loading")
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  else init();
+})();

--- a/package/timps/files/www/a/streamer-sensor.js
+++ b/package/timps/files/www/a/streamer-sensor.js
@@ -1,0 +1,37 @@
+/* streamer-sensor.js - Sensor IQ File page helper.
+ *
+ * The page has no timps-settable fields: the sensor model / resolution / fps
+ * are read-only (shown by preview.js via /x/json-sensor-info.cgi, a filesystem
+ * helper that reads /proc/jz/sensor and the /etc/sensor/*.bin md5 - NOT a timps
+ * bridge), and the IQ binary is changed through the upload form. This replaces
+ * the old a/streamer-config.js (/x/json-prudynt.cgi bridge) whose only job here
+ * was the "Save configuration" button. timps persists every /control change
+ * live, so the button just reassures + points at the restart for the sensor
+ * re-init (sensor keys are restart-required). Kept intentionally tiny. */
+(function () {
+  "use strict";
+
+  if (!document.body || document.body.id !== "page-streamer-sensor") return;
+
+  function toast(type, message, ms) {
+    if (typeof window.showAlert === "function") window.showAlert(type, message, ms);
+    else console.log("[streamer-sensor]", type + ":", message);
+  }
+
+  function init() {
+    var saveBtn = document.getElementById("save-prudynt-config");
+    if (saveBtn) {
+      saveBtn.addEventListener("click", function () {
+        toast(
+          "success",
+          "Sensor settings are saved live to the streamer configuration; restart the streamer to re-initialise the sensor.",
+          5000,
+        );
+      });
+    }
+  }
+
+  if (document.readyState === "loading")
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  else init();
+})();

--- a/package/timps/files/www/a/timps-api.js
+++ b/package/timps/files/www/a/timps-api.js
@@ -1,0 +1,193 @@
+/* timps-api.js - tiny dependency-free browser client for the timps streamer's
+ * native HTTP API (GET/POST /control, GET /events SSE). Pages talk DIRECTLY
+ * to timps on its own port instead of going through local bridge CGIs.
+ *
+ * Auth: /x/timps-token.cgi (WebUI-session protected) hands out the per-boot
+ * timps token as {"token":"...","port":8880}. fetch() sends it as the
+ * X-Timps-Token header; EventSource cannot set headers, so /events gets it
+ * as ?token=. The token changes on every camera reboot: one transparent
+ * re-fetch + retry is done on a 401/403. If the token endpoint is
+ * unreachable, requests are still attempted token-less (works on open timps
+ * configs and from localhost).
+ */
+(function () {
+  "use strict";
+
+  var DEFAULT_PORT = 8880;
+  var info = null; // cached {token, port} from /x/timps-token.cgi
+  var infoPending = null; // in-flight token fetch (dedup)
+  var controlCache = null; // last successful GET /control JSON (for caps())
+
+  // fetch {token, port} once and memoize; force=true drops the cache
+  // (used after a 401/403 - the camera may have rebooted with a new token).
+  // Never rejects: on failure it resolves {token:"", port:DEFAULT_PORT}.
+  function fetchInfo(force) {
+    if (info && !force) return Promise.resolve(info);
+    if (!infoPending) {
+      infoPending = fetch("/x/timps-token.cgi", { cache: "no-store" })
+        .then(function (res) { return res.ok ? res.json() : null; })
+        .catch(function () { return null; })
+        .then(function (data) {
+          infoPending = null;
+          info = {
+            token: data && data.token ? String(data.token) : "",
+            port: data && data.port ? parseInt(data.port, 10) : DEFAULT_PORT,
+            tls: !!(data && data.tls),
+          };
+          return info;
+        });
+    }
+    return infoPending;
+  }
+
+  function base() {
+    var host = window.location.hostname || "127.0.0.1";
+    if (host.indexOf(":") >= 0 && host.charAt(0) !== "[") host = "[" + host + "]"; // IPv6
+    var scheme = (info && info.tls) ? "https" : "http";
+    return scheme + "://" + host + ":" + (info ? info.port : DEFAULT_PORT);
+  }
+
+  // one /control round trip with the token header; retries ONCE with a
+  // freshly fetched token when the answer is 401/403 (rebooted camera).
+  function request(method, body, retried) {
+    return fetchInfo(false).then(function (i) {
+      var opts = { method: method, cache: "no-store", headers: {} };
+      if (i.token) opts.headers["X-Timps-Token"] = i.token;
+      if (body !== undefined) {
+        opts.headers["Content-Type"] = "application/json";
+        opts.body = JSON.stringify(body);
+      }
+      return fetch(base() + "/control", opts).then(function (res) {
+        if ((res.status === 401 || res.status === 403) && !retried) {
+          return fetchInfo(true).then(function () {
+            return request(method, body, true);
+          });
+        }
+        if (!res.ok) throw new Error("timps /control HTTP " + res.status);
+        return res.json().catch(function () { return {}; });
+      });
+    });
+  }
+
+  function get() {
+    return request("GET").then(function (json) {
+      controlCache = json;
+      return json;
+    });
+  }
+
+  function set(obj) {
+    return request("POST", obj);
+  }
+
+  // merge rapid set() calls (slider drags) into one POST per quiet period.
+  // Only image-style two-level objects are merged ({section:{key:val}}).
+  // Every caller's promise settles with the outcome of the single flush.
+  var debounceBuf = null, debounceTimer = null, debounceWaiters = [];
+  function setDebounced(obj, ms) {
+    if (!debounceBuf) debounceBuf = {};
+    Object.keys(obj || {}).forEach(function (sec) {
+      if (obj[sec] && typeof obj[sec] === "object") {
+        debounceBuf[sec] = debounceBuf[sec] || {};
+        Object.keys(obj[sec]).forEach(function (k) {
+          debounceBuf[sec][k] = obj[sec][k];
+        });
+      } else {
+        debounceBuf[sec] = obj[sec];
+      }
+    });
+    if (debounceTimer) clearTimeout(debounceTimer);
+    return new Promise(function (resolve, reject) {
+      debounceWaiters.push({ resolve: resolve, reject: reject });
+      debounceTimer = setTimeout(function () {
+        var payload = debounceBuf, waiters = debounceWaiters;
+        debounceBuf = null;
+        debounceTimer = null;
+        debounceWaiters = [];
+        set(payload).then(
+          function (r) { waiters.forEach(function (w) { w.resolve(r); }); },
+          function (e) { waiters.forEach(function (w) { w.reject(e); }); },
+        );
+      }, ms === undefined ? 150 : ms);
+    });
+  }
+
+  // caps object from a cached GET /control (fetches once when not cached)
+  function caps() {
+    if (controlCache && controlCache.caps)
+      return Promise.resolve(controlCache.caps);
+    return get().then(function (json) { return json.caps || {}; });
+  }
+
+  // /events SSE: streams = "motion,daynight,stats" (or "" for all).
+  // onEvent(type, data) gets each parsed event; onError(err) any failure.
+  // Auto-pauses while the tab is hidden and resumes on visibilitychange.
+  // Returns {close()}.
+  function events(streams, onEvent, onError) {
+    var es = null, closed = false;
+    var types = String(streams || "motion,daynight,stats")
+      .split(",").map(function (s) { return s.trim(); })
+      .filter(Boolean);
+
+    function open() {
+      fetchInfo(false).then(function (i) {
+        if (closed || document.hidden) return;
+        var url = base() + "/events?stream=" + encodeURIComponent(types.join(","));
+        if (i.token) url += "&token=" + encodeURIComponent(i.token);
+        try { es = new EventSource(url); } catch (e) {
+          if (onError) onError(e);
+          return;
+        }
+        types.forEach(function (t) {
+          es.addEventListener(t, function (ev) {
+            var data = null;
+            try { data = JSON.parse(ev.data); } catch (e) { /* keep null */ }
+            if (onEvent) onEvent(t, data);
+          });
+        });
+        es.onerror = function (err) {
+          // token may be stale after a reboot: drop the cache so the
+          // browser's automatic EventSource reconnect... cannot change the
+          // URL, so reopen ourselves with a fresh token instead.
+          if (closed) return;
+          stop();
+          if (onError) onError(err);
+          fetchInfo(true).then(function () {
+            if (!closed && !document.hidden) setTimeout(open, 3000);
+          });
+        };
+      });
+    }
+
+    function stop() {
+      if (es) { es.close(); es = null; }
+    }
+
+    function onVis() {
+      if (document.hidden) stop();
+      else if (!es && !closed) open();
+    }
+    document.addEventListener("visibilitychange", onVis);
+    open();
+
+    return {
+      close: function () {
+        closed = true;
+        document.removeEventListener("visibilitychange", onVis);
+        stop();
+      },
+    };
+  }
+
+  window.timpsApi = {
+    base: base,
+    token: function () {
+      return fetchInfo(false).then(function (i) { return i.token; });
+    },
+    get: get,
+    set: set,
+    setDebounced: setDebounced,
+    caps: caps,
+    events: events,
+  };
+})();

--- a/package/timps/files/www/a/tool-record.js
+++ b/package/timps/files/www/a/tool-record.js
@@ -1,0 +1,127 @@
+/* tool-record.js - timps Video Recorder settings.
+ *
+ * Replaces the stock thingino recorder page (which POSTed to
+ * /x/tool-record.cgi and wrote thingino's OWN recorder config, never touching
+ * timps.conf). This version talks DIRECTLY to the timps native recorder via
+ * GET/POST /control (a/timps-api.js): every field maps to a record.* config
+ * key, and timps persists the changed keys into /etc/timps.conf itself
+ * (config_write_keys) while the running recorder reads them live. So the path
+ * you set here is the path timps actually records to and the Recordings page
+ * lists from. Dependency-free; no bridge CGI. */
+(function () {
+  "use strict";
+
+  if (!document.body || document.body.id !== "page-tool-record-video") return;
+  if (!window.timpsApi) {
+    console.error("[tool-record] timps-api.js not loaded");
+    return;
+  }
+
+  var $ = function (id) { return document.getElementById(id); };
+
+  // field id -> {key, type}. type: bool | int | str
+  var FIELDS = [
+    { id: "rec_enabled",  key: "enabled",     type: "bool" },
+    { id: "rec_dir",      key: "dir",         type: "str"  },
+    { id: "rec_name",     key: "name",        type: "str"  },
+    { id: "rec_audio",    key: "audio",       type: "bool" },
+    { id: "rec_mode",     key: "mode",        type: "int"  },
+    { id: "rec_channel",  key: "channel",     type: "int"  },
+    { id: "rec_segment",  key: "segment_s",   type: "int"  },
+    { id: "rec_preroll",  key: "pre_roll_s",  type: "int"  },
+    { id: "rec_postroll", key: "post_roll_s", type: "int"  },
+    { id: "rec_minfree",  key: "min_free_mb", type: "int"  },
+  ];
+
+  var form = $("recForm");
+  var reloadBtn = $("rec-reload");
+  var saveBtn = $("rec-save");
+  var statusEl = $("rec-status");
+
+  function toast(type, msg, ms) {
+    if (typeof window.showAlert === "function") window.showAlert(type, msg, ms);
+    else console.log("[tool-record]", type + ":", msg);
+  }
+
+  function setStatus(rec) {
+    if (!statusEl) return;
+    if (!rec || !rec.available) { statusEl.textContent = "Recorder not available in this build."; return; }
+    var bits = [];
+    bits.push(rec.recording ? "recording now" : "idle");
+    if (rec.free_mb != null && rec.free_mb >= 0) bits.push(rec.free_mb + " MB free");
+    if (rec.recording && rec.file) bits.push(rec.file);
+    statusEl.textContent = bits.join(" · ");
+  }
+
+  function fill(rec) {
+    rec = rec || {};
+    FIELDS.forEach(function (f) {
+      var el = $(f.id);
+      if (!el) return;
+      var v = rec[f.key];
+      if (f.type === "bool") el.checked = (v === true || v === 1);
+      else if (v === null || typeof v === "undefined") el.value = "";
+      else el.value = v;
+    });
+  }
+
+  function collect() {
+    var out = {};
+    FIELDS.forEach(function (f) {
+      var el = $(f.id);
+      if (!el) return;
+      if (f.type === "bool") out[f.key] = !!el.checked;
+      else if (f.type === "int") out[f.key] = parseInt(el.value, 10) || 0;
+      else out[f.key] = el.value || "";
+    });
+    return out;
+  }
+
+  function motionHint(json) {
+    // motion-triggered recording only fires when motion DETECTION is enabled
+    // (Streamer -> Motion), which is a different switch from this "mode" select
+    var modeEl = $("rec_mode");
+    var isMotion = modeEl && String(modeEl.value) === "1";
+    var m = json && json.motion;
+    if (isMotion && m && m.available && !m.enabled) {
+      toast(
+        "warning",
+        "Recording mode is “Motion-triggered”, but motion detection is OFF — enable it under Streamer → Motion, otherwise nothing will be recorded.",
+        9000,
+      );
+    }
+  }
+
+  function load() {
+    if (reloadBtn) reloadBtn.disabled = true;
+    window.timpsApi.get().then(function (json) {
+      fill(json && json.record);
+      setStatus(json && json.record);
+      motionHint(json);
+    }).catch(function (e) {
+      toast("danger", "Unable to load recorder settings: " + (e.message || e));
+    }).finally(function () {
+      if (reloadBtn) reloadBtn.disabled = false;
+    });
+  }
+
+  function save(ev) {
+    if (ev) ev.preventDefault();
+    if (saveBtn) saveBtn.disabled = true;
+    window.timpsApi.set({ record: collect() }).then(function () {
+      toast("success", "Recorder settings saved to timps.conf (applies to the next clip).", 4000);
+      load();
+    }).catch(function (e) {
+      toast("danger", "Failed to save recorder settings: " + (e.message || e));
+    }).finally(function () {
+      if (saveBtn) saveBtn.disabled = false;
+    });
+  }
+
+  if (form) form.addEventListener("submit", save);
+  if (reloadBtn) reloadBtn.addEventListener("click", load);
+
+  if (document.readyState === "loading")
+    document.addEventListener("DOMContentLoaded", load, { once: true });
+  else load();
+})();

--- a/package/timps/files/www/a/tool-sensor-data.js
+++ b/package/timps/files/www/a/tool-sensor-data.js
@@ -1,0 +1,397 @@
+(function () {
+  const chartCanvas = $("#dataChart");
+  if (!chartCanvas || typeof Chart === "undefined") return;
+
+  class SensorDataCollector {
+    constructor() {
+      this.maxPoints = 300;
+      this.data = {};
+      this.chart = null;
+      this.stream = null;
+      this.isPaused = false;
+      this.nightThreshold = null;
+      this.dayThreshold = null;
+      this.modeData = [];
+      this.stats = {};
+
+      this.metrics = [
+        { key: "ev", label: "Exposure Time (EV)", color: "#FF6384" },
+        { key: "total_gain", label: "Total Gain", color: "#36A2EB" },
+        { key: "ae_luma", label: "AE Luma", color: "#FFCE56" },
+        { key: "daynight_brightness", label: "Brightness %", color: "#B8FF4D" },
+      ];
+
+      this.init();
+    }
+
+    init() {
+      this.setupEventListeners();
+      this.initChart();
+      this.fetchThresholds();
+      this.startStream();
+    }
+
+    // day/night gain thresholds live in thingino.json (not timps); read them
+    // once from the thingino daynight config CGI for the chart reference lines.
+    async fetchThresholds() {
+      try {
+        const res = await fetch("/x/json-config-daynight.cgi", { cache: "no-store" });
+        if (!res.ok) return;
+        const cfg = await res.json();
+        const nt = parseInt(cfg.total_gain_night_threshold, 10);
+        const dt = parseInt(cfg.total_gain_day_threshold, 10);
+        if (!Number.isNaN(nt)) {
+          this.nightThreshold = nt;
+          this.chart.options.scales.y.max = nt + 200;
+        }
+        if (!Number.isNaN(dt)) this.dayThreshold = dt;
+      } catch (e) {
+        /* reference lines are optional */
+      }
+    }
+
+    setupEventListeners() {
+      const clearBtn = $("#clear-data");
+      const pauseBtn = $("#toggle-pause");
+      const exportJsonBtn = $("#export-json");
+      const exportCsvBtn = $("#export-csv");
+      const pointButtons = $$("#max-points button");
+
+      if (clearBtn) {
+        clearBtn.addEventListener("click", () => this.clearData());
+      }
+      if (pauseBtn) {
+        pauseBtn.addEventListener("click", (e) => this.togglePause(e));
+      }
+      if (exportJsonBtn) {
+        exportJsonBtn.addEventListener("click", () => this.exportJSON());
+      }
+      if (exportCsvBtn) {
+        exportCsvBtn.addEventListener("click", () => this.exportCSV());
+      }
+      pointButtons.forEach((btn) => {
+        btn.addEventListener("click", (e) => {
+          pointButtons.forEach((b) => {
+            b.classList.remove("btn-primary", "active");
+            b.classList.add("btn-secondary");
+          });
+          e.target.classList.remove("btn-secondary");
+          e.target.classList.add("btn-primary", "active");
+          this.maxPoints = parseInt(e.target.dataset.points, 10) || 300;
+          this.trimData();
+        });
+      });
+    }
+
+    initChart() {
+      this.chart = new Chart(chartCanvas.getContext("2d"), {
+        type: "line",
+        data: {
+          labels: [],
+          datasets: [],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          interaction: {
+            mode: "index",
+            intersect: false,
+          },
+          plugins: {
+            legend: {
+              display: false,
+            },
+          },
+          scales: {
+            x: {
+              display: true,
+              title: {
+                display: true,
+                text: "Time",
+              },
+            },
+            y: {
+              display: true,
+              min: 0,
+              max: 3200,
+              title: {
+                display: true,
+                text: "Raw Value",
+              },
+            },
+            y1: {
+              display: false,
+              type: "linear",
+              min: 0,
+              max: 1,
+              position: "right",
+            },
+          },
+        },
+      });
+    }
+
+    startStream() {
+      if (this.stream) return;
+      if (!window.timpsApi) {
+        console.error("timps-api.js not loaded");
+        this.updateStreamStatus(false);
+        return;
+      }
+      // timps pushes "daynight" over its native SSE /events on every change
+      // (mode flip / brightness / gain move): {enabled,mode,brightness,
+      // total_gain}. No polling - it also sends the current state on connect
+      // and auto-reconnects (token refresh + tab visibility) internally.
+      this.stream = window.timpsApi.events(
+        "daynight",
+        (type, d) => {
+          if (this.isPaused || !d) return;
+          this.updateStreamStatus(true);
+          this.addDataPoint({
+            time_now: Math.floor(Date.now() / 1000),
+            total_gain: d.total_gain,
+            daynight_brightness: d.brightness,
+            daynight_mode: Number(d.mode) === 1 ? "night" : "day",
+          });
+        },
+        () => this.updateStreamStatus(false),
+      );
+      this.updateStreamStatus(true);
+    }
+
+    addDataPoint(jsonData, updateChart = true) {
+      const timestamp = new Date(parseInt(jsonData.time_now, 10) * 1000);
+      const timeStr = timestamp.toLocaleTimeString();
+
+      this.chart.data.labels.push(timeStr);
+
+      if (
+        jsonData.total_gain_night_threshold !== undefined &&
+        this.nightThreshold === null
+      ) {
+        this.nightThreshold = parseInt(jsonData.total_gain_night_threshold, 10);
+        this.dayThreshold = parseInt(jsonData.total_gain_day_threshold, 10);
+        if (!Number.isNaN(this.nightThreshold)) {
+          this.chart.options.scales.y.max = this.nightThreshold + 200;
+        }
+      }
+
+      const currentMode = jsonData.daynight_mode === "night" ? 1 : 0;
+      this.modeData.push(currentMode);
+
+      this.metrics.forEach((metric) => {
+        if (!(metric.key in jsonData)) return;
+        if (!this.data[metric.key]) {
+          this.data[metric.key] = [];
+        }
+        const value = parseFloat(jsonData[metric.key]);
+        if (!Number.isNaN(value)) {
+          this.data[metric.key].push(value);
+          this.updateStats(metric.key, value);
+        }
+      });
+
+      this.trimData();
+      if (updateChart) {
+        this.updateChart();
+      }
+    }
+
+    updateStats(metricKey, value) {
+      if (!this.stats[metricKey]) {
+        this.stats[metricKey] = {
+          latest: value,
+          min: value,
+          max: value,
+          avg: value,
+          count: 1,
+          sum: value,
+        };
+      } else {
+        const stat = this.stats[metricKey];
+        stat.latest = value;
+        stat.min = Math.min(stat.min, value);
+        stat.max = Math.max(stat.max, value);
+        stat.count += 1;
+        stat.sum += value;
+        stat.avg = stat.sum / stat.count;
+      }
+
+      this.updateStatsDisplay();
+    }
+
+    updateStatsDisplay() {
+      const container = $("#data-stats");
+      if (!container) return;
+      container.innerHTML = "";
+
+      this.metrics.forEach((metric) => {
+        const stat = this.stats[metric.key];
+        if (!stat) return;
+        const div = document.createElement("div");
+        div.className = `stat-card ${metric.key}`;
+        div.innerHTML = `
+          <div class="stat-label">${metric.label}</div>
+          <div class="stat-value">${stat.latest.toFixed(1)}</div>
+          <div class="stat-detail">Min: ${stat.min.toFixed(1)} | Max: ${stat.max.toFixed(1)} | Avg: ${stat.avg.toFixed(1)}</div>
+        `;
+        container.appendChild(div);
+      });
+    }
+
+    updateChart() {
+      this.chart.data.datasets = [];
+
+      this.metrics.forEach((metric) => {
+        if (!this.data[metric.key]) return;
+        this.chart.data.datasets.push({
+          label: metric.label,
+          data: this.data[metric.key],
+          borderColor: metric.color,
+          backgroundColor: `${metric.color}20`,
+          borderWidth: 2,
+          tension: 0.4,
+          fill: false,
+          pointRadius: 1,
+          pointBackgroundColor: metric.color,
+          pointBorderColor: metric.color,
+          pointBorderWidth: 1,
+        });
+      });
+
+      if (this.nightThreshold !== null && this.data.total_gain) {
+        const labelCount = this.chart.data.labels.length;
+        if (!Number.isNaN(this.nightThreshold)) {
+          this.chart.data.datasets.push({
+            label: `Night Threshold (${this.nightThreshold})`,
+            data: Array(labelCount).fill(this.nightThreshold),
+            borderColor: "rgba(255, 0, 0, 0.7)",
+            borderWidth: 1,
+            borderDash: [5, 5],
+            fill: false,
+            pointRadius: 0,
+          });
+        }
+        if (this.dayThreshold !== null && !Number.isNaN(this.dayThreshold)) {
+          this.chart.data.datasets.push({
+            label: `Day Threshold (${this.dayThreshold})`,
+            data: Array(labelCount).fill(this.dayThreshold),
+            borderColor: "rgba(0, 255, 0, 0.7)",
+            borderWidth: 1,
+            borderDash: [5, 5],
+            fill: false,
+            pointRadius: 0,
+          });
+        }
+      }
+
+      if (this.modeData.length > 0) {
+        this.chart.data.datasets.push({
+          label: "Mode (0=Day, 1=Night)",
+          data: this.modeData,
+          borderColor: "rgba(128, 128, 128, 0.5)",
+          backgroundColor: "rgba(128, 128, 128, 0.1)",
+          borderWidth: 1,
+          tension: 0,
+          fill: false,
+          pointRadius: 0,
+          yAxisID: "y1",
+        });
+      }
+
+      this.chart.update("none");
+    }
+
+    trimData() {
+      if (this.chart.data.labels.length > this.maxPoints) {
+        const excess = this.chart.data.labels.length - this.maxPoints;
+        this.chart.data.labels.splice(0, excess);
+        this.modeData.splice(0, excess);
+        this.metrics.forEach((metric) => {
+          if (this.data[metric.key]) {
+            this.data[metric.key].splice(0, excess);
+          }
+        });
+      }
+    }
+
+    async clearData() {
+      const confirmed = await confirm("Clear all data?");
+      if (!confirmed) return;
+      this.data = {};
+      this.modeData = [];
+      this.stats = {};
+      this.chart.data.labels = [];
+      this.chart.data.datasets = [];
+      this.chart.update();
+      this.updateStatsDisplay();
+    }
+
+    togglePause(e) {
+      this.isPaused = !this.isPaused;
+      if (e && e.target) {
+        e.target.textContent = this.isPaused ? "Resume" : "Pause";
+        e.target.classList.toggle("btn-warning", this.isPaused);
+        e.target.classList.toggle("btn-secondary", !this.isPaused);
+      }
+    }
+
+    updateStreamStatus(connected) {
+      const statusIcon = $("#stream-status");
+      if (!statusIcon) return;
+      if (connected) {
+        statusIcon.classList.remove("disconnected");
+        statusIcon.classList.add("connected");
+        statusIcon.title = "Connected - Collecting sensor data";
+      } else {
+        statusIcon.classList.remove("connected");
+        statusIcon.classList.add("disconnected");
+        statusIcon.title = "Disconnected - Reconnecting...";
+      }
+    }
+
+    exportJSON() {
+      const payload = {
+        exported_at: new Date().toISOString(),
+        stats: this.stats,
+        datapoints: this.data,
+        labels: this.chart.data.labels,
+      };
+      this.downloadFile(
+        JSON.stringify(payload, null, 2),
+        "sensor-data.json",
+        "application/json",
+      );
+    }
+
+    exportCSV() {
+      const headers = this.metrics.map((m) => m.label).join(",");
+      const rows = this.chart.data.labels.map((label, idx) => {
+        const values = this.metrics
+          .map((m) => {
+            const series = this.data[m.key];
+            const value = series ? series[idx] : undefined;
+            return typeof value === "number" ? value.toFixed(2) : "";
+          })
+          .join(",");
+        return `"${label}",${values}`;
+      });
+      const csv = `Time,${headers}\n${rows.join("\n")}`;
+      this.downloadFile(csv, "sensor-data.csv", "text/csv");
+    }
+
+    downloadFile(content, filename, type) {
+      const blob = new Blob([content], { type });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    }
+  }
+
+  new SensorDataCollector();
+})();

--- a/package/timps/files/www/a/tool-timelapse.js
+++ b/package/timps/files/www/a/tool-timelapse.js
@@ -1,0 +1,106 @@
+/* tool-timelapse.js - timps native Timelapse Recorder settings.
+ *
+ * Replaces the stock thingino timelapse page (which edited /etc/timelapse.json
+ * + a cron entry calling a prudynt-derived capture script). This version talks
+ * DIRECTLY to the timps native timelapse via GET/POST /control (a/timps-api.js):
+ * every field maps to a timelapse.* config key, timps persists the changed
+ * keys into /etc/timps.conf itself and the running timelapse thread reads
+ * them live. Same structure as a/tool-record.js. */
+(function () {
+  "use strict";
+
+  if (!document.body || document.body.id !== "page-tool-timelapse") return;
+  if (!window.timpsApi) {
+    console.error("[tool-timelapse] timps-api.js not loaded");
+    return;
+  }
+
+  var $ = function (id) { return document.getElementById(id); };
+
+  // field id -> {key, type}. type: bool | int | str
+  var FIELDS = [
+    { id: "tl_enabled",  key: "enabled",    type: "bool" },
+    { id: "tl_dir",      key: "dir",        type: "str"  },
+    { id: "tl_name",     key: "name",       type: "str"  },
+    { id: "tl_channel",  key: "channel",    type: "int"  },
+    { id: "tl_interval", key: "interval_s", type: "int"  },
+    { id: "tl_keepdays", key: "keep_days",  type: "int"  },
+  ];
+
+  var form = $("tlForm");
+  var reloadBtn = $("tl-reload");
+  var saveBtn = $("tl-save");
+  var statusEl = $("tl-status");
+
+  function toast(type, msg, ms) {
+    if (typeof window.showAlert === "function") window.showAlert(type, msg, ms);
+    else console.log("[tool-timelapse]", type + ":", msg);
+  }
+
+  function setStatus(tl) {
+    if (!statusEl) return;
+    if (!tl || !tl.available) { statusEl.textContent = "Timelapse not available in this build."; return; }
+    var bits = [];
+    bits.push(tl.enabled ? "running" : "off");
+    if (tl.count > 0) bits.push(tl.count + " shot" + (tl.count === 1 ? "" : "s") + " since start");
+    if (tl.free_mb != null && tl.free_mb >= 0) bits.push(tl.free_mb + " MB free");
+    if (tl.last_file) bits.push(tl.last_file);
+    statusEl.textContent = bits.join(" · ");
+  }
+
+  function fill(tl) {
+    tl = tl || {};
+    FIELDS.forEach(function (f) {
+      var el = $(f.id);
+      if (!el) return;
+      var v = tl[f.key];
+      if (f.type === "bool") el.checked = (v === true || v === 1);
+      else if (v === null || typeof v === "undefined") el.value = "";
+      else el.value = v;
+    });
+  }
+
+  function collect() {
+    var out = {};
+    FIELDS.forEach(function (f) {
+      var el = $(f.id);
+      if (!el) return;
+      if (f.type === "bool") out[f.key] = !!el.checked;
+      else if (f.type === "int") out[f.key] = parseInt(el.value, 10) || 0;
+      else out[f.key] = el.value || "";
+    });
+    return out;
+  }
+
+  function load() {
+    if (reloadBtn) reloadBtn.disabled = true;
+    window.timpsApi.get().then(function (json) {
+      fill(json && json.timelapse);
+      setStatus(json && json.timelapse);
+    }).catch(function (e) {
+      toast("danger", "Unable to load timelapse settings: " + (e.message || e));
+    }).finally(function () {
+      if (reloadBtn) reloadBtn.disabled = false;
+    });
+  }
+
+  function save(ev) {
+    if (ev) ev.preventDefault();
+    if (saveBtn) saveBtn.disabled = true;
+    window.timpsApi.set({ timelapse: collect() }).then(function () {
+      toast("success", "Timelapse settings saved to timps.conf (applied live).", 4000);
+      load();
+    }).catch(function (e) {
+      toast("danger", "Failed to save timelapse settings: " + (e.message || e));
+    }).finally(function () {
+      if (saveBtn) saveBtn.disabled = false;
+    });
+  }
+
+  if (form) form.addEventListener("submit", save);
+  if (reloadBtn) reloadBtn.addEventListener("click", load);
+
+  if (document.readyState === "loading")
+    document.addEventListener("DOMContentLoaded", load, { once: true });
+  else load();
+})();

--- a/package/timps/files/www/config-audio.html
+++ b/package/timps/files/www/config-audio.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Audio Settings</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+</head>
+
+<body id="page-config-audio">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container" style="min-height:80vh">
+    <div data-app-controls></div>
+
+    <section>
+      <form id="audio-form" class="needs-validation" novalidate autocomplete="off">
+        <div class="card mb-3">
+          <div class="card-header">
+            <h2 class="card-title">Audio Settings</h2>
+            <small>Volume, gain, AGC, noise suppression and high-pass apply live. Codec, sampling rate, bitrate and stereo/speaker settings are saved and take effect after a streamer restart. Unsupported controls on this camera are greyed out.</small>
+            <button type="button" class="btn btn-outline-secondary" id="audio-reload" title="Reload values from camera">
+              <i class="bi bi-arrow-clockwise"></i> Reload
+            </button>
+          </div><!-- .card-header -->
+          <div class="card-body">
+            <h4>Microphone</h4>
+            <small>Parameters of the sound coming from the camera</small>
+            <div class="row row-cols-1 row-cols-md-2 row-cols-xl-4 mb-3">
+              <div class="col">
+                <p class="select" id="audio_mic_format_wrap">
+                  <label for="audio_mic_format">Codec</label>
+                  <select class="form-select" id="audio_mic_format" name="audio_mic_format">
+                    <option value="">- Select -</option>
+                    <option value="AAC">AAC</option>
+                    <option value="G711A">G711A</option>
+                    <option value="G711U">G711U</option>
+                    <option value="G726">G726</option>
+                    <option value="OPUS">OPUS</option>
+                    <option value="PCM">PCM</option>
+                  </select>
+                </p>
+                <p class="select" id="audio_mic_sample_rate_wrap">
+                  <label for="audio_mic_sample_rate">Sampling, Hz</label>
+                  <select class="form-select" id="audio_mic_sample_rate" name="audio_mic_sample_rate" data-option-values="8000,12000,16000,24000,48000">
+                    <option value="">- Select -</option>
+                  </select>
+                </p>
+                <p class="select" id="audio_mic_bitrate_wrap">
+                  <label for="audio_mic_bitrate">Bitrate, kbps</label>
+                  <select class="form-select" id="audio_mic_bitrate" name="audio_mic_bitrate" data-range-min="6" data-range-max="256" data-range-step="2">
+                    <option value="">- Select -</option>
+                  </select>
+                </p>
+              </div><!-- .col -->
+              <div class="col">
+                <p class="number-range">
+                  <label for="audio_mic_vol">Mic volume</label>
+                  <span class="input-group">
+                    <input type="text" id="audio_mic_vol" name="audio_mic_vol" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="-30" data-max="120" data-step="1">
+                    <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
+                  </span>
+                </p>
+                <p class="number-range">
+                  <label for="audio_mic_gain">Mic gain</label>
+                  <span class="input-group">
+                    <input type="text" id="audio_mic_gain" name="audio_mic_gain" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="0" data-max="31" data-step="1">
+                    <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
+                  </span>
+                </p>
+                <p class="number-range">
+                  <label for="audio_mic_alc_gain">
+                    <abbr title="Automatic Level Control">ALC</abbr> gain
+                  </label>
+                  <span class="input-group">
+                    <input type="text" id="audio_mic_alc_gain" name="audio_mic_alc_gain" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="0" data-max="7" data-step="1">
+                    <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
+                  </span>
+                </p>
+              </div><!-- .col -->
+              <div class="col">
+                <p class="number-range">
+                  <label for="audio_mic_noise_suppression">Noise suppression</label>
+                  <span class="input-group">
+                    <input type="text" id="audio_mic_noise_suppression" name="audio_mic_noise_suppression" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="0" data-max="3" data-step="1">
+                    <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
+                  </span>
+                </p>
+                <p class="number-range">
+                  <label for="audio_mic_agc_compression_gain_db">Compression gain, dB</label>
+                  <span class="input-group">
+                    <input type="text" id="audio_mic_agc_compression_gain_db" name="audio_mic_agc_compression_gain_db" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="0" data-max="90" data-step="1">
+                    <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
+                  </span>
+                </p>
+                <p class="number-range">
+                  <label for="audio_mic_agc_target_level_dbfs">Target level, dBfs</label>
+                  <span class="input-group">
+                    <input type="text" id="audio_mic_agc_target_level_dbfs" name="audio_mic_agc_target_level_dbfs" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="0" data-max="31" data-step="1">
+                    <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
+                  </span>
+                </p>
+              </div><!-- .col -->
+              <div class="col">
+                <p class="form-switch">
+                  <input type="hidden" id="audio_mic_agc_enabled-false" name="audio_mic_agc_enabled" value="false">
+                  <input type="checkbox" id="audio_mic_agc_enabled" name="audio_mic_agc_enabled" value="true" role="switch" class="form-check-input">
+                  <label for="audio_mic_agc_enabled" class="form-check-label"><abbr title="Automatic gain control">AGC</abbr> Enabled</label>
+                </p>
+                <p class="form-switch">
+                  <input type="hidden" id="audio_mic_high_pass_filter-false" name="audio_mic_high_pass_filter" value="false">
+                  <input type="checkbox" id="audio_mic_high_pass_filter" name="audio_mic_high_pass_filter" value="true" role="switch" class="form-check-input">
+                  <label for="audio_mic_high_pass_filter" class="form-check-label">High pass filter</label>
+                </p>
+                <p class="form-switch">
+                  <input type="hidden" id="audio_force_stereo-false" name="audio_force_stereo" value="false">
+                  <input type="checkbox" id="audio_force_stereo" name="audio_force_stereo" value="true" role="switch" class="form-check-input">
+                  <label for="audio_force_stereo" class="form-check-label">Force stereo</label>
+                </p>
+              </div><!-- .col -->
+            </div><!-- .row -->
+
+            <h4>Speaker</h4>
+            <small>Parameters of the sound played on the camera speaker</small>
+            <div class="row row-cols-1 row-cols-md-2 row-cols-xl-4 mb-3">
+              <p class="col number-range">
+                <label for="audio_spk_vol">Speaker volume</label>
+                <span class="input-group">
+                  <input type="text" id="audio_spk_vol" name="audio_spk_vol" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="-30" data-max="120" data-step="1">
+                  <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
+                </span>
+              </p>
+              <p class="col number-range">
+                <label for="audio_spk_gain">Speaker gain</label>
+                <span class="input-group">
+                  <input type="text" id="audio_spk_gain" name="audio_spk_gain" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="0" data-max="31" data-step="1">
+                  <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
+                </span>
+              </p>
+              <p class="col select" id="audio_spk_sample_rate_wrap">
+                <label for="audio_spk_sample_rate">Speaker sampling, Hz</label>
+                <select class="form-select" id="audio_spk_sample_rate" name="audio_spk_sample_rate" data-option-values="8000,12000,16000,24000,48000">
+                  <option value="">- Select -</option>
+                </select>
+              </p>
+            </div><!-- .row -->
+          </div><!-- .card-body -->
+        </div><!-- .card -->
+
+        <button type="button" id="save-prudynt-config" class="btn btn-primary">
+          <i class="bi bi-floppy me-1"></i> Save configuration to file
+        </button>
+      </form>
+    </section>
+  </div>
+</main>
+
+<footer data-app-footer></footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/config-audio.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/config-motion.html
+++ b/package/timps/files/www/config-motion.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<!--
+  thingino · Motion Detection (timps)
+
+  Configures the timps IMP_IVS grid motion detection through the
+  /x/json-prudynt.cgi bridge ({"motion":{...}} tree). All settings apply
+  LIVE (timps stops + recreates its IVS grid) and persist to
+  /etc/timps.conf. The grid size selectors are limited by the SoC/SDK cell
+  budget (caps.motion.max_cells via the bridge echo: 52 on most SoCs, 4 on
+  the old T10/T20 3.9.0 SDK). On SoCs without the IMP_IVS move API the page
+  shows a notice and stays disabled.
+
+  Event ACTIONS on motion (email/Telegram/webhook/...) are NOT configured
+  here - use Tools -> "Send to services"; timps triggers them through the
+  motion.on_motion command in /etc/timps.conf (config-file only, e.g.
+  "/usr/sbin/send2 -j").
+-->
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Motion Detection</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+  <style>
+    #motion-grid-preview {
+      display: grid;
+      gap: 2px;
+      width: 100%;
+      max-width: 320px;
+      aspect-ratio: 16 / 9;
+      background: #000;
+      border-radius: 0.375rem;
+      padding: 2px;
+    }
+    #motion-grid-preview .cell {
+      background: rgba(255, 255, 255, 0.08);
+      border: 1px solid rgba(255, 255, 255, 0.2);
+      border-radius: 2px;
+    }
+  </style>
+</head>
+
+<body id="page-config-motion">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container">
+    <div data-app-controls></div>
+
+    <h3>Motion Detection</h3>
+
+    <div id="motion-alerts"></div>
+
+    <div class="alert alert-warning d-none" id="motion-unavailable" role="alert">
+      <i class="bi bi-exclamation-triangle me-1"></i>
+      This SoC/SDK has no IMP motion detection (IMP_IVS move API unavailable)
+      &mdash; the feature is disabled.
+    </div>
+
+    <form id="motion-form">
+      <div class="row mb-3">
+        <div class="col-12 col-lg-8">
+          <div class="card mb-3">
+            <div class="card-header">
+              <h5 class="card-title mb-0">Detection grid</h5>
+            </div>
+            <div class="card-body">
+              <p class="boolean form-switch">
+                <input type="checkbox" id="motion_enabled" name="motion_enabled" class="form-check-input" role="switch">
+                <label for="motion_enabled" class="form-check-label ms-2">Enable motion detection</label>
+              </p>
+              <div class="row g-3">
+                <p class="col-6 col-md-3 select">
+                  <label for="motion_cols">Grid columns</label>
+                  <select class="form-select" id="motion_cols" name="motion_cols"></select>
+                </p>
+                <p class="col-6 col-md-3 select">
+                  <label for="motion_rows">Grid rows</label>
+                  <select class="form-select" id="motion_rows" name="motion_rows"></select>
+                </p>
+                <p class="col-12 col-md-6 select">
+                  <label for="motion_monitor_stream">Monitor stream</label>
+                  <select class="form-select" id="motion_monitor_stream" name="motion_monitor_stream">
+                    <option value="0">Main stream (stream 0)</option>
+                    <option value="1">Substream (stream 1)</option>
+                  </select>
+                </p>
+              </div>
+              <p class="range">
+                <label for="motion_sensitivity">Sensitivity
+                  <span class="badge text-bg-secondary" id="motion_sensitivity_value">-</span>
+                </label>
+                <input type="range" class="form-range" id="motion_sensitivity" name="motion_sensitivity"
+                  min="0" max="255" step="1">
+              </p>
+              <p class="text-secondary small mb-0" id="motion-caps-note"></p>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-12 col-lg-4">
+          <div class="card mb-3">
+            <div class="card-header">
+              <h5 class="card-title mb-0">Grid raster</h5>
+            </div>
+            <div class="card-body">
+              <div id="motion-grid-preview" aria-hidden="true"></div>
+              <p class="text-secondary small mt-2 mb-0">
+                The frame of the monitor stream is split evenly into these
+                cells; each cell reports motion on its own. Watch it live on
+                the <a href="/preview.html">Preview</a> page (grid overlay
+                button).
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </form>
+
+    <div class="alert alert-secondary" role="alert">
+      <i class="bi bi-info-circle me-1"></i>
+      All settings apply immediately and persist. Actions on motion
+      (email, Telegram, webhook, &hellip;) are configured under
+      <a href="/tool-send2.html" class="alert-link">Tools &rarr; Send to services</a>;
+      timps triggers them via the <code>motion.on_motion</code> command in
+      <code>/etc/timps.conf</code> (e.g. <code>/usr/sbin/send2 -j</code>,
+      rate-limited by <code>motion.cooldown_ms</code>).
+    </div>
+  </div>
+</main>
+
+<footer data-app-footer></footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/config-motion.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/config-photosensing.html
+++ b/package/timps/files/www/config-photosensing.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Photosensing</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+</head>
+
+<body id="page-config-photosensing">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container" style="min-height:80vh">
+    <div data-app-controls></div>
+
+    <section>
+      <form id="photosensing-form" class="needs-validation" novalidate  autocomplete="off">
+        <div class="card mb-3">
+          <div class="card-header">
+            <h2 class="card-title">Photosensing</h2>
+            <small>Configure the day/night automation thresholds and the controls it toggles.</small>
+            <button type="button" class="btn btn-outline-secondary" id="photosensing-reload" title="Reload values from camera">
+              <i class="bi bi-arrow-clockwise"></i> Reload
+            </button>
+          </div><!-- .card-header -->
+          <div class="card-body">
+            <div class="row row-cols-lg-3 g-4">
+              <div class="col">
+                <h4>Thresholds</h4>
+                <small>Maximum and minimum boundaries of Day/Night modes</small>
+                <p class="form-switch">
+                  <input type="hidden" id="daynight_enabled-false" name="daynight_enabled" value="false">
+                  <input type="checkbox" id="daynight_enabled" name="daynight_enabled" value="true" role="switch" class="form-check-input">
+                  <label for="daynight_enabled" class="form-check-label">Enable photosensing on boot</label>
+                </p>
+                <p class="number-range">
+                  <label for="daynight_total_gain_night_threshold">Switch to night mode above</label>
+                  <span class="input-group">
+                    <input type="text" id="daynight_total_gain_night_threshold" name="daynight_total_gain_night_threshold" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="0" data-max="40000" data-step="1">
+                    <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
+                  </span>
+                </p>
+                <p class="number-range">
+                  <label for="daynight_total_gain_day_threshold">Switch to day mode below</label>
+                  <span class="input-group">
+                    <input type="text" id="daynight_total_gain_day_threshold" name="daynight_total_gain_day_threshold" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="0" data-max="40000" data-step="1">
+                    <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
+                  </span>
+                </p>
+              </div>
+              <div class="col">
+                <h4>Controls</h4>
+                <small>Select actions to perform when changing Day/Night mode</small>
+                <p class="form-switch">
+                  <input type="hidden" id="daynight_controls_color-false" name="daynight_controls_color" value="false">
+                  <input type="checkbox" id="daynight_controls_color" name="daynight_controls_color" value="true" role="switch" class="form-check-input">
+                  <label for="daynight_controls_color" class="form-check-label">Change color mode</label>
+                </p>
+                <p class="form-switch">
+                  <input type="hidden" id="daynight_controls_ircut-false" name="daynight_controls_ircut" value="false">
+                  <input type="checkbox" id="daynight_controls_ircut" name="daynight_controls_ircut" value="true" role="switch" class="form-check-input">
+                  <label for="daynight_controls_ircut" class="form-check-label">Flip IR cut filter</label>
+                </p>
+                <p class="form-switch">
+                  <input type="hidden" id="daynight_controls_ir850-false" name="daynight_controls_ir850" value="false">
+                  <input type="checkbox" id="daynight_controls_ir850" name="daynight_controls_ir850" value="true" role="switch" class="form-check-input">
+                  <label for="daynight_controls_ir850" class="form-check-label">Toggle IR 850 nm</label>
+                </p>
+                <p class="form-switch">
+                  <input type="hidden" id="daynight_controls_ir940-false" name="daynight_controls_ir940" value="false">
+                  <input type="checkbox" id="daynight_controls_ir940" name="daynight_controls_ir940" value="true" role="switch" class="form-check-input">
+                  <label for="daynight_controls_ir940" class="form-check-label">Toggle IR 940 nm</label>
+                </p>
+                <p class="form-switch">
+                  <input type="hidden" id="daynight_controls_white-false" name="daynight_controls_white" value="false">
+                  <input type="checkbox" id="daynight_controls_white" name="daynight_controls_white" value="true" role="switch" class="form-check-input">
+                  <label for="daynight_controls_white" class="form-check-label">Toggle white light</label>
+                </p>
+              </div>
+              <div class="col">
+                <h4>Time Schedule</h4>
+                <small>Enable/disable photosensing at specific times</small>
+                <p class="form-switch mt-3">
+                  <input type="hidden" id="daynight_schedule_enabled-false" name="daynight_schedule_enabled" value="false">
+                  <input type="checkbox" id="daynight_schedule_enabled" name="daynight_schedule_enabled" value="true" role="switch" class="form-check-input">
+                  <label for="daynight_schedule_enabled" class="form-check-label">Use time-based schedule</label>
+                </p>
+                <p>
+                  <label for="daynight_schedule_start_at">Start photosensing at</label>
+                  <input type="time" id="daynight_schedule_start_at" name="daynight_schedule_start_at" class="form-control" value="">
+                </p>
+                <p>
+                  <label for="daynight_schedule_stop_at">Stop photosensing at</label>
+                  <input type="time" id="daynight_schedule_stop_at" name="daynight_schedule_stop_at" class="form-control" value="">
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <button type="button" id="save-prudynt-config" class="btn btn-primary">
+          <i class="bi bi-floppy me-1"></i> Save changes
+        </button>
+      </form>
+    </div>
+  </section>
+</main>
+
+<footer data-app-footer></footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/config-photosensing.js"></script></body>
+</html>

--- a/package/timps/files/www/config-privacy.html
+++ b/package/timps/files/www/config-privacy.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<!--
+  thingino · Privacy masks (timps) — visual region editor
+
+  Solid cover rectangles per video stream, edited by dragging/resizing boxes
+  over a live snapshot. Talks DIRECTLY to timps /control (privacy section) via
+  a/timps-api.js - no bridge. Changes apply live.
+-->
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Privacy Masks</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+  <style>
+    .pm-stage {
+      position: relative; width: 100%; max-width: 760px;
+      background: #000; border-radius: .375rem; overflow: hidden;
+      user-select: none; touch-action: none;
+    }
+    .pm-stage img { display: block; width: 100%; height: auto; }
+    .pm-empty {
+      position: absolute; inset: 0; display: flex; align-items: center;
+      justify-content: center; color: var(--bs-secondary-color); font-size: .9rem;
+      text-align: center; padding: 1rem;
+    }
+    .pm-box {
+      position: absolute; box-sizing: border-box; cursor: move;
+      border: 2px solid rgba(255,80,80,.95); background: rgba(255,40,40,.28);
+    }
+    .pm-box.sel { border-color: #ffd24d; box-shadow: 0 0 0 1px #000; }
+    .pm-box.off { border-style: dashed; background: rgba(128,128,128,.22); }
+    .pm-box .pm-handle {
+      position: absolute; width: 16px; height: 16px; right: -8px; bottom: -8px;
+      background: #fff; border: 1px solid #333; border-radius: 3px;
+      cursor: nwse-resize;
+    }
+    .pm-box .pm-tag {
+      position: absolute; left: 2px; top: 2px; font-size: 11px; line-height: 1.3;
+      background: rgba(0,0,0,.6); color: #fff; padding: 0 4px; border-radius: 2px;
+    }
+  </style>
+</head>
+
+<body id="page-config-privacy">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container" style="min-height:80vh">
+    <div data-app-controls></div>
+
+    <h3>Privacy masks</h3>
+    <div id="privacy-alerts"></div>
+    <div class="alert alert-warning d-none" id="privacy-unavailable" role="alert">
+      <i class="bi bi-exclamation-triangle me-1"></i>
+      The streamer does not report privacy support (or is unreachable) &mdash;
+      the editor is disabled.
+    </div>
+
+    <div class="d-flex flex-wrap gap-2 align-items-center mb-2">
+      <label for="pm-stream" class="mb-0">Stream</label>
+      <select id="pm-stream" class="form-select w-auto">
+        <option value="0">Main (stream 0)</option>
+        <option value="1">Substream (stream 1)</option>
+      </select>
+      <button type="button" id="pm-add" class="btn btn-primary btn-sm">
+        <i class="bi bi-plus-lg"></i> Add mask
+      </button>
+      <button type="button" id="pm-reload" class="btn btn-outline-secondary btn-sm" title="Reload snapshot & values">
+        <i class="bi bi-arrow-clockwise"></i>
+      </button>
+      <span class="text-secondary small">Drag a box to move, the corner handle to resize. Up to <span id="privacy-max">4</span> per stream.</span>
+    </div>
+
+    <div class="row">
+      <div class="col-12 col-xl-8">
+        <div id="pm-stage" class="pm-stage">
+          <img id="pm-img" alt="Stream snapshot">
+          <div class="pm-empty d-none" id="pm-noimg">No snapshot &mdash; you can still add masks and type coordinates.</div>
+        </div>
+      </div>
+      <div class="col-12 col-xl-4">
+        <div id="pm-list" class="mt-3 mt-xl-0"></div>
+      </div>
+    </div>
+  </div>
+</main>
+
+<footer data-app-footer></footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/privacy.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/preview-timps.html
+++ b/package/timps/files/www/preview-timps.html
@@ -1,0 +1,382 @@
+<!DOCTYPE html>
+<!--
+  thingino · timps preview
+
+  Native MSE/fMP4 player (no iframe): fetches
+      http://<location.hostname>:8880/stream.mp4?chn=N
+  from timpsd and feeds it into a MediaSource SourceBuffer. The
+  buffering/eviction/live-edge logic is a port of timps's own embedded
+  player (src/mp4/httpd.c, PLAYER_TAIL). The motor joystick overlay and
+  /a/preview-motors.js are taken over UNCHANGED from preview-raptor.html, so
+  PTZ keeps working through thingino's /x/json-motor.cgi.
+
+  IMPORTANT - KNOWN LIMITATION (mixed content):
+  The video is loaded from plain HTTP on port 8880. If this web UI itself is
+  served over HTTPS, browsers block the http://<camera>:8880 request as mixed
+  content and the preview stays black. Workarounds: serve the web UI over
+  HTTP, or reverse-proxy timps's HTTP port under the same HTTPS origin.
+
+  If you change http.port in /etc/timps.conf, adjust MS_PORT below.
+-->
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · timps preview</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+  <style>
+    .ms-video-wrap {
+      position: relative;
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      background: #000;
+      border-radius: 0.5rem;
+      overflow: hidden;
+    }
+    .ms-video-wrap video {
+      width: 100%;
+      height: 100%;
+      background: #000;
+      object-fit: contain;
+    }
+    /* live motion-grid overlay (drawn by /a/preview-motion.js); it never
+       captures the pointer, so the motor joystick keeps working */
+    #motion-overlay {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+    }
+    .ms-hint {
+      font-size: 0.875rem;
+      color: var(--bs-secondary-color);
+    }
+  </style>
+</head>
+
+<body id="page-preview">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container" style="min-height:80vh">
+    <div data-app-controls></div>
+
+    <section>
+      <div class="card mb-3">
+        <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
+          <div>
+            <h2 class="card-title mb-0">timps Live View</h2>
+            <small>Native fMP4/MSE player (no iframe), stream from port 8880</small>
+          </div>
+          <div class="d-flex gap-2">
+            <select class="form-select form-select-sm" id="ms-stream" title="Select stream" style="width:auto; min-width: 140px;">
+              <option value="0">Main stream</option>
+              <option value="1">Sub stream</option>
+            </select>
+            <!-- motion-grid overlay toggle: hidden until /a/preview-motion.js
+                 confirms this timps build has IMP_IVS motion detection -->
+            <button type="button" class="btn btn-outline-secondary" id="ms-motion"
+              title="Motion grid overlay" style="display:none">
+              <i class="bi bi-grid-3x3"></i>
+            </button>
+            <button type="button" class="btn btn-outline-secondary" id="ms-connect" title="Connect/Disconnect stream">
+              <i class="bi bi-play-circle"></i> Connect
+            </button>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="ms-video-wrap">
+            <video id="ms-video" autoplay muted controls playsinline></video>
+            <canvas id="motion-overlay" style="display:none" aria-hidden="true"></canvas>
+            <div class="position-absolute top-50 start-50 translate-middle text-center" id="ms-connecting-overlay" style="display:none;">
+              <div class="spinner-border text-light mb-2" role="status" style="width:3rem;height:3rem;">
+                <span class="visually-hidden">Connecting...</span>
+              </div>
+              <div class="text-light small">Connecting...</div>
+            </div>
+            <div class="position-absolute top-50 start-50 translate-middle" id="motor-overlay" style="display:none">
+              <div id="motor">
+                <div class="jst">
+                  <a class="s" data-dir="uc"></a>
+                  <a class="s" data-dir="ur"></a>
+                  <a class="s" data-dir="cr"></a>
+                  <a class="s" data-dir="dr"></a>
+                  <a class="s" data-dir="dc"></a>
+                  <a class="s" data-dir="dl"></a>
+                  <a class="s" data-dir="cl"></a>
+                  <a class="s" data-dir="ul"></a>
+                  <a class="b" data-dir="h"></a>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="ms-hint mt-2" id="ms-status"></div>
+        </div>
+      </div>
+    </section>
+  </div>
+</main>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script>
+  (function () {
+    // timps's HTTP server port (http.port in /etc/timps.conf)
+    const MS_PORT = 8880;
+
+    const video = document.getElementById("ms-video");
+    const connectButton = document.getElementById("ms-connect");
+    const streamSelect = document.getElementById("ms-stream");
+    const status = document.getElementById("ms-status");
+    const overlay = document.getElementById("ms-connecting-overlay");
+    if (!video || !connectButton || !streamSelect || !status) return;
+
+    let host = location.hostname || "127.0.0.1";
+    if (host.indexOf(":") >= 0 && host[0] !== "[") host = "[" + host + "]"; // raw IPv6
+    let base = "http://" + host + ":" + MS_PORT;   /* updated from the token info (scheme/port) */
+
+    // Per-boot timps token, fetched ONCE and shared with preview-motion.js
+    // (which subscribes to /events with it). Appended as ?token= to the
+    // /stream.mp4 fetch so the preview also works when http.user is set in
+    // timps.conf - the token unlocks media viewing + /control + /events,
+    // never RTSP. Resolves to null when the endpoint is unavailable (e.g.
+    // prudynt build); the stream is then fetched without a token and the
+    // existing 401 fallback message still applies.
+    window.timpsTokenInfo = window.timpsTokenInfo ||
+      fetch("/x/timps-token.cgi", { cache: "no-store" })
+        .then((r) => (r.ok ? r.json() : null))
+        .catch(() => null);
+
+    const params = new URLSearchParams(window.location.search);
+    const defaultStream = params.get("stream") || sessionStorage.getItem("ms.stream") || "0";
+
+    let mediaSource = null;
+    let abortCtrl = null;
+    let running = false;
+    // Monotonic stream-session token: every start/stop bumps it. The async
+    // MSE plumbing of an old session (reader loop, sourceopen tail) checks
+    // its captured token before touching shared state/UI, so switching
+    // streams live (stop+start in quick succession) can never let the dying
+    // session kill or "disconnect" the new one.
+    let session = 0;
+
+    function setStatus(message) { status.textContent = message; }
+
+    function setConnectingUi(active) {
+      if (overlay) overlay.style.display = active ? "" : "none";
+      if (active) {
+        connectButton.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span>Connecting…';
+        connectButton.disabled = true;
+      } else {
+        connectButton.disabled = false;
+      }
+    }
+
+    function setConnectedUi(connected) {
+      connectButton.innerHTML = connected
+        ? '<i class="bi bi-stop-circle"></i> Disconnect'
+        : '<i class="bi bi-play-circle"></i> Connect';
+      // the stream select stays enabled while connected: picking another
+      // stream live tears the player down and rebuilds it on the new channel
+      if (connected) setConnectingUi(false);
+    }
+
+    // The embedded timps player derives the exact codec string from the
+    // live SPS server-side; a static page cannot, so probe common strings.
+    // The init segment carries the real avcC/hvcC, so a generic profile in
+    // the MIME string is fine for MSE.
+    function pickMime() {
+      const candidates = [
+        'video/mp4; codecs="avc1.640028, mp4a.40.2"', // H.264 High + AAC
+        'video/mp4; codecs="avc1.640028"',            // H.264 High, video only
+        'video/mp4; codecs="hvc1.1.6.L123.B0, mp4a.40.2"', // H.265 + AAC
+        'video/mp4; codecs="hvc1.1.6.L123.B0"'        // H.265, video only
+      ];
+      for (const m of candidates) {
+        if (MediaSource.isTypeSupported(m)) return m;
+      }
+      return null;
+    }
+
+    async function stopStream(reason = "Disconnected") {
+      session++;              // invalidate all async work of the old session
+      running = false;
+      if (abortCtrl) {
+        try { abortCtrl.abort(); } catch (e) { /* ignore */ }
+        abortCtrl = null;
+      }
+      if (mediaSource) {
+        try { if (mediaSource.readyState === "open") mediaSource.endOfStream(); } catch (e) { /* ignore */ }
+        mediaSource = null;
+      }
+      video.removeAttribute("src");
+      try { video.load(); } catch (e) { /* ignore */ }
+      setConnectingUi(false);
+      setConnectedUi(false);
+      setStatus(reason);
+    }
+
+    // Port of timps's embedded MSE player (src/mp4/httpd.c PLAYER_TAIL):
+    // sequence mode, append queue with pump(), eviction of data >10 s behind
+    // playback, live-edge jump when drifting >6 s behind.
+    async function startStream() {
+      if (running) return;
+      running = true;
+      const mySession = ++session;   // this attempt owns the player now
+      setStatus("Connecting...");
+      setConnectingUi(true);
+
+      const chn = streamSelect.value === "1" ? "1" : "0";
+      const info = await window.timpsTokenInfo;
+      if (info) base = (info.tls ? "https" : "http") + "://" + host + ":" + (info.port || MS_PORT);
+      const tok = info && info.token
+        ? "&token=" + encodeURIComponent(info.token) : "";
+      const src = base + "/stream.mp4?chn=" + chn + tok;
+      const mime = pickMime();
+
+      if (!window.MediaSource || !mime) {
+        // no MSE (e.g. old iOS Safari): let the <video> try progressive mp4
+        video.src = src;
+        setConnectedUi(true);
+        setStatus("MSE unavailable - direct playback attempt");
+        return;
+      }
+
+      const ms = new MediaSource();
+      mediaSource = ms;
+      video.src = URL.createObjectURL(ms);
+
+      ms.addEventListener("sourceopen", async () => {
+        if (session !== mySession) return;   // superseded while opening
+        let sb;
+        try {
+          sb = ms.addSourceBuffer(mime);
+        } catch (e) {
+          video.src = src;
+          return;
+        }
+        sb.mode = "sequence";
+        let dead = false;
+        const q = [];
+        let busy = false;
+
+        const stop = () => {
+          dead = true;
+          try { if (ms.readyState === "open") ms.endOfStream(); } catch (e) { /* ignore */ }
+        };
+        // drop buffered data older than ~10s behind playback so the
+        // SourceBuffer never fills up during a long-running live stream
+        const evict = () => {
+          try {
+            if (sb.buffered.length) {
+              const s = sb.buffered.start(0), e = video.currentTime - 10;
+              if (e > s + 4 && !sb.updating) sb.remove(s, e);
+            }
+          } catch (e) { /* ignore */ }
+        };
+        const pump = () => {
+          if (dead || busy || sb.updating || ms.readyState !== "open" || !q.length) return;
+          busy = true;
+          const c = q[0];
+          try { sb.appendBuffer(c); q.shift(); }
+          catch (e) {
+            busy = false;
+            if (e.name === "QuotaExceededError") evict(); else stop();
+          }
+        };
+        sb.addEventListener("updateend", () => {
+          busy = false;
+          if (video.buffered.length) {
+            if (video.currentTime < video.buffered.start(0)) video.currentTime = video.buffered.start(0);
+            // keep close to the live edge; if we drift >6s behind, jump forward
+            const end = video.buffered.end(video.buffered.length - 1);
+            if (end - video.currentTime > 6) video.currentTime = end - 1;
+          }
+          evict();
+          pump();
+        });
+        sb.addEventListener("error", stop);
+
+        const ctrl = new AbortController();
+        abortCtrl = ctrl;
+        try {
+          const res = await fetch(src, { signal: ctrl.signal, cache: "no-store" });
+          if (session !== mySession) {           // superseded mid-connect
+            try { ctrl.abort(); } catch (e) { /* ignore */ }
+            stop();
+            return;
+          }
+          if (!res.ok || !res.body) {
+            await stopStream("Connect failed: HTTP " + res.status +
+              (res.status === 401 ? " (timps HTTP auth - open " + base + " once and log in)" : ""));
+            return;
+          }
+          setConnectedUi(true);
+          setStatus("Connected (" + (chn === "1" ? "sub" : "main") + " stream)");
+          const rd = res.body.getReader();
+          while (true) {
+            const { done, value } = await rd.read();
+            if (done || dead || session !== mySession) break;
+            q.push(value);
+            pump();
+          }
+        } catch (e) {
+          if (session === mySession && running) {
+            setStatus("Stream error: " + (e && e.message ? e.message : e) +
+              " - if the web UI runs on HTTPS this is likely blocked mixed content (see page source)");
+          }
+        }
+        stop();
+        // only the still-current session may flip the UI back to disconnected
+        if (session === mySession && running) {
+          setConnectedUi(false);
+          setConnectingUi(false);
+          running = false;
+        }
+      });
+    }
+
+    // live main/sub switch: selecting another stream while playing tears the
+    // MSE player down and rebuilds it on the new ?chn= (a different
+    // resolution/SPS needs a fresh MediaSource) - no manual Disconnect needed
+    streamSelect.addEventListener("change", () => {
+      sessionStorage.setItem("ms.stream", streamSelect.value || "0");
+      if (running) {
+        stopStream("Switching stream...").then(startStream);
+      }
+    });
+
+    connectButton.addEventListener("click", () => {
+      if (running) stopStream(); else startStream();
+    });
+
+    window.addEventListener("pagehide", () => {
+      if (running) stopStream();
+    });
+
+    streamSelect.value = defaultStream === "1" ? "1" : "0";
+    setConnectedUi(false);
+    startStream().catch((err) => {
+      console.warn("Auto-connect failed:", err);
+      setStatus("Auto-connect failed. Click Connect to try again.");
+    });
+  })();
+</script>
+<script src="/a/preview-motors.js"></script>
+<script src="/a/preview-motion.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/recordings.html
+++ b/package/timps/files/www/recordings.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<!-- thingino · Recordings (timps SD segments, via /x/json-recordings.cgi) -->
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Recordings</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+</head>
+
+<body id="page-recordings">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container" style="min-height:80vh">
+    <div data-app-controls></div>
+
+    <div class="d-flex align-items-center flex-wrap gap-2">
+      <h3 class="mb-0">Recordings</h3>
+      <button type="button" id="rec-reload" class="btn btn-outline-secondary btn-sm" title="Reload">
+        <i class="bi bi-arrow-clockwise"></i>
+      </button>
+      <span class="text-secondary small" id="rec-info"></span>
+    </div>
+
+    <div id="rec-alerts" class="mt-2"></div>
+
+    <div class="table-responsive mt-2">
+      <table class="table table-sm align-middle">
+        <thead><tr><th>Recorded</th><th>Segment</th><th class="text-end">Size</th><th class="text-end">Actions</th></tr></thead>
+        <tbody id="rec-list"><tr><td colspan="4" class="text-secondary">Loading…</td></tr></tbody>
+      </table>
+    </div>
+  </div>
+</main>
+
+<footer data-app-footer></footer>
+
+<div class="modal fade" id="recModal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="recModalTitle">Playback</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <video id="rec-video" class="w-100" controls preload="metadata" style="background:#000"></video>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/recordings.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/streamer-config.html
+++ b/package/timps/files/www/streamer-config.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Streamer config</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+</head>
+
+<body id="page-streamer-config">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container" style="min-height:80vh">
+    <div data-app-controls></div>
+
+    <section>
+      <div class="card mb-3">
+        <div class="card-header">
+          <h2 class="card-title">Streamer config</h2>
+          <small>The live timps configuration file (<code>/etc/timps.conf</code>).</small>
+          <button type="button" class="btn btn-outline-secondary" id="conf-reload" title="Reload from camera">
+            <i class="bi bi-arrow-clockwise"></i> Reload
+          </button>
+        </div><!-- .card-header -->
+        <div class="card-body">
+          <div class="alert alert-secondary" role="alert">
+            Most settings are applied live from the Streamer pages (Image, OSD, Motion, …).
+            Advanced keys that have no page — TLS/HTTPS, SRT, <code>motion.hold_ms</code>,
+            <code>motion.skip_frames</code> — live only here; edit <code>/etc/timps.conf</code>
+            on the camera and restart the streamer to apply them.
+          </div>
+          <pre id="conf-view" class="terminal" style="max-height:70vh;overflow:auto;white-space:pre;">Loading…</pre>
+        </div><!-- .card-body -->
+      </div><!-- .card -->
+    </section>
+  </div>
+</main>
+
+<footer data-app-footer></footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script>
+/* Read-only viewer of /etc/timps.conf via the stock texteditor.cgi (auth'd by
+ * the WebUI session; no timps token / port needed, so it works over http or
+ * https alike). timps persists every /control change to this file, so this is
+ * always the effective running config. */
+(function () {
+  "use strict";
+  var CONF = "/etc/timps.conf";
+  var view = document.getElementById("conf-view");
+  var btn = document.getElementById("conf-reload");
+
+  function b64decode(s) {
+    try { return decodeURIComponent(escape(window.atob(s))); }
+    catch (e) { try { return window.atob(s); } catch (e2) { return ""; } }
+  }
+
+  async function load() {
+    if (btn) btn.disabled = true;
+    view.textContent = "Loading…";
+    try {
+      var res = await fetch("/x/texteditor.cgi?file=" + encodeURIComponent(CONF),
+                            { cache: "no-store" });
+      var data = await res.json();
+      if (!res.ok || (data && data.error))
+        throw new Error(data && data.error ? data.error.message : "HTTP " + res.status);
+      var content = data.content || "";
+      if (data.content_encoding === "base64") content = b64decode(content);
+      view.textContent = content || "(empty)";
+    } catch (err) {
+      view.textContent = "Unable to load " + CONF + ": " + (err.message || err);
+    } finally {
+      if (btn) btn.disabled = false;
+    }
+  }
+
+  if (btn) btn.addEventListener("click", load);
+  if (document.readyState === "loading")
+    document.addEventListener("DOMContentLoaded", load, { once: true });
+  else load();
+})();
+</script>
+</body>
+</html>

--- a/package/timps/files/www/streamer-image.html
+++ b/package/timps/files/www/streamer-image.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Image Quality</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+</head>
+
+<body id="page-streamer-image">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container">
+    <div data-app-controls></div>
+
+    <h3>Image Quality</h3>
+
+    <div class="row mb-3">
+      <div class="col-12 col-xl-4 mb-3">
+        <div id="frame" class="position-relative">
+          <img id="preview" src="/a/nostream.svg" class="img-fluid" alt="Image: Preview" tabindex="-1" data-stream="ch1">
+        </div>
+      </div>
+      <div class="col col-xl-8">
+        <div class="row g-2">
+          <div class="col">
+            <p>
+              <label for="brightness">Brightness</label>
+              <input type="text" id="brightness" name="brightness" class="form-control text-end" value="" pattern="[0-9]{1,}" data-min="0" data-max="255" data-step="1">
+            </p>
+            <p>
+              <label for="contrast">Contrast</label>
+              <input type="text" id="contrast" name="contrast" class="form-control text-end" value="" pattern="[0-9]{1,}" data-min="0" data-max="255" data-step="1">
+            </p>
+            <p>
+              <label for="sharpness">Sharpness</label>
+              <input type="text" id="sharpness" name="sharpness" class="form-control text-end" value="" pattern="[0-9]{1,}" data-min="0" data-max="255" data-step="1">
+            </p>
+            <p>
+              <label for="saturation">Saturation</label>
+              <input type="text" id="saturation" name="saturation" class="form-control text-end" value="" pattern="[0-9]{1,}" data-min="0" data-max="255" data-step="1">
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p>
+              <label for="backlight">Backlight</label>
+              <input type="text" id="backlight" name="backlight" class="form-control text-end" value="" pattern="[0-9]{1,}" data-min="0" data-max="10" data-step="1">
+            </p>
+            <p>
+              <label for="wide_dynamic_range">WDR</label><span class="input-group">
+              <input type="text" id="wide_dynamic_range" name="wide_dynamic_range" class="form-control text-end" value="" pattern="[0-9]{1,}" data-min="0" data-max="255" data-step="1">
+            </p>
+            <p>
+              <label for="tone">Highlights</label>
+              <input type="text" id="tone" name="tone" class="form-control text-end" value="" pattern="[0-9]{1,}" data-min="0" data-max="255" data-step="1">
+            </p>
+            <p>
+              <label for="defog">Defog</label>
+              <input type="text" id="defog" name="defog" class="form-control text-end" value="" pattern="[0-9]{1,}" data-min="0" data-max="255" data-step="1">
+            </p>
+            <p>
+              <label for="noise_reduction">Noise reduction</label>
+              <input type="text" id="noise_reduction" name="noise_reduction" class="form-control text-end" value="" pattern="[0-9]{1,}" data-min="0" data-max="255" data-step="1">
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p class="select" id="image_core_wb_mode_wrap">
+              <label for="image_core_wb_mode">White balance mode</label>
+              <select class="form-select" id="image_core_wb_mode" name="image_core_wb_mode">
+                <option value="0">AUTO</option>
+                <option value="1">MANUAL</option>
+                <option value="2">DAY LIGHT</option>
+                <option value="3">CLOUDY</option>
+                <option value="4">INCANDESCENT</option>
+                <option value="5">FLOURESCENT</option>
+                <option value="6">TWILIGHT</option>
+                <option value="7">SHADE</option>
+                <option value="8">WARM FLOURESCENT</option>
+                <option value="9">CUSTOM</option>
+              </select>
+            </p>
+            <p>
+              <label for="image_wb_bgain">Blue channel gain</label>
+              <input type="text" id="image_wb_bgain" name="image_wb_bgain" class="form-control text-end" value="" pattern="[0-9]{1,}" data-min="0" data-max="1024" data-step="1">
+            </p>
+            <p>
+              <label for="image_wb_rgain">Red channel gain</label>
+              <input type="text" id="image_wb_rgain" name="image_wb_rgain" class="form-control text-end" value="" pattern="[0-9]{1,}" data-min="0" data-max="1024" data-step="1">
+            </p>
+            <p>
+              <label for="image_ae_compensation"><abbr title="Automatic Exposure">AE</abbr> compensation</label>
+              <input type="text" id="image_ae_compensation" name="image_ae_compensation" class="form-control text-end" value="" pattern="[0-9]{1,}" data-min="0" data-max="255" data-step="1">
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p class="boolean form-switch" id="image_hflip_wrap">
+              <input type="hidden" id="image_hflip-false" name="image_hflip" value="false">
+              <input type="checkbox" id="image_hflip" name="image_hflip" value="true" role="switch" class="form-check-input">
+              <label for="image_hflip" class="form-check-label">H-Flip</label>
+            </p>
+            <p class="boolean form-switch" id="image_vflip_wrap">
+              <input type="hidden" id="image_vflip-false" name="image_vflip" value="false">
+              <input type="checkbox" id="image_vflip" name="image_vflip" value="true" role="switch" class="form-check-input">
+              <label for="image_vflip" class="form-check-label">V-Flip</label>
+            </p>
+          </div><!-- .col -->
+        </div><!-- .row -->
+      </div><!-- .col -->
+    </div><!-- .row -->
+
+    <button type="button" id="save-prudynt-config" class="btn btn-primary mt-3">
+      <i class="bi bi-floppy me-1"></i> Save configuration to file
+    </button>
+  </div><!-- .container -->
+</main>
+
+<footer data-app-footer></footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="/a/preview.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/streamer-image.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/streamer-main.html
+++ b/package/timps/files/www/streamer-main.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · RTSP Main Stream</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+</head>
+
+<body id="page-streamer-main">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container">
+    <div data-app-controls></div>
+
+    <h3>RTSP Main Stream</h3>
+
+    <div class="row mb-3">
+      <div class="col-12 col-xl-4">
+        <div id="frame" class="position-relative">
+          <img id="preview" src="/a/nostream.svg" class="img-fluid" alt="Image: Preview" tabindex="-1" data-stream="ch0">
+        </div>
+      </div>
+      <div class="col col-xl-8">
+        <div class="row g-2">
+          <div class="col">
+            <p>
+              <label for="stream0_width">Width</label>
+              <input type="text" id="stream0_width" name="stream0_width" class="form-control" value="">
+            </p>
+            <p>
+              <label for="stream0_height">Height</label>
+              <input type="text" id="stream0_height" name="stream0_height" class="form-control" value="">
+            </p>
+            <p>
+              <label for="stream0_format">Format</label>
+              <select class="form-select" id="stream0_format" name="stream0_format">
+                <option value="">- Select -</option>
+              </select>
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p>
+              <label for="stream0_fps">FPS</label>
+              <input type="text" id="stream0_fps" name="stream0_fps" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="5" data-max="30" data-step="1">
+            </p>
+            <p>
+              <label for="stream0_gop">GOP</label>
+              <input type="text" id="stream0_gop" name="stream0_gop" class="form-control" value="">
+            </p>
+            <p>
+              <label for="stream0_max_gop">Max GOP</label>
+              <input type="text" id="stream0_max_gop" name="stream0_max_gop" class="form-control" value="">
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p>
+              <label for="stream0_mode">Mode</label>
+              <select class="form-select" id="stream0_mode" name="stream0_mode">
+                <option value="">- Select -</option>
+              </select>
+            </p>
+            <p>
+              <label for="stream0_bitrate">Bitrate</label>
+              <input type="text" id="stream0_bitrate" name="stream0_bitrate" class="form-control" value="">
+            </p>
+            <p>
+              <label for="stream0_profile">Profile</label>
+              <input type="text" id="stream0_profile" name="stream0_profile" class="form-control" value="">
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p>
+              <label for="stream0_buffers">Buffers</label>
+              <input type="text" id="stream0_buffers" name="stream0_buffers" class="form-control" value="">
+            </p>
+            <p>
+              <label for="stream0_rtsp_endpoint">RTSP Endpoint</label>
+              <input type="text" id="stream0_rtsp_endpoint" name="stream0_rtsp_endpoint" class="form-control" value="">
+            </p>
+            <p class="form-switch">
+              <input type="hidden" id="stream0_enabled-false" name="stream0_enabled" value="false">
+              <input type="checkbox" id="stream0_enabled" name="stream0_enabled" value="true" role="switch" class="form-check-input">
+              <label for="stream0_enabled" class="form-check-label">Stream enabled</label>
+            </p>
+            <p class="form-switch">
+              <input type="hidden" id="stream0_audio_enabled-false" name="stream0_audio_enabled" value="false">
+              <input type="checkbox" id="stream0_audio_enabled" name="stream0_audio_enabled" value="true" role="switch" class="form-check-input">
+              <label for="stream0_audio_enabled" class="form-check-label">Audio in stream</label>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <button type="button" id="save-prudynt-config" class="btn btn-primary mt-3">
+      <i class="bi bi-floppy me-1"></i> Save configuration to file
+    </button>
+  </div>
+</main>
+
+<footer data-app-footer></footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="/a/preview.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/streamer-encoder.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/streamer-osd0.html
+++ b/package/timps/files/www/streamer-osd0.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Main Stream OSD</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+</head>
+
+<body id="page-streamer-osd0">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container">
+    <div data-app-controls></div>
+
+    <h3>Main Stream OSD</h3>
+    <p><small>This page configures the main stream's own overlay set &mdash; the
+      substream has its independent set on the Substream OSD page. Text, position,
+      size, color, alpha and the shadow/stroke outline apply live; the master OSD
+      switch (shared by both streams) and enabling an overlay that is currently off
+      take effect after a streamer restart. Greyed-out controls are not supported by
+      the running streamer.</small></p>
+
+    <div class="row mb-3">
+      <div class="col-12 col-xl-4">
+        <div id="frame" class="position-relative">
+          <img id="preview" src="/a/nostream.svg" class="img-fluid" alt="Image: Preview" tabindex="-1" data-stream="ch0">
+        </div>
+      </div>
+      <div class="col col-xl-8">
+        <div class="row g-2">
+          <div class="col">
+            <p class="form-switch">
+              <input type="hidden" id="osd0_enabled-false" name="osd0_enabled" value="false">
+              <input type="checkbox" id="osd0_enabled" name="osd0_enabled" value="true" role="switch" class="form-check-input">
+              <label for="osd0_enabled" class="form-check-label">OSD enabled</label>
+            </p>
+            <p>
+              <label class="d-block">Font file</label>
+              <button type="button" class="btn btn-outline-secondary w-100" data-bs-toggle="modal" data-bs-target="#mdFont">Upload or restore default font</button>
+            </p>
+            <p>
+              <label for="osd0_fontsize">Size</label>
+              <input type="text" id="osd0_fontsize" name="osd0_fontsize" class="form-control" value="">
+            </p>
+            <p>
+              <label for="osd0_strokesize">Shadow</label>
+              <input type="text" id="osd0_strokesize" name="osd0_strokesize" class="form-control" value="">
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p class="form-switch">
+              <input type="hidden" id="osd0_logo_enabled-false" name="osd0_logo_enabled" value="false">
+              <input type="checkbox" id="osd0_logo_enabled" name="osd0_logo_enabled" value="true" role="switch" class="form-check-input">
+              <label for="osd0_logo_enabled" class="form-check-label">Logo</label>
+            </p>
+            <p>
+              <label for="osd0_logo_position">Position (x,y)</label>
+              <input type="text" id="osd0_logo_position" name="osd0_logo_position" class="form-control" value="">
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p class="form-switch">
+              <input type="hidden" id="osd0_time_enabled-false" name="osd0_time_enabled" value="false">
+              <input type="checkbox" id="osd0_time_enabled" name="osd0_time_enabled" value="true" role="switch" class="form-check-input">
+              <label for="osd0_time_enabled" class="form-check-label">Time</label>
+            </p>
+            <p>
+              <label for="osd0_time_position">Position (x,y)</label>
+              <input type="text" id="osd0_time_position" name="osd0_time_position" class="form-control" value="">
+            </p>
+            <p id="osd0_time_fillcolor_wrap" class="file">
+              <label for="osd0_time_fillcolor">Color</label>
+              <input type="color" id="osd0_time_fillcolor" name="osd0_time_fillcolor" class="form-control input-color">
+              <input type="range" id="osd0_time_fillcolor-alpha" name="osd0_time_fillcolor-alpha" min=0 max=255 step=1 class="expert">
+            </p>
+            <p id="osd0_time_strokecolor_wrap" class="file">
+              <label for="osd0_time_strokecolor">Shadow</label>
+              <input type="color" id="osd0_time_strokecolor" name="osd0_time_strokecolor" class="form-control input-color">
+              <input type="range" id="osd0_time_strokecolor-alpha" name="osd0_time_strokecolor-alpha" min=0 max=255 step=1 class="expert">
+            </p>
+            <p>
+              <label for="osd0_time_format">Format</label>
+              <input type="text" id="osd0_time_format" name="osd0_time_format" class="form-control" value="">
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p class="form-switch">
+              <input type="hidden" id="osd0_uptime_enabled-false" name="osd0_uptime_enabled" value="false">
+              <input type="checkbox" id="osd0_uptime_enabled" name="osd0_uptime_enabled" value="true" role="switch" class="form-check-input">
+              <label for="osd0_uptime_enabled" class="form-check-label">Uptime</label>
+            </p>
+            <p>
+              <label for="osd0_uptime_position">Position (x,y)</label>
+              <input type="text" id="osd0_uptime_position" name="osd0_uptime_position" class="form-control" value="">
+            </p>
+            <p>
+              <label for="osd0_uptime_fillcolor">Color</label>
+              <input type="color" id="osd0_uptime_fillcolor" name="osd0_uptime_fillcolor" class="form-control input-color">
+              <input type="range" id="osd0_uptime_fillcolor-alpha" name="osd0_uptime_fillcolor-alpha" min=0 max=255 step=1 class="expert">
+            </p>
+            <p>
+              <label for="osd0_uptime_strokecolor">Shadow</label>
+              <input type="color" id="osd0_uptime_strokecolor" name="osd0_uptime_strokecolor" class="form-control input-color">
+              <input type="range" id="osd0_uptime_strokecolor-alpha" name="osd0_uptime_strokecolor-alpha" min=0 max=255 step=1 class="expert">
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p class="form-switch">
+              <input type="hidden" id="osd0_usertext_enabled-false" name="osd0_usertext_enabled" value="false">
+              <input type="checkbox" id="osd0_usertext_enabled" name="osd0_usertext_enabled" value="true" role="switch" class="form-check-input">
+              <label for="osd0_usertext_enabled" class="form-check-label">User text</label>
+            </p>
+            <p>
+              <label for="osd0_usertext_position">Position (x,y)</label>
+              <input type="text" id="osd0_usertext_position" name="osd0_usertext_position" class="form-control" value="">
+            </p>
+            <p>
+              <label for="osd0_usertext_fillcolor">Color</label>
+              <input type="color" id="osd0_usertext_fillcolor" name="osd0_usertext_fillcolor" class="form-control input-color">
+              <input type="range" id="osd0_usertext_fillcolor-alpha" name="osd0_usertext_fillcolor-alpha" min=0 max=255 step=1 class="expert">
+            </p>
+            <p>
+              <label for="osd0_usertext_strokecolor">Shadow</label>
+              <input type="color" id="osd0_usertext_strokecolor" name="osd0_usertext_strokecolor" class="form-control input-color">
+              <input type="range" id="osd0_usertext_strokecolor-alpha" name="osd0_usertext_strokecolor-alpha" min=0 max=255 step=1 class="expert">
+            </p>
+            <p>
+              <label for="osd0_usertext_format">Format</label>
+              <input type="text" id="osd0_usertext_format" name="osd0_usertext_format" class="form-control" value="">
+            </p>
+          </div><!-- .col -->
+        </div><!-- .row -->
+      </div><!-- .col -->
+    </div><!-- .row -->
+
+    <button type="button" id="save-prudynt-config" class="btn btn-primary mt-3">
+      <i class="bi bi-floppy me-1"></i> Save configuration to file
+    </button>
+  </div><!-- .container -->
+</main>
+
+<footer data-app-footer></footer>
+
+<div class="modal fade" id="mdFont" tabindex="-1" aria-labelledby="mdlFont" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title fs-4" id="mdlFont">Upload font file</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="fontUploadForm" class="mb-4" method="post" action="/x/preview.cgi" enctype="multipart/form-data">
+          <input type="hidden" name="form" value="font">
+          <div class="mb-3">
+            <label for="fontfile">Upload a TTF file</label>
+            <input type="file" class="form-control" id="fontfile" name="fontfile" accept=".ttf,.otf" required>
+          </div>
+          <button type="submit" class="btn btn-primary w-100">Upload font</button>
+        </form>
+        <form method="post" action="/x/preview.cgi" enctype="multipart/form-data">
+          <input type="hidden" name="form" value="font-reset">
+          <button type="submit" class="btn btn-outline-danger w-100">Restore firmware font</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="/a/preview.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/streamer-osd.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/streamer-osd1.html
+++ b/package/timps/files/www/streamer-osd1.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Substream OSD</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+</head>
+
+<body id="page-streamer-osd1">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container">
+    <div data-app-controls></div>
+
+    <h3>Substream OSD</h3>
+    <p><small>This page configures the substream's own overlay set &mdash; the main
+      stream has its independent set on the Main Stream OSD page. Text, position,
+      size, color, alpha and the shadow/stroke outline apply live; the master OSD
+      switch (shared by both streams) and enabling an overlay that is currently off
+      take effect after a streamer restart. Greyed-out controls are not supported by
+      the running streamer.</small></p>
+
+    <div class="row mb-3">
+      <div class="col-12 col-xl-4">
+        <div id="frame" class="position-relative">
+          <img id="preview" src="/a/nostream.svg" class="img-fluid" alt="Image: Preview" tabindex="-1" data-stream="ch1">
+        </div>
+      </div>
+      <div class="col col-xl-8">
+        <div class="row g-2">
+          <div class="col">
+            <p class="form-switch">
+              <input type="hidden" id="osd1_enabled-false" name="osd1_enabled" value="false">
+              <input type="checkbox" id="osd1_enabled" name="osd1_enabled" value="true" role="switch" class="form-check-input">
+              <label for="osd1_enabled" class="form-check-label">OSD enabled</label>
+            </p>
+            <p>
+              <label class="d-block">Font file</label>
+              <button type="button" class="btn btn-outline-secondary w-100" data-bs-toggle="modal" data-bs-target="#mdFont">Upload or restore default font</button>
+            </p>
+            <p>
+              <label for="osd1_fontsize">Size</label>
+              <input type="text" id="osd1_fontsize" name="osd1_fontsize" class="form-control" value="">
+            </p>
+            <p>
+              <label for="osd1_strokesize">Shadow</label>
+              <input type="text" id="osd1_strokesize" name="osd1_strokesize" class="form-control" value="">
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p class="form-switch">
+              <input type="hidden" id="osd1_logo_enabled-false" name="osd1_logo_enabled" value="false">
+              <input type="checkbox" id="osd1_logo_enabled" name="osd1_logo_enabled" value="true" role="switch" class="form-check-input">
+              <label for="osd1_logo_enabled" class="form-check-label">Logo</label>
+            </p>
+            <p>
+              <label for="osd1_logo_position">Position (x,y)</label>
+              <input type="text" id="osd1_logo_position" name="osd1_logo_position" class="form-control" value="">
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p class="form-switch">
+              <input type="hidden" id="osd1_time_enabled-false" name="osd1_time_enabled" value="false">
+              <input type="checkbox" id="osd1_time_enabled" name="osd1_time_enabled" value="true" role="switch" class="form-check-input">
+              <label for="osd1_time_enabled" class="form-check-label">Time</label>
+            </p>
+            <p>
+              <label for="osd1_time_position">Position (x,y)</label>
+              <input type="text" id="osd1_time_position" name="osd1_time_position" class="form-control" value="">
+            </p>
+            <p id="osd1_time_fillcolor_wrap" class="file">
+              <label for="osd1_time_fillcolor">Color</label>
+              <input type="color" id="osd1_time_fillcolor" name="osd1_time_fillcolor" class="form-control input-color">
+              <input type="range" id="osd1_time_fillcolor-alpha" name="osd1_time_fillcolor-alpha" min=0 max=255 step=1 class="expert">
+            </p>
+            <p id="osd1_time_strokecolor_wrap" class="file">
+              <label for="osd1_time_strokecolor">Shadow</label>
+              <input type="color" id="osd1_time_strokecolor" name="osd1_time_strokecolor" class="form-control input-color">
+              <input type="range" id="osd1_time_strokecolor-alpha" name="osd1_time_strokecolor-alpha" min=0 max=255 step=1 class="expert">
+            </p>
+            <p>
+              <label for="osd1_time_format">Format</label>
+              <input type="text" id="osd1_time_format" name="osd1_time_format" class="form-control" value="">
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p class="form-switch">
+              <input type="hidden" id="osd1_uptime_enabled-false" name="osd1_uptime_enabled" value="false">
+              <input type="checkbox" id="osd1_uptime_enabled" name="osd1_uptime_enabled" value="true" role="switch" class="form-check-input">
+              <label for="osd1_uptime_enabled" class="form-check-label">Uptime</label>
+            </p>
+            <p>
+              <label for="osd1_uptime_position">Position (x,y)</label>
+              <input type="text" id="osd1_uptime_position" name="osd1_uptime_position" class="form-control" value="">
+            </p>
+            <p>
+              <label for="osd1_uptime_fillcolor">Color</label>
+              <input type="color" id="osd1_uptime_fillcolor" name="osd1_uptime_fillcolor" class="form-control input-color">
+              <input type="range" id="osd1_uptime_fillcolor-alpha" name="osd1_uptime_fillcolor-alpha" min=0 max=255 step=1 class="expert">
+            </p>
+            <p>
+              <label for="osd1_uptime_strokecolor">Shadow</label>
+              <input type="color" id="osd1_uptime_strokecolor" name="osd1_uptime_strokecolor" class="form-control input-color">
+              <input type="range" id="osd1_uptime_strokecolor-alpha" name="osd1_uptime_strokecolor-alpha" min=0 max=255 step=1 class="expert">
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p class="form-switch">
+              <input type="hidden" id="osd1_usertext_enabled-false" name="osd1_usertext_enabled" value="false">
+              <input type="checkbox" id="osd1_usertext_enabled" name="osd1_usertext_enabled" value="true" role="switch" class="form-check-input">
+              <label for="osd1_usertext_enabled" class="form-check-label">User text</label>
+            </p>
+            <p>
+              <label for="osd1_usertext_position">Position (x,y)</label>
+              <input type="text" id="osd1_usertext_position" name="osd1_usertext_position" class="form-control" value="">
+            </p>
+            <p>
+              <label for="osd1_usertext_fillcolor">Color</label>
+              <input type="color" id="osd1_usertext_fillcolor" name="osd1_usertext_fillcolor" class="form-control input-color">
+              <input type="range" id="osd1_usertext_fillcolor-alpha" name="osd1_usertext_fillcolor-alpha" min=0 max=255 step=1 class="expert">
+            </p>
+            <p>
+              <label for="osd1_usertext_strokecolor">Shadow</label>
+              <input type="color" id="osd1_usertext_strokecolor" name="osd1_usertext_strokecolor" class="form-control input-color">
+              <input type="range" id="osd1_usertext_strokecolor-alpha" name="osd1_usertext_strokecolor-alpha" min=0 max=255 step=1 class="expert">
+            </p>
+            <p>
+              <label for="osd1_usertext_format">Format</label>
+              <input type="text" id="osd1_usertext_format" name="osd1_usertext_format" class="form-control" value="">
+            </p>
+          </div><!-- .col -->
+        </div><!-- .row -->
+      </div><!-- .col -->
+    </div><!-- .row -->
+
+    <button type="button" id="save-prudynt-config" class="btn btn-primary mt-3">
+      <i class="bi bi-floppy me-1"></i> Save configuration to file
+    </button>
+  </div><!-- .container -->
+</main>
+
+<footer data-app-footer></footer>
+
+<div class="modal fade" id="mdFont" tabindex="-1" aria-labelledby="mdlFont" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title fs-4" id="mdlFont">Upload font file</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="fontUploadForm" class="mb-4" method="post" action="/x/preview.cgi" enctype="multipart/form-data">
+          <input type="hidden" name="form" value="font">
+          <div class="mb-3">
+            <label for="fontfile">Upload a TTF file</label>
+            <input type="file" class="form-control" id="fontfile" name="fontfile" accept=".ttf,.otf" required>
+          </div>
+          <button type="submit" class="btn btn-primary w-100">Upload font</button>
+        </form>
+        <form method="post" action="/x/preview.cgi" enctype="multipart/form-data">
+          <input type="hidden" name="form" value="font-reset">
+          <button type="submit" class="btn btn-outline-danger w-100">Restore firmware font</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="/a/preview.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/streamer-osd.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/streamer-sensor.html
+++ b/package/timps/files/www/streamer-sensor.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Sensor IQ File</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+</head>
+
+<body id="page-streamer-sensor">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container">
+    <div data-app-controls></div>
+
+    <h3>Sensor IQ File</h3>
+
+    <div class="row mb-3">
+      <div class="col-12 col-xl-4">
+        <div id="frame" class="position-relative">
+          <img id="preview" src="/a/nostream.svg" class="img-fluid" alt="Image: Preview" tabindex="-1" data-stream="ch1">
+        </div>
+      </div>
+      <div class="col col-xl-8">
+        <h4>Sensor IQ file</h4>
+        <small>This file contains image quality settings for the image sensor</small>
+        <p class="alert alert-secondary" id="sensor-info">
+          <span id="sensor-loading">Loading sensor information...</span>
+          <span id="sensor-details" class="d-none">
+            File: <span id="sensor-file-path"></span><br>
+            MD5: <span id="sensor-md5"></span>
+          </span>
+        </p>
+        <p>Upload a custom sensor IQ file for <span class="fw-bold text-uppercase" id="sensor-soc-family"></span>
+          and <span class="fw-bold text-uppercase" id="sensor-model"></span>, e.g. from a stock firmware backup.</p>
+        <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#mdSensorIQ">
+          <i class="bi bi-upload"></i> Upload Sensor IQ File
+        </button>
+
+        <button type="button" id="save-prudynt-config" class="btn btn-primary mt-3">
+          <i class="bi bi-floppy me-1"></i> Save configuration to file
+        </button>
+      </div>
+    </div>
+  </div>
+</main>
+
+<footer data-app-footer></footer>
+
+<div class="modal fade" id="mdSensorIQ" tabindex="-1" aria-labelledby="mdlSensorIQ" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title fs-4" id="mdlSensorIQ">Upload sensor IQ file</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form id="sensorUploadForm" class="mb-4" method="post" action="/x/preview.cgi" enctype="multipart/form-data">
+          <input type="hidden" name="form" value="sensor">
+          <div class="mb-3">
+            <label for="sensorfile">Upload a sensor IQ binary file</label>
+            <input type="file" class="form-control" id="sensorfile" name="sensorfile" accept=".bin" required>
+          </div>
+          <button type="submit" class="btn btn-primary w-100">Upload sensor IQ file</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/preview.js"></script>
+<script src="/a/streamer-sensor.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/streamer-substream.html
+++ b/package/timps/files/www/streamer-substream.html
@@ -1,0 +1,124 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · RTSP Substream</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+</head>
+
+<body id="page-streamer-substream">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container">
+    <div data-app-controls></div>
+
+    <h3>RTSP Substream</h3>
+
+    <div class="row mb-3">
+      <div class="col-12 col-xl-4">
+        <div id="frame" class="position-relative">
+          <img id="preview" src="/a/nostream.svg" class="img-fluid" alt="Image: Preview" tabindex="-1" data-stream="ch1">
+        </div>
+      </div>
+      <div class="col col-xl-8">
+        <div class="row g-2">
+          <div class="col">
+            <p>
+              <label for="stream1_width">Width</label>
+              <input type="text" id="stream1_width" name="stream1_width" class="form-control" value="">
+            </p>
+            <p>
+              <label for="stream1_height">Height</label>
+              <input type="text" id="stream1_height" name="stream1_height" class="form-control" value="">
+            </p>
+            <p>
+              <label for="stream1_format">Format</label>
+              <select class="form-select" id="stream1_format" name="stream1_format">
+                <option value="">- Select -</option>
+              </select>
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p>
+              <label for="stream1_fps">FPS</label>
+              <input type="text" id="stream1_fps" name="stream1_fps" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="5" data-max="30" data-step="1">
+            </p>
+            <p>
+              <label for="stream1_gop">GOP</label>
+              <input type="text" id="stream1_gop" name="stream1_gop" class="form-control" value="">
+            </p>
+            <p>
+              <label for="stream1_max_gop">Max GOP</label>
+              <input type="text" id="stream1_max_gop" name="stream1_max_gop" class="form-control" value="">
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p>
+              <label for="stream1_mode">Mode</label>
+              <select class="form-select" id="stream1_mode" name="stream1_mode">
+                <option value="">- Select -</option>
+              </select>
+            </p>
+            <p>
+              <label for="stream1_bitrate">Bitrate</label>
+              <input type="text" id="stream1_bitrate" name="stream1_bitrate" class="form-control" value="">
+            </p>
+            <p>
+              <label for="stream1_profile">Profile</label>
+              <input type="text" id="stream1_profile" name="stream1_profile" class="form-control" value="">
+            </p>
+          </div><!-- .col -->
+          <div class="col">
+            <p>
+              <label for="stream1_buffers">Buffers</label>
+              <input type="text" id="stream1_buffers" name="stream1_buffers" class="form-control" value="">
+            </p>
+            <p>
+              <label for="stream1_rtsp_endpoint">RTSP Endpoint</label>
+              <input type="text" id="stream1_rtsp_endpoint" name="stream1_rtsp_endpoint" class="form-control" value="">
+            </p>
+            <p class="form-switch">
+              <input type="hidden" id="stream1_enabled-false" name="stream1_enabled" value="false">
+              <input type="checkbox" id="stream1_enabled" name="stream1_enabled" value="true" role="switch" class="form-check-input">
+              <label for="stream1_enabled" class="form-check-label">Stream enabled</label>
+            </p>
+            <p class="form-switch">
+              <input type="hidden" id="stream1_audio_enabled-false" name="stream1_audio_enabled" value="false">
+              <input type="checkbox" id="stream1_audio_enabled" name="stream1_audio_enabled" value="true" role="switch" class="form-check-input">
+              <label for="stream1_audio_enabled" class="form-check-label">Audio in stream</label>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <button type="button" id="save-prudynt-config" class="btn btn-primary mt-3">
+      <i class="bi bi-floppy me-1"></i> Save configuration to file
+    </button>
+  </div>
+</main>
+
+<footer data-app-footer></footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="/a/preview.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/streamer-encoder.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/tool-record.html
+++ b/package/timps/files/www/tool-record.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Video Recorder</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+</head>
+
+<body id="page-tool-record-video">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container" style="min-height:80vh">
+    <div data-app-controls></div>
+
+    <section>
+      <form id="recForm" class="needs-validation" novalidate autocomplete="off">
+        <div class="card mb-3">
+          <div class="card-header">
+            <h2 class="card-title">Video Recorder</h2>
+            <small>timps records fragmented-MP4 clips to your storage target. Settings are saved live into <code>/etc/timps.conf</code>. Browse clips under <a href="/recordings.html" class="link-light text-decoration-none">Recordings</a>.</small>
+            <button type="button" class="btn btn-outline-secondary" id="rec-reload" title="Reload values from camera">
+              <i class="bi bi-arrow-clockwise"></i> Reload
+            </button>
+          </div>
+          <div class="card-body">
+            <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3">
+
+              <div class="col">
+                <h4>Storage</h4>
+                <small>where clips are written</small>
+                <p class="form-switch">
+                  <input class="form-check-input" type="checkbox" role="switch" id="rec_enabled">
+                  <label class="form-check-label" for="rec_enabled">Enable recorder (also starts on boot)</label>
+                </p>
+                <p>
+                  <label for="rec_dir">Storage directory</label>
+                  <a href="/tool-file-manager.html" class="small text-decoration-none">
+                    <i class="bi bi-folder2-open ms-2 me-1"></i> Open in File Manager
+                  </a>
+                  <input type="text" class="form-control" id="rec_dir" placeholder="/mnt/mmcblk0p1"
+                    data-help="SD card or share mount; clips go under &lt;dir&gt;/&lt;hostname&gt;/records/">
+                </p>
+                <p>
+                  <label for="rec_name">File name template</label>
+                  <input type="text" class="form-control strftime" id="rec_name" placeholder="%Y%m%d/%H/%Y%m%dT%H%M%S"
+                    data-help="strftime path under the records folder (.mp4 is appended)">
+                </p>
+                <p class="form-switch">
+                  <input class="form-check-input" type="checkbox" role="switch" id="rec_audio">
+                  <label class="form-check-label" for="rec_audio">Record audio (when available)</label>
+                </p>
+              </div>
+
+              <div class="col">
+                <h4>Recorder</h4>
+                <small>source, mode and clip length</small>
+                <p>
+                  <label for="rec_mode">Recording mode</label>
+                  <select class="form-select" id="rec_mode">
+                    <option value="0">Continuous</option>
+                    <option value="1">Motion-triggered</option>
+                  </select>
+                </p>
+                <p>
+                  <label for="rec_channel">Stream to record</label>
+                  <select class="form-select" id="rec_channel">
+                    <option value="0">Main stream</option>
+                    <option value="1">Substream</option>
+                  </select>
+                </p>
+                <p>
+                  <label for="rec_segment">Clip length, seconds</label>
+                  <input type="number" class="form-control" id="rec_segment" min="0" max="3600" step="5"
+                    data-help="Rotate to a new file every N seconds at a keyframe (0 = single file)">
+                </p>
+              </div>
+
+              <div class="col">
+                <h4>Motion &amp; storage</h4>
+                <small>pre/post-roll and free-space guard</small>
+                <p>
+                  <label for="rec_preroll">Motion pre-roll, seconds</label>
+                  <input type="number" class="form-control" id="rec_preroll" min="0" max="60" step="1"
+                    data-help="Motion mode: keep this much video from before the trigger">
+                </p>
+                <p>
+                  <label for="rec_postroll">Motion post-roll, seconds</label>
+                  <input type="number" class="form-control" id="rec_postroll" min="0" max="600" step="1"
+                    data-help="Motion mode: keep recording this long after the last motion">
+                </p>
+                <p>
+                  <label for="rec_minfree">Minimum free space, megabytes</label>
+                  <input type="number" class="form-control" id="rec_minfree" min="0" max="102400" step="50"
+                    data-help="Oldest clips are pruned to keep at least this much free">
+                </p>
+              </div>
+
+            </div><!-- .row -->
+            <p class="small text-secondary mb-0" id="rec-status">&nbsp;</p>
+          </div><!-- .card-body -->
+        </div><!-- .card -->
+
+        <button type="submit" class="btn btn-primary" id="rec-save">
+          <i class="bi bi-save me-1"></i> Save changes
+        </button>
+      </form>
+    </section>
+  </div>
+</main>
+
+<footer data-app-footer></footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/tool-record.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/tool-sensor-data.html
+++ b/package/timps/files/www/tool-sensor-data.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Sensor Data Collector</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+  <style>
+    #chart-container {
+      position: relative;
+      height: 500px;
+      margin-bottom: 2rem;
+    }
+
+    .controls select {
+      padding: 0.25rem 0.5rem;
+      border-radius: 0.25rem;
+      cursor: pointer;
+    }
+
+    .stat-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1rem;
+      margin-bottom: 1rem;
+    }
+
+    .stat-card {
+      padding: 0.5rem;
+      border: 1px solid #e0e0e0;
+      border-radius: 0.25rem;
+      background-color: var(--bs-body-bg);
+      text-align: center;
+    }
+
+    .stat-card.ev .stat-value {
+      color: #FF6384;
+    }
+
+    .stat-card.total_gain .stat-value {
+      color: #36A2EB;
+    }
+
+    .stat-card.ae_luma .stat-value {
+      color: #FFCE56;
+    }
+
+    .stat-card.daynight_brightness .stat-value {
+      color: #B8FF4D;
+    }
+
+    .stat-label {
+      font-size: 0.875rem;
+      font-weight: 700;
+      color: #999;
+      margin-bottom: 0.25rem;
+    }
+
+    .stat-value {
+      font-size: 1.75rem;
+      font-weight: bold;
+      color: var(--bs-body-color);
+    }
+
+    .stat-detail {
+      font-size: 0.75rem;
+      color: #999;
+      margin-top: 0.25rem;
+    }
+
+    .stream-status {
+      font-size: 1rem;
+      margin-left: 0.5rem;
+    }
+
+    .stream-status.connected {
+      color: #28a745;
+    }
+
+    .stream-status.disconnected {
+      color: #dc3545;
+    }
+  </style>
+</head>
+
+<body id="page-tool-sensor-data">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container" style="min-height:80vh">
+    <div data-app-controls></div>
+
+    <section class="card shadow-sm mb-4">
+      <div class="card-body">
+        <div class="d-flex flex-column flex-lg-row align-items-lg-center gap-3 mb-3">
+          <div class="d-flex align-items-center gap-2">
+            <h2 class="mb-0">Raw Sensor Data Collection</h2>
+            <i id="stream-status" class="bi bi-circle-fill stream-status disconnected" title="Connecting..."></i>
+          </div>
+          <p class="mb-0 text-secondary small flex-grow-1">Graphs raw unprocessed sensor values for day/night algorithm analysis.</p>
+        </div>
+        <div class="row preview">
+          <div class="col-12 col-lg-5" id="preview-col">
+            <div id="frame" class="position-relative mb-2">
+              <img id="preview" src="/a/nostream.svg" data-stream="ch1" class="img-fluid" alt="Image: Preview">
+            </div>
+            <h5 class="mt-3">Current Values</h5>
+            <div class="stat-grid" id="data-stats"></div>
+          </div>
+          <div class="col-12 col-lg-7" id="tabs-col">
+            <div id="chart-container">
+              <canvas id="dataChart"></canvas>
+            </div>
+            <div class="controls d-flex flex-wrap gap-1 w-100">
+              <button id="clear-data" class="btn btn-sm btn-danger">Clear Data</button>
+              <button id="toggle-pause" class="btn btn-sm btn-secondary">Pause</button>
+              <div class="btn-group" role="group" id="max-points">
+                <button type="button" class="btn btn-sm btn-secondary" data-points="100">100</button>
+                <button type="button" class="btn btn-sm btn-primary active" data-points="300">300</button>
+                <button type="button" class="btn btn-sm btn-secondary" data-points="600">600</button>
+                <button type="button" class="btn btn-sm btn-secondary" data-points="1200">1200</button>
+              </div>
+              <button id="export-json" class="btn btn-sm btn-outline-secondary">Export JSON</button>
+              <button id="export-csv" class="btn btn-sm btn-outline-secondary">Export CSV</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</main>
+
+<footer data-app-footer></footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+<!-- preview.js drives the live preview <img> (direct-to-timps MJPEG with
+     the per-boot token; the static /x/chN.mjpg proxy CGIs are gone) -->
+<script src="/a/preview.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/tool-sensor-data.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/tool-timelapse.html
+++ b/package/timps/files/www/tool-timelapse.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Timelapse Recorder</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+</head>
+
+<body id="page-tool-timelapse">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container" style="min-height:80vh">
+    <div data-app-controls></div>
+
+    <section>
+      <form id="tlForm" class="needs-validation" novalidate autocomplete="off">
+        <div class="card mb-3">
+          <div class="card-header">
+            <h2 class="card-title">Timelapse Recorder</h2>
+            <small>timps saves a JPEG snapshot every interval. Settings are saved live into <code>/etc/timps.conf</code>; shots go under <code>&lt;dir&gt;/&lt;hostname&gt;/timelapses/</code>. The control-bar timelapse button toggles the same switch.</small>
+            <button type="button" class="btn btn-outline-secondary" id="tl-reload" title="Reload values from camera">
+              <i class="bi bi-arrow-clockwise"></i> Reload
+            </button>
+          </div>
+          <div class="card-body">
+            <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3">
+
+              <div class="col">
+                <h4>Storage</h4>
+                <small>where snapshots are written</small>
+                <p class="form-switch">
+                  <input class="form-check-input" type="checkbox" role="switch" id="tl_enabled">
+                  <label class="form-check-label" for="tl_enabled">Enable timelapse (also starts on boot)</label>
+                </p>
+                <p>
+                  <label for="tl_dir">Storage directory</label>
+                  <a href="/tool-file-manager.html" class="small text-decoration-none">
+                    <i class="bi bi-folder2-open ms-2 me-1"></i> Open in File Manager
+                  </a>
+                  <input type="text" class="form-control" id="tl_dir" placeholder="/mnt/mmcblk0p1"
+                    data-help="SD card or share mount; shots go under &lt;dir&gt;/&lt;hostname&gt;/timelapses/">
+                </p>
+                <p>
+                  <label for="tl_name">File name template</label>
+                  <input type="text" class="form-control strftime" id="tl_name" placeholder="%Y%m%d/%H/%Y%m%dT%H%M%S"
+                    data-help="strftime path under the timelapses folder (.jpg is appended)">
+                </p>
+              </div>
+
+              <div class="col">
+                <h4>Capture</h4>
+                <small>source and cadence</small>
+                <p>
+                  <label for="tl_channel">Stream to capture</label>
+                  <select class="form-select" id="tl_channel">
+                    <option value="0">Main stream</option>
+                    <option value="1">Substream</option>
+                  </select>
+                </p>
+                <p>
+                  <label for="tl_interval">Interval, seconds</label>
+                  <input type="number" class="form-control" id="tl_interval" min="1" max="86400" step="1"
+                    data-help="Save one snapshot every N seconds">
+                </p>
+              </div>
+
+              <div class="col">
+                <h4>Retention</h4>
+                <small>automatic cleanup</small>
+                <p>
+                  <label for="tl_keepdays">Keep, days</label>
+                  <input type="number" class="form-control" id="tl_keepdays" min="0" max="3650" step="1"
+                    data-help="Snapshots older than this are deleted (0 = keep forever)">
+                </p>
+              </div>
+
+            </div><!-- .row -->
+            <p class="small text-secondary mb-0" id="tl-status">&nbsp;</p>
+          </div><!-- .card-body -->
+        </div><!-- .card -->
+
+        <button type="submit" class="btn btn-primary" id="tl-save">
+          <i class="bi bi-save me-1"></i> Save changes
+        </button>
+      </form>
+    </section>
+  </div>
+</main>
+
+<footer data-app-footer></footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/tool-timelapse.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/x/json-heartbeat-slow.cgi
+++ b/package/timps/files/www/x/json-heartbeat-slow.cgi
@@ -1,0 +1,15 @@
+#!/bin/sh
+# timps replacement for the slow (polled) heartbeat CGI (same name, same URL).
+# Same payload as json-heartbeat.cgi, single shot (see timps-heartbeat.sh).
+
+# Check authentication
+. /var/www/x/auth.sh
+require_auth
+
+. /var/www/x/timps-heartbeat.sh
+
+printf 'Content-Type: application/json\r\n'
+printf 'Cache-Control: no-cache\r\n'
+printf 'Connection: close\r\n\r\n'
+
+timps_heartbeat_payload

--- a/package/timps/files/www/x/json-heartbeat.cgi
+++ b/package/timps/files/www/x/json-heartbeat.cgi
@@ -1,0 +1,37 @@
+#!/bin/sh
+# timps replacement for the SSE heartbeat CGI (same name, same URL).
+# The stock version proxies the thingino agent, which has no timps backend
+# and reports unknown/false for every control-bar field (resetting the
+# day/night/auto and Mic buttons). This one builds the payload from timps's
+# GET /control and the thingino GPIO tools (see timps-heartbeat.sh).
+
+# Check authentication
+. /var/www/x/auth.sh
+require_auth
+
+. /var/www/x/timps-heartbeat.sh
+
+HEARTBEAT_INTERVAL="${HEARTBEAT_INTERVAL:-5}"
+HEARTBEAT_RETRY_MS=$((HEARTBEAT_INTERVAL * 1000))
+
+http_200() { printf 'Status: 200 OK\r\n'; }
+
+send_headers() {
+	http_200
+	printf 'Content-Type: text/event-stream\r\n'
+	printf 'Cache-Control: no-cache\r\n\r\n'
+}
+
+trap 'exit 0' INT TERM PIPE HUP
+send_headers
+
+while true; do
+	printf 'retry: %d\n' "$HEARTBEAT_RETRY_MS" || exit 0
+	data=$(timps_heartbeat_payload)
+	if [ -n "$data" ]; then
+		printf 'data: %s\n\n' "$data" || exit 0
+	else
+		printf 'data: {"error":"timps heartbeat unavailable"}\n\n' || exit 0
+	fi
+	sleep "$HEARTBEAT_INTERVAL" || exit 0
+done

--- a/package/timps/files/www/x/json-imp.cgi
+++ b/package/timps/files/www/x/json-imp.cgi
@@ -1,0 +1,133 @@
+#!/bin/sh
+# shellcheck disable=SC2039
+# timps replacement for the day/night control CGI (same name, same URL).
+# Translates the WebUI's {"cmd":..,"val":..} into timps /control calls;
+# the IR/white-light and IR-cut GPIO helpers are kept as-is.
+
+# Check authentication
+. /var/www/x/auth.sh
+require_auth
+
+# derive timps's HTTP port + scheme from the config (http.port / http.https),
+# fall back to 8880/http. When http.https is set timps serves TLS-only on that
+# port, so this localhost bridge must use https + curl -k or every POST fails.
+TIMPS_PORT=$(sed -n 's/^[[:space:]]*http\.port[[:space:]]*=[[:space:]]*\([0-9]\{1,\}\).*/\1/p' /etc/timps.conf 2>/dev/null | head -n1)
+[ -z "$TIMPS_PORT" ] && TIMPS_PORT=8880
+TIMPS_HTTPS=$(sed -n 's/^[[:space:]]*http\.https[[:space:]]*=[[:space:]]*\([0-9A-Za-z]*\).*/\1/p' /etc/timps.conf 2>/dev/null | head -n1)
+case "$TIMPS_HTTPS" in
+  1 | true | yes | on) TIMPS_SCHEME=https; TIMPS_CURL_K="-k" ;;
+  *) TIMPS_SCHEME=http; TIMPS_CURL_K="" ;;
+esac
+CONTROL_URL="${TIMPS_SCHEME}://127.0.0.1:${TIMPS_PORT}/control"
+
+http_200() {
+  printf 'Status: 200 OK\r\n'
+}
+
+http_400() {
+  printf 'Status: 400 Bad Request\r\n'
+}
+
+http_412() {
+  printf 'Status: 412 Precondition Failed\r\n'
+}
+
+json_header() {
+  printf 'Content-Type: application/json\r\n'
+  printf 'Pragma: no-cache\r\n'
+  printf 'Expires: %s\r\n' "$(TZ=GMT0 date +'%a, %d %b %Y %T %Z')"
+  printf 'Etag: "%s"\r\n' "$(cat /proc/sys/kernel/random/uuid)"
+  printf 'Connection: close\r\n'
+  printf '\r\n'
+}
+
+json_error() {
+  http_412
+  json_header
+  printf '{"error":{"code":412,"message":"%s"}}
+' "$1"
+  exit 0
+}
+
+json_ok() {
+  http_200
+  json_header
+  if [ "{" = "${1:0:1}" ]; then
+    printf '{"code":200,"result":"success","message":%s}
+' "$1"
+  else
+    printf '{"code":200,"result":"success","message":"%s"}
+' "$1"
+  fi
+  exit 0
+}
+
+bad_request() {
+  http_400
+  echo
+  echo "$1"
+  exit 1
+}
+
+# Read POST data
+read -r POST_DATA
+
+# Parse JSON (supports quoted or numeric val)
+cmd=$(printf '%s' "$POST_DATA" | awk -F'"' '/"cmd"/{for(i=1;i<=NF;i++){if($i=="cmd"){print $(i+2); exit}}}')
+val=$(printf '%s' "$POST_DATA" | sed -n 's/.*"val"[[:space:]]*:[[:space:]]*"\{0,1\}\([^",}]*\).*/\1/p')
+
+[ -z "$cmd" ] && bad_request "missing required parameter cmd"
+[ -z "$val" ] && bad_request "missing required parameter val"
+
+case "$cmd" in
+  auto)
+    # toggle timps's native automatic day/night detection (the WebUI Auto
+    # button sends val 1 to enable and 0 to disable)
+    case "$val" in
+      0 | false) AUTO=false ;;
+      *) AUTO=true ;;
+    esac
+    curl -s $TIMPS_CURL_K -m 5 -X POST "$CONTROL_URL" \
+      -d "{\"daynight\":{\"enabled\":$AUTO}}" >/dev/null 2>&1
+    ;;
+  color)
+    # manual override: disable auto detection, then set the ISP mode
+    # (0 = day/color, 1 = night/b&w)
+    case "$val" in
+      0 | 1) ;;
+      *) bad_request "invalid value for color" ;;
+    esac
+    curl -s $TIMPS_CURL_K -m 5 -X POST "$CONTROL_URL" \
+      -d "{\"daynight\":{\"enabled\":false},\"image\":{\"running_mode\":$val}}" >/dev/null 2>&1
+    ;;
+  daynight)
+    # manual override: disable auto detection, force the ISP mode, then run
+    # the board's daynight script - the same one timps's auto detection
+    # calls - so the IR-cut filter, IR/white LEDs and the mode file
+    # (/run/thingino/daynight_mode, read by the heartbeat) all switch too.
+    # The /control force_mode is dedup-safe against the script's color hook.
+    case "$val" in
+      day | night) ;;
+      *) bad_request "invalid value for daynight" ;;
+    esac
+    curl -s $TIMPS_CURL_K -m 5 -X POST "$CONTROL_URL" \
+      -d "{\"daynight\":{\"enabled\":false},\"force_mode\":\"$val\"}" >/dev/null 2>&1
+    command -v daynight >/dev/null 2>&1 && daynight "$val" >/dev/null 2>&1
+    ;;
+  ir850 | ir940 | white)
+    # manual light override: switch auto detection off first (like the stock
+    # prudynt CGI), then drive the GPIO through thingino's light tool
+    curl -s $TIMPS_CURL_K -m 5 -X POST "$CONTROL_URL" \
+      -d '{"daynight":{"enabled":false}}' >/dev/null 2>&1
+    light $cmd $val
+    ;;
+  ircut)
+    curl -s $TIMPS_CURL_K -m 5 -X POST "$CONTROL_URL" \
+      -d '{"daynight":{"enabled":false}}' >/dev/null 2>&1
+    ircut $val >/dev/null
+    ;;
+esac
+
+# All state data is provided by the (timps-aware) heartbeat CGIs, no need to
+# build a payload here
+json_ok

--- a/package/timps/files/www/x/json-recordings.cgi
+++ b/package/timps/files/www/x/json-recordings.cgi
@@ -1,0 +1,58 @@
+#!/bin/sh
+# json-recordings.cgi - browse/serve the timps SD recordings. This is a
+# FILESYSTEM helper (like json-sensor-info.cgi), not a streamer bridge:
+#   GET                -> JSON list of segments under <record.dir>/<host>/records
+#   GET ?file=<rel>    -> streams that segment as video/mp4 (play/download)
+#   GET ?del=<rel>     -> deletes that segment
+# Auth-protected; the file/del parameter is guarded against path traversal.
+
+. /var/www/x/auth.sh
+require_auth
+
+CONF=/etc/timps.conf
+DIR=$(sed -n 's/^[[:space:]]*record\.dir[[:space:]]*=[[:space:]]*"\{0,1\}\([^"#]*\).*/\1/p' "$CONF" 2>/dev/null | head -n1 | tr -d ' \t')
+[ -z "$DIR" ] && DIR=/mnt/mmcblk0p1
+BASE="$DIR/$(hostname)/records"
+
+qval() { printf '%s' "$QUERY_STRING" | sed -n "s/.*$1=\([^&]*\).*/\1/p"; }
+urldec() { printf '%b' "$(printf '%s' "$1" | sed 's/+/ /g; s/%\(..\)/\\x\1/g')"; }
+
+FILE=$(urldec "$(qval file)")
+DEL=$(urldec "$(qval del)")
+
+# reject absolute paths and traversal
+safe() { case "$1" in ""|/*|*..*) return 1 ;; *) return 0 ;; esac; }
+
+if [ -n "$DEL" ]; then
+  if safe "$DEL" && [ -f "$BASE/$DEL" ]; then rm -f "$BASE/$DEL"; printf 'Content-Type: application/json\r\n\r\n{"ok":true}\n'
+  else printf 'Status: 400 Bad Request\r\n\r\n'; fi
+  exit 0
+fi
+
+if [ -n "$FILE" ]; then
+  if ! safe "$FILE" || [ ! -f "$BASE/$FILE" ]; then printf 'Status: 404 Not Found\r\n\r\n'; exit 0; fi
+  F="$BASE/$FILE"; SZ=$(stat -c%s "$F" 2>/dev/null || echo 0)
+  printf 'Status: 200 OK\r\n'
+  printf 'Content-Type: video/mp4\r\n'
+  printf 'Content-Length: %s\r\n' "$SZ"
+  printf 'Content-Disposition: inline; filename="%s"\r\n' "$(basename "$F")"
+  printf 'Connection: close\r\n\r\n'
+  cat "$F"
+  exit 0
+fi
+
+# ---- listing (newest first) ----
+printf 'Content-Type: application/json\r\n'
+printf 'Cache-Control: no-store\r\n\r\n'
+if [ ! -d "$BASE" ]; then printf '{"base":"%s","files":[]}\n' "$BASE"; exit 0; fi
+printf '{"base":"%s","files":[' "$BASE"
+i=0
+for f in $(find "$BASE" -type f -name '*.mp4' 2>/dev/null | sort -r); do
+  rel=${f#"$BASE"/}
+  sz=$(stat -c%s "$f" 2>/dev/null || echo 0)
+  mt=$(stat -c%Y "$f" 2>/dev/null || echo 0)
+  [ $i -gt 0 ] && printf ','
+  printf '{"file":"%s","size":%s,"mtime":%s}' "$rel" "$sz" "$mt"
+  i=$((i+1))
+done
+printf ']}\n'

--- a/package/timps/files/www/x/restart-prudynt.cgi
+++ b/package/timps/files/www/x/restart-prudynt.cgi
@@ -1,0 +1,15 @@
+#!/bin/sh
+# timps replacement for the streamer restart CGI (same name, same URL,
+# because the WebUI calls /x/restart-prudynt.cgi; also installed as
+# restart-timps.cgi). Restarts the timps streamer service.
+
+# Check authentication
+. /var/www/x/auth.sh
+require_auth
+
+echo "Content-Type: application/json"
+echo "Connection: close"
+echo
+echo '{"status":"ok","message":"Streamer (timps) restart initiated"}'
+
+/etc/init.d/S95timps restart >/dev/null 2>&1 &

--- a/package/timps/files/www/x/timps-heartbeat.sh
+++ b/package/timps/files/www/x/timps-heartbeat.sh
@@ -1,0 +1,141 @@
+#!/bin/sh
+# timps heartbeat payload builder, shared by json-heartbeat.cgi (SSE) and
+# json-heartbeat-slow.cgi. Include this AFTER auth.sh.
+#
+# Why this exists: the stock heartbeat comes from the thingino agent, which
+# has no timps adapter - its "null" backend reports daynight_mode "unknown",
+# mic/spk false and daynight_enabled false every beat, which keeps resetting
+# the control-bar buttons (day/night/auto, Mic) no matter what the user
+# clicks. This timps-aware payload takes the same fields from timps's own
+# GET /control (day/night auto flag, ISP running mode, live mic mute) and
+# from the thingino GPIO tools (ircut / light state files), so the control
+# bar reflects and keeps the real device state.
+#
+# "spk_supported":false is a timps-only extension: timps has no audio-output
+# (AO) pipeline, so main.js greys out the Speaker button when it sees it.
+
+TIMPS_CONF="${TIMPS_CONF:-/etc/timps.conf}"
+# timps now speaks HTTPS-only on its port when http.https is set (ONVIF-safe
+# 8880 by default). The heartbeat runs on the camera and talks to localhost,
+# so it must follow the same scheme/port or curl gets nothing back (which used
+# to null out total_gain / privacy_enabled every beat -> no gain in the UI).
+_timps_port=$(sed -n 's/^[[:space:]]*http\.port[[:space:]]*=[[:space:]]*\([0-9]\{1,\}\).*/\1/p' "$TIMPS_CONF" 2>/dev/null | head -n1)
+[ -n "$_timps_port" ] || _timps_port=8880
+_timps_https=$(sed -n 's/^[[:space:]]*http\.https[[:space:]]*=[[:space:]]*\([0-9A-Za-z]*\).*/\1/p' "$TIMPS_CONF" 2>/dev/null | head -n1)
+case "$_timps_https" in
+	1 | true | yes | on) _timps_scheme=https; TIMPS_CURL_K="-k" ;;
+	*) _timps_scheme=http; TIMPS_CURL_K="" ;;
+esac
+TIMPS_CONTROL_URL="$_timps_scheme://127.0.0.1:$_timps_port/control"
+TIMPS_DAYNIGHT_MODE_FILE="${TIMPS_DAYNIGHT_MODE_FILE:-/run/thingino/daynight_mode}"
+TIMPS_IRCUT_MODE_FILE="${TIMPS_IRCUT_MODE_FILE:-/tmp/ircutmode.txt}"
+
+timps_hb_light_state() {
+	command -v light >/dev/null 2>&1 || {
+		printf 'null'
+		return 0
+	}
+	v=$(light "$1" read 2>/dev/null | tr -d '\r\n')
+	case "$v" in
+		0 | 1) printf '%s' "$v" ;;
+		*) printf 'null' ;;
+	esac
+}
+
+timps_hb_ircut_state() {
+	v=$(sed -n '1p' "$TIMPS_IRCUT_MODE_FILE" 2>/dev/null | tr -d '\r\n ')
+	case "$v" in
+		0 | 1) printf '%s' "$v" ;;
+		*) printf 'null' ;;
+	esac
+}
+
+timps_hb_wg_status() {
+	if ip link show wg0 2>/dev/null | grep -q 'state UP'; then
+		printf '1'
+	else
+		printf '0'
+	fi
+}
+
+timps_heartbeat_payload() {
+	CUR=$(curl -s $TIMPS_CURL_K -m 2 "$TIMPS_CONTROL_URL" 2>/dev/null)
+
+	# ISP running mode from the flat image object (0 = day/color, 1 = night)
+	RM=$(printf '%s' "$CUR" | sed -n 's/.*"image":{[^}]*"running_mode":\([01]\).*/\1/p')
+	# native auto day/night detection on/off (the trailing daynight object)
+	DN_EN=$(printf '%s' "$CUR" | sed -n 's/.*"daynight":{"enabled":\([01]\).*/\1/p')
+	# measured day/night status from the same daynight object: brightness in
+	# %, total_gain in the ISP [24.8] linear scale (256 = 1x - the same value
+	# prudynt/raptor report, so main.js's .dnd-gain display and the
+	# photosensing thresholds keep their units); timps answers -1 while
+	# unknown -> null (main.js skips null like the stock heartbeat)
+	DNOBJ=$(printf '%s' "$CUR" | sed -n 's/.*"daynight":{\([^}]*\)}.*/\1/p')
+	BRI=$(printf '%s' "$DNOBJ" | sed -n 's/.*"brightness":\(-\{0,1\}[0-9][0-9]*\(\.[0-9][0-9]*\)\{0,1\}\).*/\1/p')
+	TG=$(printf '%s' "$DNOBJ" | sed -n 's/.*"total_gain":\(-\{0,1\}[0-9][0-9]*\).*/\1/p')
+	case "$BRI" in '' | -*) BRI=null ;; esac
+	case "$TG" in '' | -*) TG=null ;; esac
+	# live mic mute + persisted audio enable from the flat audio object
+	MUTE=$(printf '%s' "$CUR" | sed -n 's/.*"audio":{[^}]*"mute":\([01]\).*/\1/p')
+	AEN=$(printf '%s' "$CUR" | sed -n 's/.*"audio":{[^}]*"enabled":\([01]\).*/\1/p')
+	# privacy button state: ON if ANY cover region is enabled (timps privacy is
+	# per-region; the control-bar button is a global on/off). The privacy object
+	# sits just before the daynight object in GET /control.
+	PRIV=$(printf '%s' "$CUR" | sed -n 's/.*"privacy":{\(.*\)},"daynight".*/\1/p')
+	case "$PRIV" in *'"enabled":1'*) PRIV=true ;; *) PRIV=false ;; esac
+	# recording status: rec_ch<channel> reflects the timps recorder state
+	REC=$(printf '%s' "$CUR" | sed -n 's/.*"record":{\([^}]*\)}.*/\1/p')
+	RECING=$(printf '%s' "$REC" | sed -n 's/.*"recording":\([01]\).*/\1/p')
+	RECCH=$(printf '%s' "$REC" | sed -n 's/.*"channel":\([0-9]\).*/\1/p')
+	REC0=false; REC1=false
+	if [ "$RECING" = "1" ]; then
+		if [ "$RECCH" = "1" ]; then REC1=true; else REC0=true; fi
+	fi
+
+	# current mode: the board daynight script's mode file (written on every
+	# switch, by auto detection and manual forcing alike); fall back to the
+	# ISP running mode when the script has not run yet
+	MODE=$(sed -n '1p' "$TIMPS_DAYNIGHT_MODE_FILE" 2>/dev/null | tr -d '\r\n ')
+	case "$MODE" in
+		day | night) ;;
+		*)
+			case "$RM" in
+				0) MODE=day ;;
+				1) MODE=night ;;
+				*) MODE=unknown ;;
+			esac
+			;;
+	esac
+
+	case "$RM" in
+		0 | 1) COLOR=$RM ;;
+		*) COLOR=null ;;
+	esac
+
+	if [ "$DN_EN" = "1" ]; then DN_JSON=true; else DN_JSON=false; fi
+
+	# Mic button state: on unless live-muted (or audio disabled entirely)
+	if [ "$MUTE" = "1" ] || [ "$AEN" = "0" ]; then MIC=false; else MIC=true; fi
+
+	MOTION=$(sed -n 's/^[[:space:]]*motion\.enabled[[:space:]]*=[[:space:]]*\([01]\).*/\1/p' "$TIMPS_CONF" 2>/dev/null | head -n 1)
+	if [ "$MOTION" = "1" ]; then MOTION=true; else MOTION=false; fi
+
+	printf '{"time_now":%s,"uptime":%s,"daynight_brightness":%s,"total_gain":%s,"daynight_mode":"%s","rec_ch0":%s,"rec_ch1":%s,"motion_enabled":%s,"privacy_enabled":%s,"color_mode":%s,"mic_enabled":%s,"spk_enabled":false,"spk_supported":false,"daynight_enabled":%s,"ircut_state":%s,"ir850_state":%s,"ir940_state":%s,"white_state":%s,"wg_status":%s}\n' \
+		"$(date +%s)" \
+		"$(cut -d '.' -f 1 /proc/uptime 2>/dev/null || printf '0')" \
+		"$BRI" \
+		"$TG" \
+		"$MODE" \
+		"$REC0" \
+		"$REC1" \
+		"$MOTION" \
+		"$PRIV" \
+		"$COLOR" \
+		"$MIC" \
+		"$DN_JSON" \
+		"$(timps_hb_ircut_state)" \
+		"$(timps_hb_light_state ir850)" \
+		"$(timps_hb_light_state ir940)" \
+		"$(timps_hb_light_state white)" \
+		"$(timps_hb_wg_status)"
+}

--- a/package/timps/files/www/x/timps-token.cgi
+++ b/package/timps/files/www/x/timps-token.cgi
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Hand the per-boot timps /control token to the authenticated WebUI session.
+# timps writes a fresh random token to /run/timps.token (0640) on every start;
+# with it a browser page can drive timps DIRECTLY (no local bridge CGI):
+#   const {token, port} = await (await fetch('/x/timps-token.cgi')).json();
+#   fetch(`http://${location.hostname}:${port}/control`, {method:'POST',
+#         headers:{'X-Timps-Token': token}, body:'{"image":{...}}'});
+# Only the per-boot token is exposed here - a configured http.token secret
+# never reaches the file (timps keeps it in memory only).
+
+# Check authentication
+. /var/www/x/auth.sh
+require_auth
+
+CONF="/etc/timps.conf"
+TOKEN_FILE="/run/timps.token"
+
+# honor a custom http.token_file / http.port from the timps config
+tf=$(sed -n 's/^[[:space:]]*http\.token_file[[:space:]]*=[[:space:]]*"\{0,1\}\([^"#]*\).*/\1/p' "$CONF" 2>/dev/null | head -n1 | tr -d ' \t')
+[ -n "$tf" ] && TOKEN_FILE="$tf"
+port=$(sed -n 's/^[[:space:]]*http\.port[[:space:]]*=[[:space:]]*\([0-9]\{1,\}\).*/\1/p' "$CONF" 2>/dev/null | head -n1)
+[ -z "$port" ] && port=8880
+# whether timps serves the HTTP port over TLS (http.https): the browser must
+# then use https:// for the media/control URLs.
+https=$(sed -n 's/^[[:space:]]*http\.https[[:space:]]*=[[:space:]]*\([0-9A-Za-z]*\).*/\1/p' "$CONF" 2>/dev/null | head -n1)
+case "$https" in 1|true|yes|on) tls=true ;; *) tls=false ;; esac
+
+echo "Content-Type: application/json"
+echo "Cache-Control: no-store"
+echo "Connection: close"
+echo
+
+token=""
+[ -r "$TOKEN_FILE" ] && token=$(head -n1 "$TOKEN_FILE" 2>/dev/null | tr -cd '0-9A-Za-z')
+
+if [ -n "$token" ]; then
+  printf '{"token":"%s","port":%s,"tls":%s}\n' "$token" "$port" "$tls"
+else
+  printf '{"error":"no token available","port":%s,"tls":%s}\n' "$port" "$tls"
+fi

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -106,6 +106,130 @@ define TIMPS_INSTALL_TARGET_CMDS
 		$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/generate-tls-certs.sh \
 			$(TARGET_DIR)/usr/bin/generate-timps-tls-certs.sh; \
 	fi
+
+	# Install the self-test helper
+	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/timps-selftest.sh \
+		$(TARGET_DIR)/usr/bin/timps-selftest
+
+	# Install the day/night ISP hook (/usr/sbin/color) when native day/night
+	# detection is enabled; timps calls it to drive the ircut/light/gain
+	# switching through thingino's daynight scripts.
+	if [ "$(BR2_PACKAGE_TIMPS_DAYNIGHT)" = "y" ]; then \
+		$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/color \
+			$(TARGET_DIR)/usr/sbin/color; \
+	fi
 endef
+
+# NOTE: WebUI bridge CGIs. The stock WebUI settings pages POST prudynt-shaped
+# JSON to /x/json-prudynt*.cgi, /x/json-imp.cgi and /x/restart-prudynt.cgi.
+# files/www/x/ ships timps-flavored replacements (same names) that translate
+# the supported subset to timps's /control JSON API on 127.0.0.1:8880, plus the
+# native page scripts (files/www/a/) and pages (files/www/*.html). They are
+# installed via a TARGET_FINALIZE_HOOK so they override the thingino-webui
+# copies regardless of package build order, and only when both the WebUI and the
+# timps /control endpoint are enabled. The whole directory is installed (CGIs and
+# the .sh lib alike; busybox httpd executes anything under /x/ regardless of
+# extension). The WebUI's own prudynt-flavored bridge CGIs (they shell out to the
+# absent prudyntctl) are purged so a timps image carries no dead endpoints, and
+# the busybox httpd "/mjpeg" convenience alias is repointed at timps's own MJPEG
+# endpoint (localhost -> no auth needed; uses the default http.port 8880).
+ifeq ($(BR2_PACKAGE_THINGINO_WEBUI)$(BR2_PACKAGE_TIMPS_CONTROL),yy)
+define TIMPS_INSTALL_WEBUI_CGIS
+	# timps-flavored WebUI: overlay every timps-specific asset over the stock
+	# thingino-webui install so the settings pages talk to timps /control +
+	# /events directly (a/timps-api.js). Kept ENTIRELY in this package so
+	# thingino-webui stays pristine/upstream; the finalize hook wins regardless
+	# of package build order. x/ = the surviving structural CGIs (token, restart,
+	# GPIO json-imp, heartbeat); a/ = the native page scripts; *.html = the pages.
+	for f in $(TIMPS_PKGDIR)/files/www/x/* ; do \
+		$(INSTALL) -D -m 0755 $$f $(TARGET_DIR)/var/www/x/$$(basename $$f) ; \
+	done
+	for f in $(TIMPS_PKGDIR)/files/www/a/* ; do \
+		$(INSTALL) -D -m 0644 $$f $(TARGET_DIR)/var/www/a/$$(basename $$f) ; \
+	done
+	for f in $(TIMPS_PKGDIR)/files/www/*.html ; do \
+		$(INSTALL) -D -m 0644 $$f $(TARGET_DIR)/var/www/$$(basename $$f) ; \
+	done
+	# purge the stock files timps replaces with native /control logic: the dead
+	# prudynt bridge CGIs and orphaned scripts, so a timps image carries none.
+	rm -f $(TARGET_DIR)/var/www/a/audio.js \
+	      $(TARGET_DIR)/var/www/a/streamer-config.js \
+	      $(TARGET_DIR)/var/www/x/json-prudynt.cgi \
+	      $(TARGET_DIR)/var/www/x/json-imaging.cgi \
+	      $(TARGET_DIR)/var/www/x/json-prudynt-config.cgi \
+	      $(TARGET_DIR)/var/www/x/json-prudynt-save.cgi \
+	      $(TARGET_DIR)/var/www/x/json-timegraph-stream.cgi
+	rm -f $(TARGET_DIR)/var/www/x/ch0.mjpg $(TARGET_DIR)/var/www/x/ch1.mjpg \
+	      $(TARGET_DIR)/var/www/x/ch0.jpg  $(TARGET_DIR)/var/www/x/ch1.jpg
+	if [ -f $(TARGET_DIR)/etc/httpd.conf ]; then \
+		sed -i 's#^P:/mjpeg:.*#P:/mjpeg:http://127.0.0.1:8880/stream.mjpeg#' \
+			$(TARGET_DIR)/etc/httpd.conf ; \
+	fi
+endef
+TIMPS_TARGET_FINALIZE_HOOKS += TIMPS_INSTALL_WEBUI_CGIS
+endif
+
+# NOTE: preview page. thingino-webui picks the preview page (preview.html) at
+# ITS install time from the selected streamer, so switching raptor->timps
+# without rebuilding thingino-webui leaves raptor's WebRTC preview behind (it
+# POSTs to /x/webrtc-whip.cgi -> 502, no image). Install our self-contained
+# MSE/fMP4 preview (fetches :8880/stream.mp4) over /var/www/preview.html from a
+# finalize hook so it wins regardless of package build order. Only when the
+# WebUI is present. preview-timps.html lives in THIS package (files/www/)
+# together with the rest of the timps WebUI overlay, so thingino-webui stays
+# pristine.
+ifeq ($(BR2_PACKAGE_THINGINO_WEBUI),y)
+TIMPS_PREVIEW_SRC = $(TIMPS_PKGDIR)/files/www/preview-timps.html
+define TIMPS_INSTALL_PREVIEW
+	$(INSTALL) -D -m 0644 $(TIMPS_PREVIEW_SRC) \
+		$(TARGET_DIR)/var/www/preview.html
+endef
+TIMPS_TARGET_FINALIZE_HOOKS += TIMPS_INSTALL_PREVIEW
+endif
+
+# NOTE: native day/night. When timps detects day/night itself
+# (BR2_PACKAGE_TIMPS_DAYNIGHT), the standalone daynightd daemon must never
+# autostart (double switching), and the WebUI "Photosensing" page (which
+# configures daynightd) is dropped from the navigation. Done as a finalize
+# hook so it wins regardless of package build order; both steps are
+# idempotent and no-ops when the files are absent.
+ifeq ($(BR2_PACKAGE_TIMPS_DAYNIGHT),y)
+define TIMPS_DISABLE_DAYNIGHTD
+	rm -f $(TARGET_DIR)/etc/init.d/S97daynightd
+	if [ -f $(TARGET_DIR)/var/www/a/navigation.js ]; then \
+		sed -i '/config-photosensing\.html/d' \
+			$(TARGET_DIR)/var/www/a/navigation.js ; \
+	fi
+endef
+TIMPS_TARGET_FINALIZE_HOOKS += TIMPS_DISABLE_DAYNIGHTD
+endif
+
+# NOTE: ONVIF discovery script. thingino-onvif deliberately does NOT ship
+# S96onvif_discovery ("streamer-specific and installed by the selected streamer
+# package"); raptor/prudynt/strero each install their OWN raptor-flavored copy
+# that builds /etc/onvif.json from raptorctl. On a timps image that copy is
+# wrong (ONVIF credentials come back empty/raptor -> clients fail to log in) and
+# Buildroot leaves the stale file behind when switching streamer choice. Install
+# timps's own S96onvif_discovery - it sources the ONVIF user/pass and stream URLs
+# from /etc/timps.conf instead. Done as a finalize hook (like the WebUI overlay)
+# so it wins over any leftover raptor/prudynt copy regardless of build order.
+#
+# We deliberately do NOT gate on $(BR2_PACKAGE_THINGINO_ONVIF): in practice
+# ONVIF can be present in the image while that symbol reads "not set" (pulled in
+# indirectly, or left over in target/ from an earlier build), and the finalize
+# hook must ALSO overwrite a stale raptor/prudynt S96onvif_discovery that
+# Buildroot left behind. So the hook is always registered and decides at
+# finalize time by probing the target: install our copy whenever the ONVIF
+# daemon is present, or whenever some other streamer already dropped an S96.
+# On a genuinely ONVIF-free image neither is true and nothing is shipped.
+define TIMPS_INSTALL_ONVIF_DISCOVERY
+	if [ -e $(TARGET_DIR)/usr/sbin/wsd_simple_server ] || \
+	   [ -e $(TARGET_DIR)/var/www/onvif/onvif.cgi ] || \
+	   [ -e $(TARGET_DIR)/etc/init.d/S96onvif_discovery ]; then \
+		$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/S96onvif_discovery \
+			$(TARGET_DIR)/etc/init.d/S96onvif_discovery ; \
+	fi
+endef
+TIMPS_TARGET_FINALIZE_HOOKS += TIMPS_INSTALL_ONVIF_DISCOVERY
 
 $(eval $(generic-package))


### PR DESCRIPTION
Re-adds the timps files removed during integration, plus the matching install logic in timps.mk.

Per-streamer, no impact on other backends: color (/usr/sbin/color) and S96onvif_discovery are shipped the same way by raptor/prudynt/strero; the streamer choice is exclusive, so only the selected streamer's versions land in an image. On a timps image these are functional necessities — color drives day/night via timps /control, and S96onvif_discovery builds the ONVIF creds/URLs from timps (without it ONVIF login returns empty/raptor and clients can't authenticate).

WebUI overlay: the custom timps control/config/preview pages + CGIs, installed via a finalize hook gated on BR2_PACKAGE_THINGINO_WEBUI. Happy to scope this down if you'd rather keep timps on the stock WebUI.