### PR TITLE
webui: fix Telegram bot 'launch on boot' toggle (use service, not /etc/init.d)

### DIFF
--- a/package/thingino-webui/files/www/x/ctl-telegrambot.cgi
+++ b/package/thingino-webui/files/www/x/ctl-telegrambot.cgi
@@ -1,25 +1,25 @@
 #!/bin/sh
-CTL="/etc/init.d/telegrambot"
+SVC="service telegrambot"
 echo "Content-Type: application/json"
 echo "Connection: close"
 echo
 case "$QUERY_STRING" in
    enabled=1)
-      $CTL enable >/dev/null 2>&1
-      $CTL restart >/dev/null 2>&1 || /etc/init.d/telegrambot start >/dev/null 2>&1
+      $SVC enable >/dev/null 2>&1
+      $SVC restart >/dev/null 2>&1 || $SVC start >/dev/null 2>&1
       echo '{"ok":true}'
       ;;
-  enabled=0)
-      $CTL stop >/dev/null 2>&1
-      $CTL disable >/dev/null 2>&1
+   enabled=0)
+      $SVC stop >/dev/null 2>&1
+      $SVC disable >/dev/null 2>&1
       echo '{"ok":true}'
       ;;
-  restart=1)
-      $CTL restart >/dev/null 2>&1
+   restart=1)
+      $SVC restart >/dev/null 2>&1
       echo '{"ok":true}'
       ;;
-  status=1)
-      $CTL enabled >/dev/null 2>&1 && eb=true || eb=false
+   status=1)
+      [ "$($SVC status 2>/dev/null)" = "enabled" ] && eb=true || eb=false
       pidof telegrambot >/dev/null 2>&1 && er=true || er=false
       echo "{\"enabled_boot\":$eb,\"enabled_runtime\":$er}"
       ;;


### PR DESCRIPTION
ctl-telegrambot.cgi toggled/read the on-boot state via /etc/init.d/telegrambot enable|disable|enabled, but the init script is installed as S93telegrambot (there is no /etc/init.d/telegrambot) and init scripts don't implement enable/disable/enabled — that is what /usr/sbin/service does (it flips the S## script's exec bit, 755=enabled/644=disabled). So enabling 'Launch on boot' was a no-op and the status read-back always returned enabled_boot:false, making the checkbox revert to off after save. Switch the CGI to 'service telegrambot enable|disable|restart|start|stop' and derive enabled_boot from 'service telegrambot status'. Not streamer-specific.