### PR TITLE
motors: fix Cinnado D1 tilt direction; apply invert_x/y on GPIO/TCU steppers

### DIFF
--- a/configs/cameras/cinnado_d1_t23n_sc2331_atbm6012bx/thingino.json
+++ b/configs/cameras/cinnado_d1_t23n_sc2331_atbm6012bx/thingino.json
@@ -16,7 +16,7 @@
     "gpio_tilt": "52 53 64 59",
     "homing": true,
     "invert_x": false,
-    "invert_y": false,
+    "invert_y": true,
     "is_spi": false,
     "pos_0": "1850,500",
     "speed_pan": 900,

--- a/configs/cameras/cinnado_d1_t23n_sc2336_atbm6012bx/thingino.json
+++ b/configs/cameras/cinnado_d1_t23n_sc2336_atbm6012bx/thingino.json
@@ -16,7 +16,7 @@
     "gpio_tilt": "52 53 64 59",
     "homing": true,
     "invert_x": false,
-    "invert_y": false,
+    "invert_y": true,
     "is_spi": false,
     "pos_0": "1850,500",
     "speed_pan": 900,

--- a/configs/cameras/cinnado_d1_t31l_sc2336_atbm6031/thingino.json
+++ b/configs/cameras/cinnado_d1_t31l_sc2336_atbm6031/thingino.json
@@ -13,7 +13,7 @@
     "gpio_tilt": "52 53 64 59",
     "homing": true,
     "invert_x": false,
-    "invert_y": false,
+    "invert_y": true,
     "is_spi": false,
     "pos_0": "1850,500",
     "speed_pan": 900,

--- a/configs/cameras/cinnado_d1_t31l_sc2336_atbm6031x/thingino.json
+++ b/configs/cameras/cinnado_d1_t31l_sc2336_atbm6031x/thingino.json
@@ -13,7 +13,7 @@
     "gpio_tilt": "52 53 64 59",
     "homing": true,
     "invert_x": false,
-    "invert_y": false,
+    "invert_y": true,
     "is_spi": false,
     "pos_0": "1850,500",
     "speed_pan": 900,

--- a/package/thingino-motors/files/S59motor
+++ b/package/thingino-motors/files/S59motor
@@ -102,6 +102,7 @@ start() {
 		modprobe_args="hmaxstep=$steps_pan vmaxstep=$steps_tilt"
 
 		if [ "true" = "$is_spi" ]; then
+			# invert_x/invert_y are real module params only on the SPI driver.
 			if [ -n "$invert_x" ]; then
 				modprobe_args="$modprobe_args invert_x=$invert_x"
 			fi
@@ -143,6 +144,14 @@ start() {
 	start_daemon $DAEMON_ARGS
 	# FIXME: daemon should be reporting running state from the very first moment
 	sleep 1
+
+	# GPIO/TCU driver has no invert_x/invert_y module params (SPI-only); apply
+	# inversion at runtime via IPC instead. Daemon starts un-inverted on every
+	# boot, so this must run every time, not just on first module load.
+	if [ "true" != "$is_spi" ]; then
+		[ "true" = "$invert_x" ] && motors -I x
+		[ "true" = "$invert_y" ] && motors -I y
+	fi
 
 	# FIXME: motors may have different speeds for pan and tilt
 	set_motors_speed $speed_pan


### PR DESCRIPTION
Runtime inversion via 'motors -I' for GPIO/TCU steppers (modprobe args don't work there). Fixes swapped up/down on Cinnado D1. Squashed; the intermediate modprobe-args version was boot-breaking on PTZ boards.