### PR TITLE
timps: package hardening + v1.4.0

### DIFF
--- a/package/timps/files/S95timps
+++ b/package/timps/files/S95timps
@@ -3,23 +3,70 @@
 # S95timps - start/stop Tiny IMP Streamer
 #
 
+PIDFILE=/var/run/timpsd.pid
+DAEMON=/usr/bin/timpsd
+CONF=/etc/timps.conf
+
+# Read a "key = value" from timps.conf (strips inline comments + quotes).
+conf_get() {
+	sed -n "s/^[[:space:]]*$1[[:space:]]*=[[:space:]]*//p" "$CONF" 2>/dev/null \
+		| sed 's/[[:space:]]*#.*$//; s/^"\(.*\)"$/\1/; s/^'\''\(.*\)'\''$/\1/' \
+		| head -n1
+}
+
+# If TLS is requested but the cert/key are missing, generate a self-signed pair
+# so timpsd doesn't fail to bind the HTTPS/RTSPS listener on first boot.
+ensure_tls_certs() {
+	[ "$(conf_get http.https)" = "1" ] || [ "$(conf_get rtsp.tls)" = "1" ] || return 0
+	crt=$(conf_get http.tls_cert); key=$(conf_get http.tls_key)
+	[ -n "$crt" ] && [ -n "$key" ] || return 0
+	[ -s "$crt" ] && [ -s "$key" ] && return 0
+	[ -x /usr/bin/generate-timps-tls-certs.sh ] || return 0
+	/usr/bin/generate-timps-tls-certs.sh "$crt" "$key" >/dev/null 2>&1
+}
+
+# Wait for the daemon to actually exit (IMP/rmem teardown can take a while);
+# starting a new instance too early makes ISP init fail.
+wait_stop() {
+	i=0
+	while [ $i -lt 50 ]; do
+		[ -f "$PIDFILE" ] || return 0
+		p=$(cat "$PIDFILE" 2>/dev/null)
+		[ -n "$p" ] && kill -0 "$p" 2>/dev/null || return 0
+		i=$((i + 1))
+		usleep 100000 2>/dev/null || sleep 1
+	done
+	return 1
+}
+
 case "$1" in
 	start)
 		echo "Starting timpsd..."
-		start-stop-daemon -S -b -m -p /var/run/timpsd.pid \
-			-x /usr/bin/timpsd -- -c /etc/timps.conf
+		ensure_tls_certs
+		start-stop-daemon -S -b -m -p "$PIDFILE" \
+			-x "$DAEMON" -- -c "$CONF"
 		;;
 	stop)
 		echo "Stopping timpsd..."
-		start-stop-daemon -K -p /var/run/timpsd.pid 2>/dev/null
+		start-stop-daemon -K -p "$PIDFILE" 2>/dev/null
+		wait_stop || echo "timpsd still stopping..."
+		rm -f "$PIDFILE"
 		;;
 	restart)
 		"$0" stop
-		sleep 1
+		wait_stop
 		"$0" start
 		;;
+	status)
+		if [ -f "$PIDFILE" ] && kill -0 "$(cat "$PIDFILE" 2>/dev/null)" 2>/dev/null; then
+			echo "timpsd running (pid $(cat "$PIDFILE"))"
+			exit 0
+		fi
+		echo "timpsd not running"
+		exit 1
+		;;
 	*)
-		echo "Usage: $0 {start|stop|restart}"
+		echo "Usage: $0 {start|stop|restart|status}"
 		exit 1
 		;;
 esac

--- a/package/timps/files/S96onvif_discovery
+++ b/package/timps/files/S96onvif_discovery
@@ -140,8 +140,14 @@ configure_raptor_onvif_profiles() {
 timps_conf_get() {
 	key="$1"
 	esc=$(echo "$key" | sed 's/[.[\*^$]/\\&/g')
-	sed -n "s/^[[:space:]]*${esc}[[:space:]]*=[[:space:]]*\([^#]*\).*/\1/p" \
-		"$TIMPS_CONFIG" 2>/dev/null | head -n1 | sed 's/[[:space:]]*$//'
+	# Match the daemon's parser (config.c): capture the whole value, then strip an
+	# inline comment only when the '#' is preceded by whitespace (so a literal
+	# 'p#ss' is kept), trim trailing space, and unquote a "..."/'...' value. The
+	# old "[^#]*" capture truncated at the first '#' and left quotes in place,
+	# yielding different ONVIF creds than timps enforces -> clients locked out.
+	sed -n "s/^[[:space:]]*${esc}[[:space:]]*=[[:space:]]*\(.*\)$/\1/p" \
+		"$TIMPS_CONFIG" 2>/dev/null | head -n1 \
+		| sed 's/[[:space:]]\{1,\}#.*$//; s/[[:space:]]*$//; s/^"\(.*\)"$/\1/; s/^'\''\(.*\)'\''$/\1/'
 }
 
 timps_bool_default() {
@@ -165,7 +171,7 @@ timps_rtsp_port() {
 	if [ "$(timps_rtsp_scheme)" = "rtsps" ]; then
 		port=$(timps_conf_get rtsp.tls_port); [ -n "$port" ] || port="322"
 	else
-		port=$(timps_conf_get rtsp.port);     [ -n "$port" ] || port="8554"
+		port=$(timps_conf_get rtsp.port);     [ -n "$port" ] || port="554"
 	fi
 	echo "$port"
 }
@@ -250,8 +256,11 @@ start() {
 		start_daemon $DAEMON_ARGS
 	done
 
-	tmpfile="$(mktemp -u).json"
-	echo '{}' >$tmpfile
+	# Create the temp file atomically (mktemp, mode 0600, O_EXCL) instead of the
+	# old "mktemp -u" predictable name + redirect, which a local attacker could
+	# pre-plant as a symlink for this root-run script to follow.
+	tmpfile="$(mktemp /tmp/onvif.XXXXXX)" || exit 1
+	echo '{}' >"$tmpfile"
 	jct $tmpfile set camera.manufacturer "Thingino"
 	jct $tmpfile set camera.model "$CAMERA"
 	jct $tmpfile set camera.hardware_id "ingenic_$SOC_MODEL"

--- a/package/timps/files/generate-tls-certs.sh
+++ b/package/timps/files/generate-tls-certs.sh
@@ -1,13 +1,16 @@
 #!/bin/sh
 # Generate self-signed TLS certificates for timps HTTPS/RTSPS.
 # Uses openssl if available, falls back to mbedtls-certgen.
+#
+# Usage: generate-timps-tls-certs.sh [cert_path] [key_path]
+# Defaults match timps.conf (http.tls_cert / http.tls_key).
 
-CERT_DIR=/etc/ssl/certs
-KEY_DIR=/etc/ssl/private
+CERT="${1:-/etc/ssl/certs/httpd.crt}"
+KEY="${2:-/etc/ssl/private/httpd.key}"
 
-mkdir -p "$CERT_DIR" "$KEY_DIR"
+mkdir -p "$(dirname "$CERT")" "$(dirname "$KEY")"
 
-if [ -f "$CERT_DIR/httpd.crt" ] && [ -f "$KEY_DIR/httpd.key" ]; then
+if [ -s "$CERT" ] && [ -s "$KEY" ]; then
 	echo "TLS certificates already exist, skipping generation."
 	exit 0
 fi
@@ -15,22 +18,23 @@ fi
 if command -v openssl >/dev/null 2>&1; then
 	echo "Generating self-signed certificate with openssl..."
 	openssl req -x509 -newkey rsa:2048 \
-		-keyout "$KEY_DIR/httpd.key" \
-		-out "$CERT_DIR/httpd.crt" \
+		-keyout "$KEY" \
+		-out "$CERT" \
 		-days 3650 -nodes \
 		-subj "/C=US/ST=State/L=City/O=Thingino/CN=camera.local" \
 		2>/dev/null
-	chmod 600 "$KEY_DIR/httpd.key"
-	chmod 644 "$CERT_DIR/httpd.crt"
+	chmod 600 "$KEY"
+	chmod 644 "$CERT"
 elif command -v mbedtls-certgen >/dev/null 2>&1; then
 	echo "Generating self-signed certificate with mbedtls-certgen..."
-	mbedtls-certgen server "$CERT_DIR/httpd.crt" "$KEY_DIR/httpd.key" \
+	mbedtls-certgen server "$CERT" "$KEY" \
 		--cn camera.local --days 3650
+	chmod 600 "$KEY" 2>/dev/null
 else
 	echo "WARNING: No TLS tool found, skipping certificate generation."
 	exit 1
 fi
 
 echo "TLS certificates generated:"
-echo "  Certificate: $CERT_DIR/httpd.crt"
-echo "  Private Key:  $KEY_DIR/httpd.key"
+echo "  Certificate: $CERT"
+echo "  Private Key:  $KEY"

--- a/package/timps/files/send2common
+++ b/package/timps/files/send2common
@@ -24,15 +24,17 @@ _cleanup() {
 copy_photo() {
 	# Use existing photo from motion if available
 	if [ -n "$MOTION_PHOTO_FILE" ] && [ -f "$MOTION_PHOTO_FILE" ]; then
-		# Copy to temp file immediately to avoid race condition with cleanup
-		local tmpfile="$(mktemp -u).jpg"
+		# Create atomically (mktemp, not "mktemp -u") so cp can't follow a symlink
+		# pre-planted at a predictable name in the sticky /tmp; pin to /tmp so a
+		# hostile TMPDIR can't redirect it.
+		local tmpfile="$(mktemp /tmp/send2_photo.XXXXXX)" || return
 		cp "$MOTION_PHOTO_FILE" "$tmpfile"
 		add_to_garbage "$tmpfile"
 		echo "$tmpfile"
 		return
 	fi
 
-	local tmpfile="$(mktemp -u).jpg"
+	local tmpfile="$(mktemp /tmp/send2_photo.XXXXXX)" || return
 	if command -v prudyntctl >/dev/null 2>&1; then
 		prudyntctl snapshot -c 0 > "$tmpfile"
 	elif command -v timpsd >/dev/null 2>&1; then
@@ -48,15 +50,18 @@ copy_photo() {
 copy_video() {
 	# Use existing video from motion if available
 	if [ -n "$MOTION_VIDEO_FILE" ] && [ -f "$MOTION_VIDEO_FILE" ]; then
-		# Copy to temp file immediately to avoid race condition with cleanup
-		local tmpfile="$(mktemp -u).mp4"
+		# Create atomically (see copy_photo): cp target must not be a planted symlink.
+		local tmpfile="$(mktemp /tmp/send2_video.XXXXXX)" || return
 		cp "$MOTION_VIDEO_FILE" "$tmpfile"
 		add_to_garbage "$tmpfile"
 		echo "$tmpfile"
 		return
 	fi
 
-	local tmpfile="$(mktemp -u).mp4"
+	# Clip target: record_clip()/prudynt create the file themselves with O_EXCL,
+	# so it must NOT pre-exist -> name only (mktemp -u), but pinned to /tmp so it
+	# satisfies record_clip's required /tmp/ prefix regardless of TMPDIR.
+	local tmpfile="$(mktemp -u /tmp/send2_clip.XXXXXX)"
 
 	# timps: no prudyntctl / mp4ctl FIFO. Ask timps for an on-demand fMP4 clip
 	# via its /control endpoint (record.clip). Loopback skips auth; the request

--- a/package/timps/files/timps-motion
+++ b/package/timps/files/timps-motion
@@ -30,25 +30,31 @@ run() {
 	done
 	[ "$any" = "true" ] || exit 0
 
-	# unpredictable names: a guessable /tmp path lets a local user pre-plant a
-	# symlink and redirect the snapshot/clip write (record_clip also uses O_EXCL).
-	MOTION_PHOTO_FILE="$(mktemp -u /tmp/motion_XXXXXX).jpg"
-	MOTION_VIDEO_FILE="$(mktemp -u /tmp/motion_XXXXXX).mp4"
-
 	# capture once, shared by all services (send2common reuses these files)
+	MOTION_PHOTO_FILE=""; MOTION_VIDEO_FILE=""
 	if [ "$need_photo" = "true" ]; then
-		curl --silent "$BASE/snapshot.jpg?chn=$CHAN" > "$MOTION_PHOTO_FILE"
-		[ -s "$MOTION_PHOTO_FILE" ] || MOTION_PHOTO_FILE=""
-	else
-		MOTION_PHOTO_FILE=""
+		# Create the target atomically (mktemp, mode 0600) so curl's redirect
+		# can't be aimed at a symlink pre-planted in the sticky /tmp. Explicit
+		# /tmp template ignores any hostile TMPDIR.
+		MOTION_PHOTO_FILE="$(mktemp /tmp/motion_XXXXXX 2>/dev/null)"
+		if [ -n "$MOTION_PHOTO_FILE" ]; then
+			curl --silent "$BASE/snapshot.jpg?chn=$CHAN" > "$MOTION_PHOTO_FILE"
+			[ -s "$MOTION_PHOTO_FILE" ] || { rm -f "$MOTION_PHOTO_FILE"; MOTION_PHOTO_FILE=""; }
+		fi
 	fi
 	if [ "$need_video" = "true" ]; then
-		curl --silent --max-time 20 -X POST "$BASE/control" \
-			-d "{\"record\":{\"clip\":\"$MOTION_VIDEO_FILE\",\"seconds\":$CLIP_SECS}}" \
-			>/dev/null 2>&1
-		[ -s "$MOTION_VIDEO_FILE" ] || MOTION_VIDEO_FILE=""
-	else
-		MOTION_VIDEO_FILE=""
+		# record_clip() creates the file itself with O_CREAT|O_EXCL|O_NOFOLLOW, so
+		# the path must NOT pre-exist -> name only (mktemp -u). O_EXCL turns a
+		# planted symlink into a failed clip, never an arbitrary overwrite; the
+		# explicit /tmp template keeps it under record_clip's required /tmp/ prefix
+		# regardless of TMPDIR.
+		MOTION_VIDEO_FILE="$(mktemp -u /tmp/motion_XXXXXX 2>/dev/null)"
+		if [ -n "$MOTION_VIDEO_FILE" ]; then
+			curl --silent --max-time 20 -X POST "$BASE/control" \
+				-d "{\"record\":{\"clip\":\"$MOTION_VIDEO_FILE\",\"seconds\":$CLIP_SECS}}" \
+				>/dev/null 2>&1
+			[ -s "$MOTION_VIDEO_FILE" ] || MOTION_VIDEO_FILE=""
+		fi
 	fi
 
 	pids=""
@@ -60,7 +66,9 @@ run() {
 		pids="$pids $!"
 	done
 
-	for p in $pids; do while kill -0 "$p" 2>/dev/null; do sleep 1; done; done
+	# wait on the actual child PIDs (not kill -0 polling, which hangs on a
+	# recycled PID that a long-lived unrelated process may inherit).
+	[ -n "$pids" ] && wait $pids 2>/dev/null
 	[ -n "$MOTION_PHOTO_FILE" ] && rm -f "$MOTION_PHOTO_FILE"
 	[ -n "$MOTION_VIDEO_FILE" ] && rm -f "$MOTION_VIDEO_FILE"
 }

--- a/package/timps/files/timps.conf
+++ b/package/timps/files/timps.conf
@@ -48,17 +48,23 @@ image.wb_rgain               = 0
 image.wb_bgain               = 0
 
 # ---- RTSP server (video + audio) ----
+# Default credentials are thingino/thingino (same convention as prudynt). Change
+# them via the WebUI or here. Leaving user empty makes RTSP open (no auth).
 rtsp.enabled = 1
 rtsp.port    = 554
-rtsp.user    =
-rtsp.pass    =
+rtsp.user    = thingino
+rtsp.pass    = thingino
 
 # ---- HTTP preview (fMP4 + JPEG/MJPEG) ----
+# NOTE: the WebUI proxies /mjpeg and /onvif/image.cgi are wired to
+# http://127.0.0.1:8880 at build time. If you change http.port (or set
+# http.https=1, which turns this port TLS-only), those two loopback proxies in
+# /etc/httpd.conf stop working until you repoint them to the new port/scheme.
 http.enabled     = 1
 http.port        = 8880
 http.preview_chn = 1
-http.user        =
-http.pass        =
+http.user        = thingino
+http.pass        = thingino
 http.token       =
 http.token_file  = /run/timps.token
 
@@ -70,7 +76,10 @@ http.tls_key    = /etc/ssl/private/httpd.key
 # rtsp.tls_port = 322                     # RTSPS port
 
 # ---- SRT output (USE_SRT builds, libsrt) ----
-srt.enabled    = 1
+# Off by default: the SRT listener is unauthenticated, so don't open udp/9000
+# out of the box. Set to 1 only on trusted networks (and only matters in
+# BR2_PACKAGE_TIMPS_SRT builds).
+srt.enabled    = 0
 srt.port       = 9000
 
 # ---- recording ----

--- a/package/timps/files/www/a/navigation.js
+++ b/package/timps/files/www/a/navigation.js
@@ -152,7 +152,13 @@
             label: "Restart streamer",
             href: "#",
             id: "restart-prudynt-nav",
-            className: "text-danger confirm",
+            /* NOTE: no "confirm" class here on purpose. footer.js's
+             * restartPrudynt() shows its OWN confirm dialog; adding the generic
+             * .confirm layer too makes two dialogs share the one Bootstrap modal
+             * -> the second show() is a no-op mid hide-animation and auto-cancels
+             * -> the /x/restart-prudynt.cgi fetch never fires (streamer never
+             * restarts). One confirm only. */
+            className: "text-danger",
             trackActive: false,
           },
         ],

--- a/package/timps/files/www/a/privacy.js
+++ b/package/timps/files/www/a/privacy.js
@@ -59,12 +59,13 @@
     return { sx: dw / streamW, sy: dh / streamH, dw: dw, dh: dh };
   }
 
-  function clampRegion(r) {
-    r.w = Math.max(MIN, Math.min(streamW, Math.round(r.w)));
-    r.h = Math.max(MIN, Math.min(streamH, Math.round(r.h)));
-    r.x = Math.max(0, Math.min(streamW - r.w, Math.round(r.x)));
-    r.y = Math.max(0, Math.min(streamH - r.h, Math.round(r.y)));
+  function clampRegionTo(r, W, H) {
+    r.w = Math.max(MIN, Math.min(W, Math.round(r.w)));
+    r.h = Math.max(MIN, Math.min(H, Math.round(r.h)));
+    r.x = Math.max(0, Math.min(W - r.w, Math.round(r.x)));
+    r.y = Math.max(0, Math.min(H - r.h, Math.round(r.y)));
   }
+  function clampRegion(r) { clampRegionTo(r, streamW, streamH); }
 
   function send(n) {
     var r = regions[n];
@@ -78,12 +79,14 @@
     if (applyBoth && otherW > 0 && otherH > 0) {
       var o = 1 - streamIdx;               // only two video streams
       var fx = otherW / streamW, fy = otherH / streamH;
+      // scale, then clamp against the OTHER stream's bounds + MIN so the mirror
+      // can't round past its width/height or shrink below the minimum edge.
+      var mr = { x: r.x * fx, y: r.y * fy, w: r.w * fx, h: r.h * fy };
+      clampRegionTo(mr, otherW, otherH);
       payload[o] = {};
       payload[o][n] = {
         enabled: r.enabled ? 1 : 0,
-        x: Math.round(r.x * fx), y: Math.round(r.y * fy),
-        w: Math.max(1, Math.round(r.w * fx)),
-        h: Math.max(1, Math.round(r.h * fy)),
+        x: mr.x, y: mr.y, w: mr.w, h: mr.h,
         color: r.color,
       };
     }
@@ -355,8 +358,14 @@
   var bothChk = document.getElementById("pm-both");
   if (bothChk) bothChk.addEventListener("change", function () {
     applyBoth = bothChk.checked;
-    // enabling mirrors the current masks onto the other stream immediately
-    if (applyBoth) regions.forEach(function (r, n) { send(n); });
+    // Enabling mirrors the current masks onto the other stream immediately, but
+    // ONLY the enabled ones: mirroring disabled slots would push enabled:0 onto
+    // the other stream and wipe masks that exist only there.
+    if (applyBoth) {
+      var any = false;
+      regions.forEach(function (r, n) { if (r.enabled) { send(n); any = true; } });
+      if (any) toast("info", "Enabled masks mirrored onto the other stream.", 2500);
+    }
   });
   window.addEventListener("resize", renderBoxes);
   if (window.timpsApi) window.timpsApi.events("config", onConfigEvent);

--- a/package/timps/files/www/a/recordings.js
+++ b/package/timps/files/www/a/recordings.js
@@ -98,7 +98,12 @@
 
       var tdWhen = document.createElement("td"); tdWhen.textContent = label;
       var tdSeg = document.createElement("td");
-      tdSeg.innerHTML = '<span class="text-secondary small">' + f.file + "</span>";
+      // textContent, not innerHTML: the segment name comes from the SD card and
+      // must never be interpreted as HTML (stored-XSS otherwise).
+      var segSpan = document.createElement("span");
+      segSpan.className = "text-secondary small";
+      segSpan.textContent = f.file;
+      tdSeg.appendChild(segSpan);
       var tdSize = document.createElement("td"); tdSize.className = "text-end"; tdSize.textContent = human(f.size);
 
       tr.appendChild(tdWhen); tr.appendChild(tdSeg); tr.appendChild(tdSize); tr.appendChild(actions);

--- a/package/timps/files/www/preview-timps.html
+++ b/package/timps/files/www/preview-timps.html
@@ -226,13 +226,23 @@
     // live SPS server-side; a static page cannot, so probe common strings.
     // The init segment carries the real avcC/hvcC, so a generic profile in
     // the MIME string is fine for MSE.
-    function pickMime(MS) {
-      const candidates = [
-        'video/mp4; codecs="avc1.640028, mp4a.40.2"', // H.264 High + AAC
-        'video/mp4; codecs="avc1.640028"',            // H.264 High, video only
-        'video/mp4; codecs="hvc1.1.6.L123.B0, mp4a.40.2"', // H.265 + AAC
-        'video/mp4; codecs="hvc1.1.6.L123.B0"'        // H.265, video only
+    //
+    // CRITICAL: only advertise an mp4a (AAC) audio track when timps actually
+    // muxes AAC into the fMP4. With PCM (G.711) audio the stream is video-only
+    // (httpd.c can_audio = acodec==AAC), so a SourceBuffer typed with mp4a would
+    // reject the 1-track init segment (MSE requires the init tracks to match the
+    // codecs string) and tear down the whole MediaSource -> black player, no
+    // video at all. When wantAac is false we therefore probe video-only strings.
+    function pickMime(MS, wantAac) {
+      const vOnly = [
+        'video/mp4; codecs="avc1.640028"',            // H.264 High
+        'video/mp4; codecs="hvc1.1.6.L123.B0"'        // H.265
       ];
+      const withAac = [
+        'video/mp4; codecs="avc1.640028, mp4a.40.2"',
+        'video/mp4; codecs="hvc1.1.6.L123.B0, mp4a.40.2"'
+      ];
+      const candidates = wantAac ? withAac.concat(vOnly) : vOnly;
       // isTypeSupported must be queried on whichever MSE class we'll actually
       // construct (ManagedMediaSource on iOS) - the bare global MediaSource
       // is undefined there, so calling it unqualified throws before this
@@ -241,6 +251,19 @@
         if (MS && MS.isTypeSupported(m)) return m;
       }
       return null;
+    }
+
+    // Ask timps (GET /control) whether audio is enabled AND AAC; anything else
+    // (pcma/pcmu/disabled/unreachable) means the fMP4 is video-only, so we must
+    // NOT claim an AAC track to MSE. Uses the same token that unlocks /control.
+    async function streamHasAac(apiBase, tok) {
+      try {
+        const r = await fetch(apiBase + "/control" + (tok ? "?" + tok.slice(1) : ""),
+                              { cache: "no-store" });
+        if (!r.ok) return false;
+        const j = await r.json();
+        return !!(j && j.audio && j.audio.enabled && j.audio.codec === "aac");
+      } catch (e) { return false; }   // unreachable -> safe video-only
     }
 
     async function stopStream(reason = "Disconnected") {
@@ -264,7 +287,7 @@
     // Port of timps's embedded MSE player (src/mp4/httpd.c PLAYER_TAIL):
     // sequence mode, append queue with pump(), eviction of data >10 s behind
     // playback, live-edge jump when drifting >6 s behind.
-    async function startStream() {
+    async function startStream(forceVideoOnly = false) {
       if (running) return;
       running = true;
       const mySession = ++session;   // this attempt owns the player now
@@ -283,7 +306,11 @@
       // browsers keep using plain MediaSource. Mirrors the fix already
       // applied to timps's own embedded player (src/mp4/httpd.c PLAYER_TAIL).
       const MS = window.ManagedMediaSource || window.MediaSource;
-      const mime = pickMime(MS);
+      // Advertise AAC to MSE only if timps is actually muxing it; a video-only
+      // stream (PCM audio) with an mp4a-typed SourceBuffer shows no video.
+      const wantAac = forceVideoOnly ? false : await streamHasAac(base, tok);
+      if (session !== mySession) return;   // superseded during the /control probe
+      const mime = pickMime(MS, wantAac);
 
       if (!MS || !mime) {
         // no MSE (e.g. old iOS Safari): let the <video> try progressive mp4
@@ -308,6 +335,14 @@
           return;
         }
         sb.mode = "sequence";
+        // Safety net: if we advertised AAC but the init segment is video-only
+        // (e.g. audio pipeline degraded after the /control probe), MSE fails the
+        // append asynchronously here. Retry once forcing a video-only buffer so
+        // the video still shows instead of a black player.
+        sb.addEventListener("error", () => {
+          if (session !== mySession || forceVideoOnly || !/mp4a/.test(mime)) return;
+          stopStream("Retrying video-only…").then(() => startStream(true));
+        });
         let dead = false;
         const q = [];
         let busy = false;

--- a/package/timps/files/www/x/json-recordings.cgi
+++ b/package/timps/files/www/x/json-recordings.cgi
@@ -24,13 +24,15 @@ DEL=$(urldec "$(qval del)")
 safe() { case "$1" in ""|/*|*..*) return 1 ;; *) return 0 ;; esac; }
 
 if [ -n "$DEL" ]; then
-  if safe "$DEL" && [ -f "$BASE/$DEL" ]; then rm -f "$BASE/$DEL"; printf 'Content-Type: application/json\r\n\r\n{"ok":true}\n'
+  if safe "$DEL" && [ -f "$BASE/$DEL" ] && [ ! -L "$BASE/$DEL" ]; then rm -f "$BASE/$DEL"; printf 'Content-Type: application/json\r\n\r\n{"ok":true}\n'
   else printf 'Status: 400 Bad Request\r\n\r\n'; fi
   exit 0
 fi
 
 if [ -n "$FILE" ]; then
-  if ! safe "$FILE" || [ ! -f "$BASE/$FILE" ]; then printf 'Status: 404 Not Found\r\n\r\n'; exit 0; fi
+  # reject traversal, missing files, and symlinks (a planted symlink on an
+  # ext-formatted SD could otherwise exfiltrate arbitrary files)
+  if ! safe "$FILE" || [ ! -f "$BASE/$FILE" ] || [ -L "$BASE/$FILE" ]; then printf 'Status: 404 Not Found\r\n\r\n'; exit 0; fi
   F="$BASE/$FILE"; SZ=$(stat -c%s "$F" 2>/dev/null || echo 0)
   printf 'Status: 200 OK\r\n'
   printf 'Content-Type: video/mp4\r\n'
@@ -49,6 +51,9 @@ printf '{"base":"%s","files":[' "$BASE"
 i=0
 for f in $(find "$BASE" -type f -name '*.mp4' 2>/dev/null | sort -r); do
   rel=${f#"$BASE"/}
+  # JSON-escape the filename (backslash + double-quote) so an odd name on the SD
+  # can't break the JSON or inject into the WebUI.
+  rel=$(printf '%s' "$rel" | sed 's/\\/\\\\/g; s/"/\\"/g')
   sz=$(stat -c%s "$f" 2>/dev/null || echo 0)
   mt=$(stat -c%Y "$f" 2>/dev/null || echo 0)
   [ $i -gt 0 ] && printf ','

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,10 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.3.9
+TIMPS_VERSION = v1.4.0
+TIMPS_LICENSE = MIT
+# Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
+# once it exists so legal-info can capture it.
 
 
 # Submodule provides the IMP headers (ingenic-headers).
@@ -73,6 +76,7 @@ define TIMPS_BUILD_CMDS
 	$(MAKE) \
 		CROSS_COMPILE=$(TARGET_CROSS) \
 		PLATFORM=$(shell echo $(SOC_FAMILY) | tr a-z A-Z) \
+		VERSION=$(TIMPS_VERSION) \
 		IMP_LIB=$(STAGING_DIR)/usr/lib \
 		IMPLIBS="$(TIMPS_IMPLIBS)" \
 		FAACLIB="-lfaac" \
@@ -92,9 +96,6 @@ define TIMPS_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0755 $(@D)/timpsd \
 		$(TARGET_DIR)/usr/bin/timpsd
 
-	# Copy to NFS share for dev iteration
-	[ -d /nfs ] && cp $(TARGET_DIR)/usr/bin/timpsd /nfs/timpsd || true
-
 	# Install default configuration file
 	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/timps.conf \
 		$(TARGET_DIR)/etc/timps.conf
@@ -112,6 +113,13 @@ define TIMPS_INSTALL_TARGET_CMDS
 	# Install the self-test helper
 	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/timps-selftest.sh \
 		$(TARGET_DIR)/usr/bin/timps-selftest
+
+	# Motion->send2 bridge. timps.conf's motion.on_motion points at this path, so
+	# install it unconditionally: otherwise imp_motion.c runs system() on a
+	# missing script on every motion event. It no-ops cleanly when the send2
+	# toolkit/config are absent (the send2 hook below adds those when WEBUI is on).
+	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/timps-motion \
+		$(TARGET_DIR)/usr/sbin/timps-motion
 
 	# Install the day/night ISP hook (/usr/sbin/color) when native day/night
 	# detection is enabled; timps calls it to drive the ircut/light/gain
@@ -195,7 +203,11 @@ endif
 # scripts they call are simply missing on a timps image. Install from a
 # finalize hook (not a normal package dependency) so this doesn't require
 # enabling the prudynt-t Buildroot package itself.
-ifeq ($(BR2_PACKAGE_THINGINO_WEBUI)$(BR2_THINGINO_DEV_IPCAM),yy)
+#
+# Gated on TIMPS_CONTROL as well: timps-motion and send2common POST to timps's
+# /control endpoint; with CONTROL compiled out those calls hit a dead port, so
+# don't ship the bridge at all in that configuration.
+ifeq ($(BR2_PACKAGE_THINGINO_WEBUI)$(BR2_THINGINO_DEV_IPCAM)$(BR2_PACKAGE_TIMPS_CONTROL),yyy)
 PRUDYNT_T_FILES_DIR = $(PRUDYNT_T_PKGDIR)/files
 define TIMPS_INSTALL_SEND2
 	$(INSTALL) -D -m 0644 $(PRUDYNT_T_FILES_DIR)/prudynt-helpers \
@@ -204,8 +216,6 @@ define TIMPS_INSTALL_SEND2
 		$(TARGET_DIR)/usr/share/send2common
 	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/telegram-cam-register \
 		$(TARGET_DIR)/usr/sbin/telegram-cam-register
-	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/timps-motion \
-		$(TARGET_DIR)/usr/sbin/timps-motion
 	for f in send2email send2ftp send2ntfy send2storage send2telegram send2webhook; do \
 		$(INSTALL) -D -m 0755 $(PRUDYNT_T_FILES_DIR)/$$f $(TARGET_DIR)/usr/sbin/$$f ; \
 	done
@@ -225,7 +235,10 @@ endif
 # WebUI is present. preview-timps.html lives in THIS package (files/www/)
 # together with the rest of the timps WebUI overlay, so thingino-webui stays
 # pristine.
-ifeq ($(BR2_PACKAGE_THINGINO_WEBUI),y)
+# Gated on TIMPS_CONTROL too: preview-timps.html pulls /x/timps-token.cgi, which
+# is only installed by the WebUI-overlay hook (same gate), so shipping preview
+# without CONTROL would leave a broken token fetch.
+ifeq ($(BR2_PACKAGE_THINGINO_WEBUI)$(BR2_PACKAGE_TIMPS_CONTROL),yy)
 TIMPS_PREVIEW_SRC = $(TIMPS_PKGDIR)/files/www/preview-timps.html
 define TIMPS_INSTALL_PREVIEW
 	$(INSTALL) -D -m 0644 $(TIMPS_PREVIEW_SRC) \
@@ -247,6 +260,10 @@ define TIMPS_DISABLE_DAYNIGHTD
 		sed -i '/config-photosensing\.html/d' \
 			$(TARGET_DIR)/var/www/a/navigation.js ; \
 	fi
+	# Also drop the page + script so the orphaned "Photosensing" config (it
+	# drives the now-disabled daynightd) isn't reachable by direct URL.
+	rm -f $(TARGET_DIR)/var/www/config-photosensing.html \
+	      $(TARGET_DIR)/var/www/a/config-photosensing.js
 endef
 TIMPS_TARGET_FINALIZE_HOOKS += TIMPS_DISABLE_DAYNIGHTD
 endif


### PR DESCRIPTION
Follow-up to #1296 (v1.3.9). Bumps timps to v1.4.0 and hardens the package.

Streamer (v1.4.0 source, Lu-Fi/timps):
- G.711 audio stutter / mpv rebuffering fixed (sample-count RTP timestamps; G.711 pinned to 8kHz; faac->PCMU fallback reconfigures the AI to 8kHz instead of relabeling; deeper AI buffer)
- config-write race fixed (mutex + mkstemp + trailing-newline guard; no more glued/duplicate keys)

Package:
- version binding (VERSION=$(TIMPS_VERSION)); drop /nfs dev artifact; TIMPS_LICENSE=MIT
- gate preview+send2 on TIMPS_CONTROL; install timps-motion unconditionally (no system() spam)
- S96onvif_discovery: parser aligned to the daemon, RTSP fallback port 554, atomic mktemp
- send2common/timps-motion: symlink-safe tmpfiles, wait(1) instead of PID polling
- WebUI: recordings stored-XSS fix, privacy 'apply to both' clamp, restart-streamer double-confirm fix, preview shows video with PCM audio (video-only fMP4)
- default RTSP/HTTP creds thingino/thingino; srt.enabled=0; S95timps status/restart-race/TLS