### PR TITLE
Add MQTT TLS Certificate Verification Skip Option

### DIFF
--- a/docs/homeassistant.md
+++ b/docs/homeassistant.md
@@ -36,6 +36,8 @@ Within a few seconds HA will show a new device containing all enabled entities.
 | `ota_check_interval` | `21600` | Seconds between GitHub firmware release checks (Firmware update entity) |
 | `device_name` | `""` | Override device name (defaults to hostname) |
 | `device_model` | `""` | Override device model string |
+| `mqtt.use_ssl` | `false` | Connect to the MQTT broker with TLS using the system CA bundle |
+| `mqtt.tls_skip_verify` | `false` | Skip broker certificate verification when TLS is enabled. Insecure; use only for self-signed or otherwise untrusted broker certificates |
 | `enable_motion` | `true` | Binary sensor: motion detected |
 | `enable_motion_guard` | `true` | Switch: enable/disable motion detection |
 | `enable_ircut` | `true` | Switch: IR cut filter |
@@ -63,6 +65,7 @@ Disable individual entities you don't want:
 jct /etc/thingino.json set ha.enable_reboot false
 jct /etc/thingino.json set ha.enable_ptz true   # enable PTZ buttons
 ```
+
 
 ## MQTT topic layout
 

--- a/docs/mqtt-subscriptions.md
+++ b/docs/mqtt-subscriptions.md
@@ -97,6 +97,7 @@ resource-constrained hardware.
   "username": "myuser",
   "password": "secret",
   "use_ssl": false,
+  "tls_skip_verify": false,
   "subscriptions": [
     {
       "topic": "cameras/%id/reboot",
@@ -116,7 +117,9 @@ resource-constrained hardware.
 | `username`      | string  | Optional broker username.                          |
 | `password`      | string  | Optional broker password.                          |
 | `use_ssl`       | bool    | Enable TLS using system CA bundle.                 |
+| `tls_skip_verify` | bool | Skip broker certificate verification when TLS is enabled. Insecure; use only for self-signed or otherwise untrusted broker certificates. Default: `false`. |
 | `subscriptions` | array   | List of subscription objects (see below).          |
+
 
 Each subscription object:
 
@@ -494,6 +497,7 @@ subscriptions for a single camera, all scoped under `cameras/%id/`:
   "username": "camera",
   "password": "secret",
   "use_ssl": false,
+  "tls_skip_verify": false,
   "subscriptions": [
     { "topic": "cameras/%id/reboot",           "qos": 1, "enabled": true,  "action": "reboot" },
     { "topic": "cameras/%id/snapshot",         "qos": 1, "enabled": true,  "action": "prudyntctl snapshot -c 0 > /tmp/snap_$(date +%Y%m%d_%H%M%S).jpg" },

--- a/package/thingino-mosquitto-20x/files/www/a/tool-mqtt-sub.js
+++ b/package/thingino-mosquitto-20x/files/www/a/tool-mqtt-sub.js
@@ -29,6 +29,18 @@
   const reloadBtn = $("#mqtt-sub-reload");
   const restartBtn = $("#mqtt-sub-restart");
   const saveBtn = $("#mqtt-sub-save");
+  const tlsSkipVerifyRow = $("#mqtt_sub_tls_skip_verify_row");
+
+  function isTrue(value) {
+    return value === true || value === "true";
+  }
+
+  function updateTlsSkipVerifyState() {
+    const enabled = $("#mqtt_sub_use_ssl").checked;
+    const tlsSkipVerify = $("#mqtt_sub_tls_skip_verify");
+    tlsSkipVerifyRow.classList.toggle("d-none", !enabled);
+    tlsSkipVerify.disabled = !enabled;
+  }
 
   function updateEmptyState() {
     const hasSubs = tbody.querySelectorAll("tr").length > 0;
@@ -192,12 +204,14 @@
         throw new Error("Failed to load MQTT subscription settings");
       const data = await resp.json();
 
-      $("#mqtt_sub_enabled").checked = data.enabled === true;
+      $("#mqtt_sub_enabled").checked = isTrue(data.enabled);
       $("#mqtt_sub_host").value = data.host || "";
       $("#mqtt_sub_port").value = data.port || 1883;
       $("#mqtt_sub_username").value = data.username || "";
       $("#mqtt_sub_password").value = data.password || "";
-      $("#mqtt_sub_use_ssl").checked = data.use_ssl === true;
+      $("#mqtt_sub_use_ssl").checked = isTrue(data.use_ssl);
+      $("#mqtt_sub_tls_skip_verify").checked = isTrue(data.tls_skip_verify);
+      updateTlsSkipVerifyState();
 
       tbody.innerHTML = "";
       (Array.isArray(data.subscriptions) ? data.subscriptions : []).forEach(
@@ -264,9 +278,12 @@
       username: $("#mqtt_sub_username").value.trim(),
       password: $("#mqtt_sub_password").value.trim(),
       use_ssl: $("#mqtt_sub_use_ssl").checked,
+      tls_skip_verify: $("#mqtt_sub_tls_skip_verify").checked,
       subscriptions: collectSubscriptions(),
     });
   });
+
+  $("#mqtt_sub_use_ssl").addEventListener("change", updateTlsSkipVerifyState);
 
   addBtn.addEventListener("click", function () {
     addSubscriptionRow();

--- a/package/thingino-mosquitto-20x/files/www/tool-mqtt-sub.html
+++ b/package/thingino-mosquitto-20x/files/www/tool-mqtt-sub.html
@@ -64,6 +64,12 @@
                   <input type="checkbox" class="form-check-input" id="mqtt_sub_use_ssl" role="switch">
                   <label class="form-check-label" for="mqtt_sub_use_ssl">Use SSL/TLS</label>
                 </p>
+                <p class="form-switch d-none" id="mqtt_sub_tls_skip_verify_row">
+                  <input type="checkbox" class="form-check-input" id="mqtt_sub_tls_skip_verify" role="switch">
+                  <label class="form-check-label" for="mqtt_sub_tls_skip_verify">Skip TLS certificate verification</label>
+                  <br>
+                  <small class="form-text text-secondary">Insecure: MQTT broker identity will not be verified</small>
+                </p>
               </div>
             </div>
 

--- a/package/thingino-mosquitto-20x/files/www/x/json-config-mqtt-sub.cgi
+++ b/package/thingino-mosquitto-20x/files/www/x/json-config-mqtt-sub.cgi
@@ -100,6 +100,7 @@ handle_post() {
 	new_username=$(jct "$REQ_FILE" get username 2>/dev/null)
 	new_password=$(jct "$REQ_FILE" get password 2>/dev/null)
 	new_use_ssl=$(jct "$REQ_FILE" get use_ssl 2>/dev/null)
+	new_tls_skip_verify=$(jct "$REQ_FILE" get tls_skip_verify 2>/dev/null)
 	new_subscriptions=$(jct "$REQ_FILE" get subscriptions 2>/dev/null)
 
 	enabled=$(normalize_bool "$new_enabled")
@@ -108,6 +109,7 @@ handle_post() {
 	username=$(strip_json_string "$new_username")
 	password=$(strip_json_string "$new_password")
 	use_ssl=$(normalize_bool "$new_use_ssl")
+	tls_skip_verify=$(normalize_bool "$new_tls_skip_verify")
 
 	[ -n "$port" ] || port="1883"
 
@@ -129,6 +131,7 @@ handle_post() {
     "username": "$(json_escape "$username")",
     "password": "$(json_escape "$password")",
     "use_ssl": $use_ssl,
+    "tls_skip_verify": $tls_skip_verify,
     "subscriptions": ${new_subscriptions:-[]}
   }
 }


### PR DESCRIPTION
Add an optional `tls_skip_verify` setting for MQTT clients using TLS with self-signed or otherwise untrusted broker certificates.

When enabled together with SSL/TLS, Thingino passes Mosquitto’s `--insecure` option while still using `--capath /etc/ssl/certs`. The MQTT connection remains encrypted, but broker identity verification is disabled.

## Changes

- Add `tls_skip_verify` defaults to MQTT-related JSON configs.
- Add WebUI controls for:
  - Send to MQTT
  - MQTT subscriptions
  - Home Assistant MQTT
- Show the warning text below the toggle:
  - `Insecure: MQTT broker identity will not be verified`
- Only show the toggle when `Use SSL/TLS` is enabled.
- Pass `--insecure` only when both TLS and `tls_skip_verify` are enabled.
- Keep Home Assistant’s MQTT setting independent from the general MQTT subscription setting.
- Update MQTT and Home Assistant documentation.
- Apply the same MQTT TLS behavior to Telegram camera registration/reply helpers that use the shared `mqtt_sub` configuration.