### PR TITLE
linux: fix T31 CGU parent-only clock changes

### DIFF
--- a/package/all-patches/linux/3.10.14/0091-t31-cgu-write-parent-only-changes.patch
+++ b/package/all-patches/linux/3.10.14/0091-t31-cgu-write-parent-only-changes.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matt Davis <matteius@gmail.com>
+Date: Mon, 20 Jul 2026 10:05:00 -0400
+Subject: [PATCH] MIPS: ingenic: t31: apply parent-only CGU changes
+
+cgu_set_parent() builds a register value containing both the requested
+parent selector and a divider appropriate for that parent.  It only writes
+the value when the divider differs from the current hardware value,
+however.  A parent change that happens to keep the same divider is silently
+skipped even though clk->parent is updated, leaving the software clock tree
+out of sync with the hardware.
+
+This is visible on T31 when a bootloader leaves CIM sourced from SCLKA.
+The GC4023 driver requests VPLL and 27 MHz, and the clock framework reports
+27 MHz, but CPM_CIMCDR retains the SCLKA selector with the VPLL-derived
+divide-by-40 value.  With a 1392 MHz SCLKA, the sensor is actually driven at
+34.8 MHz.  The old vendor U-Boot masked the bug by selecting VPLL before
+Linux.
+
+Include the parent selector in the change test so the hardware register is
+updated whenever either the divider or parent differs.  Handle the one-bit
+SELECTOR_2 mux separately from the other two-bit selectors.
+
+Signed-off-by: Matt Davis <matteius@gmail.com>
+---
+ arch/mips/xburst/soc-t31/common/clk/clk_cgu.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/arch/mips/xburst/soc-t31/common/clk/clk_cgu.c b/arch/mips/xburst/soc-t31/common/clk/clk_cgu.c
+index 2698577c7..5f12b5cb9 100644
+--- a/arch/mips/xburst/soc-t31/common/clk/clk_cgu.c
++++ b/arch/mips/xburst/soc-t31/common/clk/clk_cgu.c
+@@ -316,7 +316,7 @@ static int cgu_set_parent(struct clk *clk, struct clk *parent)
+ {
+ 	int i,tmp;
+ 	int no = CLK_CGU_NO(clk->flags);
+-	unsigned int reg_val,cgu,mask;
++	unsigned int reg_val,cgu,mask,parent_mask;
+ 	int ce,stop,busy;
+ 	unsigned long flags;
+ 	stop = cgu_clks[no].ce_busy_stop;
+@@ -325,6 +325,7 @@ static int cgu_set_parent(struct clk *clk, struct clk *parent)
+ 	ce = stop + 2;
+ 	mask = (1 << cgu_clks[no].div) - 1;
+ 
++	parent_mask = cgu_clks[no].sel == SELECTOR_2 ? (1U << 31) : (3U << 30);
+ 	for(i = 0;i < 4;i++) {
+ 		if(selector[cgu_clks[no].sel].route[i] == get_clk_id(parent)){
+ 			break;
+@@ -359,7 +360,7 @@ static int cgu_set_parent(struct clk *clk, struct clk *parent)
+ 
+ 	if(reg_val & (1 << stop))
+ 		cgu_clks[no].cache = cgu;
+-	else if((mask & reg_val) != i){
++	else if((reg_val ^ cgu) & (mask | parent_mask)){
+ 		cpm_outl(cgu, cgu_clks[no].off);
+ 		while(cpm_test_bit(busy,cgu_clks[no].off))
+ 			printk("wait stable.[%d][%s]\n",__LINE__,clk->name);
+-- 
+2.51.0


### PR DESCRIPTION
## Summary

- make the T31 CGU driver write the hardware register when the parent mux changes, even if the divider stays the same
- keep the software clock tree and CPM selector synchronized
- handle the one-bit `SELECTOR_2` mux separately from the normal two-bit selectors

This patch does not choose a clock parent. It makes the existing `clk_set_parent()` API honor the parent requested by each consumer.

## Root cause

`cgu_set_parent()` constructs a value containing the requested parent and its divider, but its write condition compares only the divider. When only the parent changes, it still assigns `clk->parent` and returns success while leaving the physical selector unchanged.

This became visible after moving from the old vendor U-Boot, which initialized T31 CIM to VPLL, to modern U-Boot, which leaves it on SCLKA. The GC4023 driver explicitly requests VPLL and 27 MHz because its initialization table requires a 27 MHz MCLK. The clock framework reported 27 MHz while `CPM_CIMCDR` was `0x00000027`: SCLKA divided by 40, or 34.8 MHz with the observed 1392 MHz SCLKA.

AVPU parent policy is deliberately outside the scope of this change.

## Device validation

Tested on a T31X/GC4023 Vanhua H53E camera:

- failing state: AVPU on its compiled MPLL default and CIM at `0x00000027`; severe magenta vertical artifacts around highlights
- changed only CIM to `0x80000027` (VPLL / 40 = 27 MHz), then reloaded the same ISP/sensor modules and Raptor configuration; artifacts disappeared completely in the same scene
- changed only CIM back to the SCLKA selector while retaining AVPU on MPLL; artifacts returned
- final clean state: AVPU on MPLL and CIM at a true 27 MHz
- direct kernel patch dry-run succeeds against the exact 3.10.14 T31 kernel source used for the device

A full firmware build is left to repository CI, per the project validation workflow.