### PR TITLE
webui: fix Telegram bot 'launch on boot' toggle (use service; UI shows boot state)

### DIFF
--- a/package/thingino-webui/files/www/a/config-telegrambot.js
+++ b/package/thingino-webui/files/www/a/config-telegrambot.js
@@ -106,7 +106,7 @@
         const statusResponse = await fetch("/x/ctl-telegrambot.cgi?status=1");
         const status = await statusResponse.json();
         enabledInput.checked =
-          status.enabled_boot === true || status.enabled_runtime === true;
+          status.enabled_boot === true;
       } catch (e) {
         enabledInput.checked =
           data.enabled_boot === true ||

--- a/package/thingino-webui/files/www/x/ctl-telegrambot.cgi
+++ b/package/thingino-webui/files/www/x/ctl-telegrambot.cgi
@@ -1,25 +1,25 @@
 #!/bin/sh
-CTL="/etc/init.d/telegrambot"
+SVC="service telegrambot"
 echo "Content-Type: application/json"
 echo "Connection: close"
 echo
 case "$QUERY_STRING" in
    enabled=1)
-      $CTL enable >/dev/null 2>&1
-      $CTL restart >/dev/null 2>&1 || /etc/init.d/telegrambot start >/dev/null 2>&1
+      $SVC enable >/dev/null 2>&1
+      $SVC restart >/dev/null 2>&1 || $SVC start >/dev/null 2>&1
       echo '{"ok":true}'
       ;;
-  enabled=0)
-      $CTL stop >/dev/null 2>&1
-      $CTL disable >/dev/null 2>&1
+   enabled=0)
+      $SVC stop >/dev/null 2>&1
+      $SVC disable >/dev/null 2>&1
       echo '{"ok":true}'
       ;;
-  restart=1)
-      $CTL restart >/dev/null 2>&1
+   restart=1)
+      $SVC restart >/dev/null 2>&1
       echo '{"ok":true}'
       ;;
-  status=1)
-      $CTL enabled >/dev/null 2>&1 && eb=true || eb=false
+   status=1)
+      [ "$($SVC status 2>/dev/null)" = "enabled" ] && eb=true || eb=false
       pidof telegrambot >/dev/null 2>&1 && er=true || er=false
       echo "{\"enabled_boot\":$eb,\"enabled_runtime\":$er}"
       ;;


### PR DESCRIPTION
ctl-telegrambot.cgi called /etc/init.d/telegrambot enable|disable|enabled, but the script is S93telegrambot and only /usr/sbin/service implements enable/disable (exec-bit). Switched to 'service telegrambot ...'; UI checkbox now reflects enabled_boot only.