### PR TITLE
timps: v1.4.6 (live-audio-toggle crash fix + hardening)

### DIFF
--- a/package/timps/files/www/a/config-audio.js
+++ b/package/timps/files/www/a/config-audio.js
@@ -33,11 +33,14 @@
     audio_mic_vol: { key: "volume", live: true },
     audio_mic_gain: { key: "gain", live: true },
     audio_mic_alc_gain: { key: "alc_gain", live: true },
-    audio_mic_high_pass_filter: { key: "high_pass", live: true },
-    audio_mic_agc_enabled: { key: "agc", live: true },
-    audio_mic_agc_target_level_dbfs: { key: "agc_target_dbfs", live: true },
-    audio_mic_agc_compression_gain_db: { key: "agc_compression_db", live: true },
-    audio_mic_noise_suppression: { key: "ns", live: true },
+    // high_pass/agc/ns are restart-required: libimp runs these DSP modules on
+    // its own record thread and frees them unlocked, so a live toggle races the
+    // vendor thread -> crash. Persist + "applies on restart", like codec.
+    audio_mic_high_pass_filter: { key: "high_pass", live: false },
+    audio_mic_agc_enabled: { key: "agc", live: false },
+    audio_mic_agc_target_level_dbfs: { key: "agc_target_dbfs", live: false },
+    audio_mic_agc_compression_gain_db: { key: "agc_compression_db", live: false },
+    audio_mic_noise_suppression: { key: "ns", live: false },
     audio_mic_format: { key: "codec", live: false },
     audio_mic_sample_rate: { key: "samplerate", live: false },
     audio_mic_bitrate: { key: "bitrate", live: false },

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,7 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.4.4
+TIMPS_VERSION = v1.4.6
 TIMPS_LICENSE = MIT
 # Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
 # once it exists so legal-info can capture it.


### PR DESCRIPTION
Bumps the bundled timps streamer v1.4.4 -> v1.4.6.

**v1.4.5 fixes a crash:** toggling audio.agc/ns/high_pass live via /control raced libimp's own internal audio record thread (IMP_AI_Disable{Agc,Ns,Hpf} frees the DSP module unlocked) -> use-after-free / SIGSEGV in libaudioProcess.so (epc=0, ra in libimp). These five DSP keys are now restart-required (persist-only, applied once at boot); the WebUI shows them as 'applies on restart'. Plus audit hardening: record-config clamps, hvcC numTemporalLayers, RTSP transport range checks, JSON-accumulator UB fix.

**v1.4.6** adds M14 compiler/linker build hardening (SSP/FORTIFY/RELRO/NX, libc-aware) in the timps source.

**S96onvif_discovery** now fetches /control via curl (busybox wget returned an empty body on some builds, so ONVIF framerate/bitrate were never written to onvif.json); wget stays as fallback.

No package-structure or Kconfig changes. The ONVIF FrameRateLimit/BitrateLimit values additionally need the separate thingino-onvif template patch to surface (independent PR); harmless without it.