### PR TITLE
ingenic-audiodaemon: libuclibcshim link fix + T20 AGC/HPF API guards

### DIFF
--- a/package/ingenic-audiodaemon/0002-fix-T20-missing-agc-hpf-imp-calls.patch
+++ b/package/ingenic-audiodaemon/0002-fix-T20-missing-agc-hpf-imp-calls.patch
@@ -1,0 +1,39 @@
+Guard T20-unsupported IMP audio-processing calls.
+
+T20's older libimp does not export IMP_AI_SetAgcMode or
+IMP_AO_SetHpfCoFrequency (both link-time undefined on that SoC family),
+unlike the newer IMP APIs on T23/T31/etc this code was written against.
+Guard the two calls under #ifndef CONFIG_T20, matching the existing
+CONFIG_T20 guard around IMP_AI_SetAlcGain a few lines above
+IMP_AI_SetAgcMode in input.c. IMP_AI_EnableAgc/IMP_AO_EnableHpf are left
+unguarded - they do link on T20 - so AGC/HPF still enable, just without
+this one non-essential mode/frequency tuning call on that platform.
+
+diff -ru a/src/iad/audio/input.c b/src/iad/audio/input.c
+--- a/src/iad/audio/input.c	2026-07-26 10:02:12.783374235 +0200
++++ b/src/iad/audio/input.c	2026-07-26 10:02:12.785967249 +0200
+@@ -86,7 +86,9 @@
+         IMPAudioAgcConfig agcConfig;
+         agcConfig.TargetLevelDbfs = clamp_config_int(cJSON_GetObjectItemCaseSensitive(agcAttributes, "TargetLevelDbfs"), 0, 0, 31, "TargetLevelDbfs");
+         agcConfig.CompressionGaindB = clamp_config_int(cJSON_GetObjectItemCaseSensitive(agcAttributes, "CompressionGaindB"), 6, 0, 90, "CompressionGaindB");
++#ifndef CONFIG_T20
+         log_processing_error("IMP_AI_SetAgcMode", IMP_AI_SetAgcMode(kAgcModeFixedDigital));
++#endif
+         log_processing_error("IMP_AI_EnableAgc", IMP_AI_EnableAgc((IMPAudioIOAttr *) attr, agcConfig));
+     }
+ }
+diff -ru a/src/iad/audio/output.c b/src/iad/audio/output.c
+--- a/src/iad/audio/output.c	2026-07-26 10:02:12.784632646 +0200
++++ b/src/iad/audio/output.c	2026-07-26 10:02:12.787179114 +0200
+@@ -60,9 +60,11 @@
+     cJSON *hpfAttributes = get_audio_attribute(AUDIO_OUTPUT, "HPF_attributes");
+ 
+     if (get_config_bool(enableHpfItem, 0)) {
++#ifndef CONFIG_T20
+         if (hpfAttributes && cJSON_IsObject(hpfAttributes)) {
+             log_processing_error("IMP_AO_SetHpfCoFrequency", IMP_AO_SetHpfCoFrequency(clamp_config_int(cJSON_GetObjectItemCaseSensitive(hpfAttributes, "SetHpfCoFrequency"), 100, 0, 5000, "SetHpfCoFrequency")));
+         }
++#endif
+         log_processing_error("IMP_AO_EnableHpf", IMP_AO_EnableHpf((IMPAudioIOAttr *) attr));
+     }
+ 

--- a/package/ingenic-audiodaemon/ingenic-audiodaemon.mk
+++ b/package/ingenic-audiodaemon/ingenic-audiodaemon.mk
@@ -22,6 +22,7 @@ ifeq ($(BR2_TOOLCHAIN_USES_UCLIBC),y)
 	GCC_BUILD_TYPE += CONFIG_MUSL_BUILD=n
 	# Add explicit library links for uClibc
 	INGENIC_AUDIODAEMON_LDFLAGS += -lpthread -ldl
+	INGENIC_AUDIODAEMON_DEPENDENCIES += ingenic-uclibc
 endif
 
 ifeq ($(BR2_TOOLCHAIN_USES_GLIBC),y)
@@ -37,10 +38,6 @@ INGENIC_AUDIODAEMON_LDFLAGS = $(TARGET_LDFLAGS) \
 ifeq ($(BR2_TOOLCHAIN_USES_UCLIBC),y)
 define INGENIC_AUDIODAEMON_BUILD_CMDS
 	$(MAKE) version -C $(@D)
-	# Create compatibility stubs for glibc-specific functions
-	echo 'const unsigned short **__ctype_b_loc(void) { static const unsigned short *p = 0; return &p; }' > $(@D)/uclibc_compat.c
-	echo 'const int **__ctype_tolower_loc(void) { static const int *p = 0; return &p; }' >> $(@D)/uclibc_compat.c
-	$(TARGET_CC) -c $(@D)/uclibc_compat.c -o $(@D)/uclibc_compat.o
 	$(MAKE) $(GCC_BUILD_TYPE) CROSS_COMPILE=$(TARGET_CROSS) \
 	PLATFORM=$(AUDIODAEMON_SOC_CONFIG) \
 	CFLAGS="$(CFLAGS) $(INGENIC_AUDIODAEMON_CFLAGS) \
@@ -53,7 +50,7 @@ define INGENIC_AUDIODAEMON_BUILD_CMDS
 	-I$(STAGING_DIR)/usr/include \
 	-I$(STAGING_DIR)/usr/include/cjson \
 	-DCONFIG_$(AUDIODAEMON_SOC_CONFIG)" \
-	LDFLAGS="$(INGENIC_AUDIODAEMON_LDFLAGS) $(@D)/uclibc_compat.o" \
+	LDFLAGS="$(INGENIC_AUDIODAEMON_LDFLAGS) -Wl,--no-as-needed -luclibcshim -Wl,--as-needed" \
 	all -C $(@D)
 endef
 else


### PR DESCRIPTION
Two small, independent audiodaemon portability fixes bundled together since both surfaced while getting `ingenic-audiodaemon` building/running cleanly across the T10/T20/T21/T30 family.

## 1. Link against `libuclibcshim` instead of a hand-rolled stub

The uClibc build path hand-generated a `uclibc_compat.c` stub at build time to provide `__ctype_b_loc`/`__ctype_tolower_loc` (glibc-specific ctype accessors the vendor audiodaemon blob needs). This project already ships `ingenic-uclibc`'s `libuclibcshim` for exactly this class of legacy-symbol shim - it's already used for the vendor IMP/ISP libraries on T10/T20/T21/T30. Link against that instead of maintaining a parallel one-off stub, and add the `ingenic-uclibc` build dependency so it's guaranteed to exist first.

## 2. Guard two IMP calls unsupported by T20's libimp

`IMP_AI_SetAgcMode` and `IMP_AO_SetHpfCoFrequency` are link-time undefined on T20 - its libimp predates these APIs, unlike the newer SDK this audio-processing code (from PR upstream carry-patch `0001-audio-apply-configured-processing-and-safer-defaults.patch`) was written against. Guard both under `#ifndef CONFIG_T20`, matching the existing `CONFIG_T20` guard already a few lines above `IMP_AI_SetAgcMode` in `input.c` for `IMP_AI_SetAlcGain`.

`IMP_AI_EnableAgc`/`IMP_AO_EnableHpf` are left unguarded - they do link on T20 - so AGC/HPF still enable there, just without this one non-essential mode/frequency tuning call.

## Testing

Both verified against a real T20 build in this session (`wyze_cam2_t20x_jxf23_rtl8189ftv`) - links and runs cleanly. `0002-fix-T20-missing-agc-hpf-imp-calls.patch` dry-run validated to apply cleanly on top of `0001-audio-apply-configured-processing-and-safer-defaults.patch` against a pristine checkout of the pinned `ingenic-audiodaemon` commit.