### PR TITLE
timps: v1.4.4 (live-audio-toggle SIGSEGV fix; S96 curl for /control)

### DIFF
--- a/package/timps/files/S96onvif_discovery
+++ b/package/timps/files/S96onvif_discovery
@@ -108,12 +108,22 @@ fetch_timps_control() {
 	[ "$TIMPS_CONTROL_TRIED" = "1" ] && return
 	TIMPS_CONTROL_TRIED=1
 
-	if [ "$(timps_http_scheme)" = "https" ]; then
-		TIMPS_CONTROL_JSON=$(wget -q -T 3 --no-check-certificate -O - \
-			"https://127.0.0.1:$(timps_http_port)/control" 2>/dev/null)
+	scheme=$(timps_http_scheme)
+	url="$scheme://127.0.0.1:$(timps_http_port)/control"
+
+	# Prefer curl: busybox wget returns nothing for timps' httpd /control reply
+	# on some builds, whereas curl (a hard dep of the snapshot CGI) works. Fall
+	# back to wget only if curl is absent.
+	if command -v curl >/dev/null 2>&1; then
+		if [ "$scheme" = "https" ]; then
+			TIMPS_CONTROL_JSON=$(curl -sk -m 3 "$url" 2>/dev/null)
+		else
+			TIMPS_CONTROL_JSON=$(curl -s -m 3 "$url" 2>/dev/null)
+		fi
+	elif [ "$scheme" = "https" ]; then
+		TIMPS_CONTROL_JSON=$(wget -q -T 3 --no-check-certificate -O - "$url" 2>/dev/null)
 	else
-		TIMPS_CONTROL_JSON=$(wget -q -T 3 -O - \
-			"http://127.0.0.1:$(timps_http_port)/control" 2>/dev/null)
+		TIMPS_CONTROL_JSON=$(wget -q -T 3 -O - "$url" 2>/dev/null)
 	fi
 }
 

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,7 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.4.3
+TIMPS_VERSION = v1.4.4
 TIMPS_LICENSE = MIT
 # Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
 # once it exists so legal-info can capture it.


### PR DESCRIPTION
Bumps the bundled timps streamer to v1.4.4.

**v1.4.4 fixes a crash:** toggling audio.agc/ns/high_pass live via /control ran IMP_AI_Enable/DisableAgc/Ns/Hpf from the request thread while the audio thread was inside IMP_AI_GetFrame (where libimp processes those modules) -> use-after-free in libimp (dmesg: epc=0, ra in libimp.so). The toggle now only flags the change; the audio thread re-applies it at a frame-free point.

**S96onvif_discovery** now fetches /control via curl (busybox wget returned an empty body for timps' httpd on some builds, so ONVIF framerate/bitrate were never written into onvif.json); wget remains a fallback.

No package structure or Kconfig changes; only TIMPS_VERSION and the discovery script. The ONVIF FrameRateLimit/BitrateLimit values additionally need the separate thingino-onvif template patch to surface (independent PR); this change is harmless without it.