### PR TITLE
ingenic-audiodaemon: fix malformed output.c hunk in safer-defaults patch

### DIFF
--- a/package/ingenic-audiodaemon/0001-audio-apply-configured-processing-and-safer-defaults.patch
+++ b/package/ingenic-audiodaemon/0001-audio-apply-configured-processing-and-safer-defaults.patch
@@ -1,6 +1,16 @@
+Apply configured audio processing (NS/AGC/HPF/ALC/AEC) and safer defaults.
+
+- iad.json: lower AI SetVol/SetGain, enable NS level 1, HPF, ALC gain 2
+- defaults: 16 kHz sample rate, lower volume/gain for AI and AO
+- input.c/output.c: read processing flags from config and apply them via
+  the IMP audio APIs after volume/gain setup
+
+Rebased against upstream commit 54f1a655b46ed01ea86c07965833882c878f3ff0
+(fixes a malformed hunk in output.c that broke `patch -p1`).
+
 diff -urN orig/config/iad.json new/config/iad.json
 --- orig/config/iad.json	2025-04-28 19:34:25.000000000 -0400
-+++ new/config/iad.json	2026-03-21 16:32:05.481001686 -0400
++++ new/config/iad.json	2026-07-20 12:00:00.000000000 -0400
 @@ -32,12 +32,12 @@
          "soundmode": "AUDIO_SOUND_MODE_MONO",
          "chnCnt": 1,
@@ -22,7 +32,7 @@ diff -urN orig/config/iad.json new/config/iad.json
          "AGC_attributes": {
 diff -urN orig/src/iad/audio/audio_common.h new/src/iad/audio/audio_common.h
 --- orig/src/iad/audio/audio_common.h	2025-04-28 19:34:25.000000000 -0400
-+++ new/src/iad/audio/audio_common.h	2026-03-21 16:32:05.481001686 -0400
++++ new/src/iad/audio/audio_common.h	2026-07-20 12:00:00.000000000 -0400
 @@ -3,9 +3,9 @@
 
  #include "cJSON.h"
@@ -38,7 +48,7 @@ diff -urN orig/src/iad/audio/audio_common.h new/src/iad/audio/audio_common.h
  #define DEFAULT_AI_DEV_ID 0
 diff -urN orig/src/iad/audio/input.c new/src/iad/audio/input.c
 --- orig/src/iad/audio/input.c	2025-04-28 19:34:25.000000000 -0400
-+++ new/src/iad/audio/input.c	2026-03-21 16:32:05.493001827 -0400
++++ new/src/iad/audio/input.c	2026-07-20 12:00:00.000000000 -0400
 @@ -15,6 +15,82 @@
  #define TRUE 1
  #define TAG "AI"
@@ -133,7 +143,7 @@ diff -urN orig/src/iad/audio/input.c new/src/iad/audio/input.c
      printf("[INFO] AI Volume: %d\n", vol);
 diff -urN orig/src/iad/audio/input.h new/src/iad/audio/input.h
 --- orig/src/iad/audio/input.h	2025-04-28 19:34:25.000000000 -0400
-+++ new/src/iad/audio/input.h	2026-03-21 16:32:05.481001686 -0400
++++ new/src/iad/audio/input.h	2026-07-20 12:00:00.000000000 -0400
 @@ -3,9 +3,9 @@
 
  #include "imp/imp_audio.h"  // for AUDIO_SAMPLE_RATE_48000
@@ -149,7 +159,7 @@ diff -urN orig/src/iad/audio/input.h new/src/iad/audio/input.h
  #define DEFAULT_AI_DEV_ID 0
 diff -urN orig/src/iad/audio/output.c new/src/iad/audio/output.c
 --- orig/src/iad/audio/output.c	2025-04-28 19:34:25.000000000 -0400
-+++ new/src/iad/audio/output.c	2026-03-21 16:31:53.272859458 -0400
++++ new/src/iad/audio/output.c	2026-07-20 12:00:00.000000000 -0400
 @@ -15,6 +15,65 @@
  #define TRUE 1
  #define TAG "AO"
@@ -227,7 +237,7 @@ diff -urN orig/src/iad/audio/output.c new/src/iad/audio/output.c
      set_ao_max_frame_size(frame_size_from_config);
 diff -urN orig/src/iad/audio/output.h new/src/iad/audio/output.h
 --- orig/src/iad/audio/output.h	2025-04-28 19:34:25.000000000 -0400
-+++ new/src/iad/audio/output.h	2026-03-21 16:32:05.493001827 -0400
++++ new/src/iad/audio/output.h	2026-07-20 12:00:00.000000000 -0400
 @@ -4,10 +4,10 @@
  #include <pthread.h>
  #include "imp/imp_audio.h"  // for AUDIO_SAMPLE_RATE_48000


### PR DESCRIPTION
## Summary
- \`package/ingenic-audiodaemon/0001-audio-apply-configured-processing-and-safer-defaults.patch\` had a malformed hunk header in the \`output.c\` section that broke \`patch -p1\` when rebased against a newer upstream commit.
- Rebased the patch against upstream \`54f1a655b46ed01ea86c07965833882c878f3ff0\` and fixed the hunk so it applies cleanly.
- Noticed while testing the timps ONVIF audio backchannel with \`ingenic-audiodaemon\` enabled (see #1331) — unrelated to timps itself, splitting it out per review feedback there.

## Test plan
- [x] Package builds and applies the patch cleanly with \`BR2_PACKAGE_INGENIC_AUDIODAEMON=y\`.