### PR TITLE
Makefile.container: SELinux volume labels for Enforcing hosts

### DIFF
--- a/Makefile.container
+++ b/Makefile.container
@@ -12,6 +12,35 @@ DL_CONTAINER := thingino-dl-cache
 # Directories
 WORKSPACE_DIR := $(shell pwd)
 
+# SELinux volume labels (Podman/Docker on Fedora, Bazzite, RHEL, CentOS Stream).
+# Without a label, Enforcing hosts often fail with "Permission denied" on bind mounts.
+# Non-SELinux hosts (Debian/Ubuntu/etc.) leave this empty — :z/:Z are unnecessary there.
+#
+# Preference order:
+#   1. CONTAINER_VOLUME_LABEL override (z | Z | none | off | empty)
+#   2. Auto :z when getenforce reports Enforcing
+#   3. Otherwise unlabeled
+#
+# Use shared :z (not private :Z) by default so the host IDE and container can both
+# use the workspace. Override with CONTAINER_VOLUME_LABEL=Z only if you need a
+# private container label.
+CONTAINER_VOLUME_LABEL ?=
+ifeq ($(CONTAINER_VOLUME_LABEL),)
+  ifeq ($(shell getenforce 2>/dev/null),Enforcing)
+    CONTAINER_VOLUME_LABEL := z
+  endif
+endif
+ifneq ($(filter $(CONTAINER_VOLUME_LABEL),none off),)
+  CONTAINER_VOLUME_SUFFIX :=
+  CONTAINER_VOLUME_LABEL_DESC := none (forced off)
+else ifneq ($(CONTAINER_VOLUME_LABEL),)
+  CONTAINER_VOLUME_SUFFIX := :$(CONTAINER_VOLUME_LABEL)
+  CONTAINER_VOLUME_LABEL_DESC := $(CONTAINER_VOLUME_LABEL)
+else
+  CONTAINER_VOLUME_SUFFIX :=
+  CONTAINER_VOLUME_LABEL_DESC := none (SELinux not enforcing or unavailable)
+endif
+
 # Container run command
 ifeq ($(findstring podman,$(CONTAINER_ENGINE)),podman)
 	CONTAINER_RUN := $(CONTAINER_ENGINE) run --rm --userns=keep-id
@@ -21,8 +50,8 @@ endif
 
 CONTAINER_RUN_OPTS := \
 	--volumes-from $(DL_CONTAINER) \
-	-v $(WORKSPACE_DIR):/workspace \
-	-v $(shell readlink -f overrides):/overrides \
+	-v $(WORKSPACE_DIR):/workspace$(CONTAINER_VOLUME_SUFFIX) \
+	-v $(shell readlink -f overrides):/overrides$(CONTAINER_VOLUME_SUFFIX) \
 	-w /workspace \
 	-e TERM=xterm-256color \
 	-e BR2_DL_DIR=/dl
@@ -39,7 +68,7 @@ ifdef THINGINO_USER_DIR
     _USER_DIR_REAL := $(shell readlink -f "$(THINGINO_USER_DIR)" 2>/dev/null || echo "$(THINGINO_USER_DIR)")
     _USER_DIR_IN_WS := $(or $(filter $(WORKSPACE_DIR),$(_USER_DIR_REAL)),$(filter $(WORKSPACE_DIR)/%,$(_USER_DIR_REAL)))
     ifeq ($(_USER_DIR_IN_WS),)
-      USER_DIR_MOUNT := -v $(_USER_DIR_REAL):/user-dir -e THINGINO_USER_DIR=/user-dir
+      USER_DIR_MOUNT := -v $(_USER_DIR_REAL):/user-dir$(CONTAINER_VOLUME_SUFFIX) -e THINGINO_USER_DIR=/user-dir
       USER_DIR_LABEL := $(THINGINO_USER_DIR) → /user-dir (mounted)
     else
       USER_DIR_LABEL := $(THINGINO_USER_DIR) (in workspace)
@@ -143,6 +172,7 @@ container-info:
 	@echo "  Workspace:  $(WORKSPACE_DIR)"
 	@echo "  Downloads:  $(DL_DIR)"
 	@echo "  User Dir:   $(USER_DIR_LABEL)"
+	@echo "  SELinux:    $(CONTAINER_VOLUME_LABEL_DESC)"
 
 # Convenience targets for building in container
 .PHONY: container-build-firmware

--- a/docs/container.md
+++ b/docs/container.md
@@ -108,6 +108,48 @@ USE_FZF=0 ./build-container.sh
 - Preserves file ownership with UID/GID mapping
 - Persistent download cache
 - No root access required (with Podman)
+- Auto SELinux volume labels on Enforcing hosts (see below)
+
+## SELinux hosts (Fedora, Bazzite, RHEL, CentOS Stream)
+
+On SELinux **Enforcing** systems, unlabeled bind mounts often fail inside the
+container with errors like:
+
+```text
+make: stat: Makefile: Permission denied
+```
+
+`Makefile.container` detects this with `getenforce` and, only when the result is
+`Enforcing`, appends a shared `:z` label to workspace bind mounts. That keeps
+the host IDE and the container able to share the tree.
+
+| Host situation | Default mount suffix | Notes |
+|---|---|---|
+| SELinux Enforcing (`getenforce` → `Enforcing`) | `:z` | Auto-enabled |
+| SELinux Permissive / Disabled, or no SELinux | _(none)_ | Debian, Ubuntu, most CI images |
+| Manual override | see below | |
+
+Override if needed:
+
+```bash
+# Force shared label even when detection fails
+CONTAINER_VOLUME_LABEL=z ./build-container.sh shell
+
+# Private label (container-only; usually worse for local IDE workflows)
+CONTAINER_VOLUME_LABEL=Z ./build-container.sh shell
+
+# Disable labeling entirely
+CONTAINER_VOLUME_LABEL=none ./build-container.sh shell
+```
+
+Confirm the active choice with:
+
+```bash
+make -f Makefile.container container-info
+```
+
+`:z` / `:Z` are SELinux mount options. On non-SELinux hosts they are unused
+because detection leaves mounts unlabeled unless you force an override.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- Auto-append shared `:z` to container bind mounts when `getenforce` reports Enforcing (Fedora/Bazzite/RHEL/etc.), fixing `Permission denied` on workspace mounts.
- Allow override via `CONTAINER_VOLUME_LABEL` (`z` / `Z` / `none`) and surface the choice in `container-info`.
- Second commit is **suggested docs only** (`docs/container.md`) — feel free to drop it.

## Test plan
- [ ] On an SELinux Enforcing host: `make -f Makefile.container container-info` shows SELinux label `z`
- [ ] `./build-container.sh shell` can `stat Makefile` / run make without Permission denied
- [ ] `CONTAINER_VOLUME_LABEL=none ./build-container.sh shell` disables labeling
- [ ] On a non-SELinux host (or Permissive): mounts stay unlabeled unless overridden


Made with [Cursor](https://cursor.com)