### PR TITLE
Add sbr-decimation option to FAAC configuration

### DIFF
--- a/package/faac/faac.mk
+++ b/package/faac/faac.mk
@@ -13,6 +13,7 @@ FAAC_INSTALL_STAGING = YES
 # built and installed when BR2_PACKAGE_FAAC_INSTALL_BIN is enabled.
 FAAC_CONF_OPTS = \
 	-Dfrontend=$(if $(BR2_PACKAGE_FAAC_INSTALL_BIN),true,false) \
-	-Dmax-channels=2
+	-Dmax-channels=2 \
+	-Dsbr-decimation=4
 
 $(eval $(meson-package))


### PR DESCRIPTION
analyze every 4th slot per frame for a ~30% faster HE-AAC encode at the trivial cost of -0.015 MOS