### PR TITLE
ingenic-sdk: T31 audio codec - mute speaker amp at probe, not just on replay close

### DIFF
--- a/package/ingenic-sdk/0002-audio-t31-mute-speaker-amp-at-probe.patch
+++ b/package/ingenic-sdk/0002-audio-t31-mute-speaker-amp-at-probe.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000004 Mon Sep 17 00:00:00 2001
+From: Lu-Fi <lfiebach@googlemail.com>
+Date: Mon, 01 Jan 2024 00:00:03 +0000
+Subject: [PATCH] ingenic-sdk: t31 audio codec - mute speaker amp at probe
+
+gpio_request() alone leaves the speaker-amp enable pin floating until
+the first codec_set_speaker()/codec_turn_off() call (replay open/
+close) ever drives it. A capture-only session (mic-only, no two-way
+audio/backchannel - the common case) never opens replay, so on boards
+where the floating enable line couples analog/clock activity from mic
+capture into the amp, that shows up as a persistent audible whine for
+as long as capture runs. Confirmed on a Cinnado D1 T31L/SC2336 board:
+whine is present exactly while the mic-capture daemon runs, silent
+when it's stopped, and /proc/jz/audio/audio_info still reports replay
+as "closed" throughout - the amp was simply never told to mute.
+
+Drive the pin to its inactive level once at probe time instead. This
+is a one-time assertion, not periodic toggling (some amp ICs are
+reported to not tolerate frequent on/off cycling well).
+
+Signed-off-by: Lu-Fi <lfiebach@googlemail.com>
+---
+--- a/3.10.14/audio/t31/oss2/devices/codecs/jz_t10_codec.c
++++ b/3.10.14/audio/t31/oss2/devices/codecs/jz_t10_codec.c
+@@ -977,6 +977,17 @@
+ 			printk(KERN_DEBUG"request spk en gpio %d error!\n", codec_platform_data->gpio_spk_en.gpio);
+ 		}
+ 		printk(KERN_DEBUG"request spk en gpio %d ok!\n", codec_platform_data->gpio_spk_en.gpio);
++		/* Mute the amp right away. gpio_request() alone leaves this pin
++		 * floating until the first codec_set_speaker()/codec_turn_off()
++		 * call (replay open/close) ever drives it. A capture-only session
++		 * (mic-only, no two-way audio) never opens replay, so on boards
++		 * where the floating enable line couples analog/clock activity
++		 * from mic capture into the amp, that shows up as a persistent
++		 * audible whine for as long as capture runs. Driving it to the
++		 * inactive level here once at probe time is enough - no repeated
++		 * toggling, which some amp ICs don't tolerate well long-term. */
++		gpio_direction_output(codec_platform_data->gpio_spk_en.gpio,
++				      !codec_platform_data->gpio_spk_en.active_level);
+ 	}
+
+ 	pdev->dev.platform_data = codec_platform_data;


### PR DESCRIPTION
## Problem

On T31-family boards with a configured speaker-amp mute GPIO (`BR2_THINGINO_AUDIO_GPIO`), the amp enable pin is left **floating** for the entire uptime of any mic-capture-only session (i.e. audio recording without ever using two-way audio / backchannel - the common case for most streamers).

`jz_t10_codec.c`'s `jz_codec_register()` (probe) only calls `gpio_request()` on this pin - it never sets a direction/level. The pin is only ever driven by `codec_set_speaker()` (on replay open, → active/unmuted) and `codec_turn_off(CODEC_WMODE)` (on replay close, → muted). If replay is never opened, neither function ever runs, and the pin stays in its floating boot-time state.

On boards where this floating enable line couples clock/analog activity from mic capture into the amplifier, the audible result is a persistent high-pitched whine for as long as capture is active - even though `/proc/jz/audio/audio_info` correctly reports the replay path as "closed" throughout (the mute pin was simply never asserted, not a logical-state bug).

## Confirmation

Reproduced and confirmed live on a Cinnado D1 T31L (SC2336 sensor):
- Whine present exactly while the mic-capture daemon (timps) runs.
- Whine stops immediately when the daemon is stopped (codec fully powers down).
- Whine reproduces at every subsequent daemon start.
- `spk_gpio`/`spk_level` module params confirmed correctly configured (7 / 0) - this isn't a missing-config issue, the mute mechanism exists and works correctly on replay close, it's just never engaged for a capture-only lifecycle.
- After the fix (rebuilt + reflashed), the whine is gone; audio capture and normal replay behavior are unaffected.

## Fix

Drive the pin to its inactive level once at `probe()`, right after the existing `gpio_request()`. This is a one-time assertion at module load, not periodic toggling (some amp ICs are reported to not tolerate frequent on/off cycling well). The existing `codec_set_speaker()`/`codec_turn_off()` logic is untouched, so replay/two-way-audio continues to unmute/mute the amp exactly as before whenever it's actually used.

Scope: `3.10.14/audio/t31/oss2/devices/codecs/jz_t10_codec.c` only - this is the sole codec driver for every T31-family board built against the 3.10.14 kernel (no alternate codec variant exists at that path), so this should apply broadly across T31/T31L boards with a configured speaker GPIO. Boards without `BR2_THINGINO_AUDIO_GPIO` set (`spk_gpio == -1`) are unaffected - the patched code path isn't entered for them.