### PR TITLE
init: stop exporting TZ from rcS so daemons see live timezone changes

### DIFF
--- a/overlay/etc/init.d/rcS
+++ b/overlay/etc/init.d/rcS
@@ -1,13 +1,15 @@
 #!/bin/sh
 
-# Set up the timezone
+# Do NOT export TZ here: every daemon started below inherits it, and with TZ
+# set in the environment uClibc-ng's localtime_r() stops re-reading /etc/TZ on
+# every call - a daemon started at boot then never notices a LATER timezone
+# change (e.g. via the WebUI) without being restarted, even though the file
+# on disk is correct. Leaving TZ unset in the boot environment lets every
+# long-running daemon (timps/raptor/prudynt-t alike, no code changes needed)
+# pick up /etc/TZ edits live. Interactive shells still get TZ exported fresh
+# on each login via /etc/profile, so this only affects daemons.
 TZCODE_FILE="/etc/TZ"
-if [ -s "$TZCODE_FILE" ]; then
-	TZ="$(cat $TZCODE_FILE)"
-	export TZ
-else
-	echo -c 240 -e "- Cannot find $TZCODE_FILE"
-fi
+[ -s "$TZCODE_FILE" ] || echo -c 240 -e "- Cannot find $TZCODE_FILE"
 
 # Run init scripts in numerical order
 for i in $(find /etc/init.d/ -name "S*" -executable | sort -n); do


### PR DESCRIPTION
## Summary
- `rcS` exported `TZ` (read from `/etc/TZ`) before starting every init script, so every long-running daemon started at boot (streamer, ONVIF, etc.) inherited that `TZ` value in its environment.
- uClibc-ng's `localtime_r()`/`localtime()` only re-reads `/etc/TZ` on every call when `TZ` is **unset** in the process environment. With `TZ` set (as rcS did), a daemon started at boot never notices a *later* timezone change (e.g. via the WebUI's date/time settings page) without being restarted — even though `/etc/TZ` and `/etc/localtime` on disk are already correct.
- Confirmed hands-on on a camera running the timps streamer: after changing the timezone live via the WebUI, the video's on-screen timestamp overlay (rendered via `localtime_r()`) stayed 2h off (stale UTC) until the streamer daemon was manually restarted. The WebUI itself showed the correct time throughout, since its CGI scripts are fresh per-request processes that always re-read `/etc/TZ`. The same daemon-side staleness is expected for any long-running C/C++ service that renders wall-clock time (streamers, but potentially others too) - this fixes it project-wide with a one-line env change, no per-daemon code changes needed.
- Interactive shells are unaffected: `/etc/profile` already does its own `export TZ=$(cat /etc/TZ)` on every login, so a fresh SSH session or console login always sees the current timezone regardless of this change.

## Test plan
- [x] Boot with a timezone already set in `/etc/TZ`: daemons see the correct zone at startup (same as before - `TZ` is simply read from the file instead of inherited from the env, both land on the same effective value).
- [x] Change timezone live via `POST /x/json-config-time.cgi` (action=update) while a streamer daemon is already running, without restarting it: the daemon's rendered timestamp now updates on its own within a few seconds, instead of requiring a manual service restart.
- [ ] Would appreciate a second confirmation on a raptor or prudynt-t image, though the fix is daemon-agnostic (env-level, not streamer-specific) so I'd expect the same result.