### PR TITLE
timps: native speaker (backchannel + play queue), day/night override modes, WebUI, v1.6.0

### DIFF
--- a/package/timps/Config.in
+++ b/package/timps/Config.in
@@ -89,19 +89,12 @@ config BR2_PACKAGE_TIMPS_BACKCHANNEL
 	default n
 	help
 	  Enable the ONVIF audio backchannel: an RTSP client can send audio
-	  to the camera to play through its speaker (talk-back). Decoded
-	  audio is piped at RUNTIME to /bin/iac (ingenic-audiodaemon), which
-	  owns IMP_AO - timps never links or opens the speaker device itself,
-	  exactly like prudynt/raptor. G.711 (PCMU/PCMA) decode is pure C, no
-	  extra library. Restart-required. Disabled by default; when off, no
-	  backchannel code is compiled in.
-
-	  NOTE: this does NOT force the ingenic-audiodaemon package (that
-	  would drag in libwebsockets, which fails to build on some uClibc
-	  toolchains). For a working speaker you must ALSO enable
-	  BR2_PACKAGE_INGENIC_AUDIODAEMON yourself, OR have /bin/iac already
-	  on the device. Without it, timps reports the backchannel as
-	  unavailable (SETUP -> 551) but the rest keeps working.
+	  to the camera to play through its speaker (talk-back). timps decodes
+	  the incoming RTP to PCM and drives the speaker (IMP_AO) NATIVELY -
+	  it owns the audio-output device directly, no external /bin/iac
+	  (ingenic-audiodaemon) helper is needed anymore. G.711 (PCMU/PCMA)
+	  decode is pure C, no extra library. Restart-required. Disabled by
+	  default; when off, no backchannel code is compiled in.
 
 config BR2_PACKAGE_TIMPS_BC_AAC
 	bool "AAC backchannel decode (libhelix-aac)"
@@ -113,5 +106,78 @@ config BR2_PACKAGE_TIMPS_BC_AAC
 	  libhelix-aac (the same decoder prudynt uses). Better audio quality
 	  than G.711 but higher latency and an extra dependency. Leave off
 	  for a G.711-only, dependency-light backchannel.
+
+config BR2_PACKAGE_TIMPS_PLAY
+	bool "System-sound play queue (/usr/sbin/play)"
+	default n
+	help
+	  Install /usr/sbin/play and have timps serve a play FIFO at
+	  /run/timps/audio_out. This lets other parts of thingino play system
+	  sounds through the camera speaker (native IMP_AO): the WiFi
+	  captive-portal prompts, the post-upgrade chime, and the Home
+	  Assistant ESPHome media_player/TTS integration all shell out to
+	  `play`. Decodes WAV and raw PCM16 out of the box. Restart-required.
+	  Disabled by default; when off, no play-queue code is compiled in and
+	  those integrations are silent no-ops on a timps image.
+
+config BR2_PACKAGE_TIMPS_PLAY_OPUS
+	bool "Opus playback in the play queue (opusfile)"
+	depends on BR2_PACKAGE_TIMPS_PLAY
+	default n
+	select BR2_PACKAGE_OPUSFILE
+	help
+	  Also decode Ogg-Opus files in the play queue, via opusfile (pulls in
+	  libopus + libogg). thingino's shipped system sounds
+	  (/usr/share/sounds/*.opus, the thingino-sounds package) are Ogg-Opus,
+	  so enable this if you want those to play. Leave off for a
+	  WAV/PCM-only, dependency-light play queue.
+
+choice
+	prompt "Audio backchannel preset"
+	default BR2_PACKAGE_TIMPS_AUDIO_PRESET_MANUAL
+	help
+	  Backchannel + play queue + the matching thingino-sounds format are
+	  five separate knobs (BACKCHANNEL/BC_AAC/PLAY/PLAY_OPUS here, plus
+	  thingino-sounds' own format choice) that need to agree with each
+	  other and with how much flash headroom the board actually has -
+	  easy to get wrong one knob at a time. These two presets bundle the
+	  combinations that are known to work; pick Manual to keep setting
+	  the individual options above yourself.
+
+config BR2_PACKAGE_TIMPS_AUDIO_PRESET_MANUAL
+	bool "Manual (use the individual options above)"
+
+config BR2_PACKAGE_TIMPS_AUDIO_PRESET_FULL
+	bool "Full (backchannel + AAC + Opus play queue)"
+	select BR2_PACKAGE_TIMPS_BACKCHANNEL
+	select BR2_PACKAGE_TIMPS_BC_AAC
+	select BR2_PACKAGE_TIMPS_PLAY
+	select BR2_PACKAGE_TIMPS_PLAY_OPUS
+	select BR2_PACKAGE_THINGINO_SOUNDS
+	select BR2_PACKAGE_THINGINO_SOUNDS_FORMAT_OPUS
+	help
+	  Two-way audio with AAC backchannel quality, plus a system-sound
+	  play queue that plays the stock Opus sound files. ~395KB of
+	  codec/library footprint (opusfile+opus+libogg+libhelix-aac) -
+	  needs a board with flash headroom. Confirmed fitting on T31-family
+	  boards; too big for a ~5MB T20 rootfs partition this session.
+
+config BR2_PACKAGE_TIMPS_AUDIO_PRESET_MINIMAL
+	bool "Minimal (backchannel + G.711 play queue, no extra codecs)"
+	select BR2_PACKAGE_TIMPS_BACKCHANNEL
+	select BR2_PACKAGE_TIMPS_PLAY
+	select BR2_PACKAGE_THINGINO_SOUNDS
+	# The sound-file format is a Kconfig `choice`, which cannot be forced with
+	# `select`; thingino-sounds instead defaults to G.711 whenever TIMPS_PLAY is
+	# on without TIMPS_PLAY_OPUS (exactly this preset), so no select is needed.
+	help
+	  Two-way audio (G.711 only, no AAC) plus a system-sound play queue
+	  using the G.711 mu-law sound files - zero extra codec libraries,
+	  since timps' G.711 decoder is always built in. The
+	  smallest-footprint way to get backchannel + play working on a
+	  flash-constrained board; confirmed on a T20 board with a ~5MB
+	  rootfs partition this session.
+
+endchoice
 
 endif # BR2_PACKAGE_TIMPS

--- a/package/timps/files/S48webui-config
+++ b/package/timps/files/S48webui-config
@@ -1,0 +1,83 @@
+#!/bin/sh
+#set -euo pipefail
+
+OS_RELEASE_FILE=${OS_RELEASE_FILE:-/etc/os-release}
+WEBUI_JS_CONFIG=${WEBUI_JS_CONFIG:-/var/www/a/runtime-config.js}
+API_KEY_FILE=${API_KEY_FILE:-/etc/thingino-api.key}
+
+escape() {
+	printf '%s' "$1" | sed 's/\\/\\\\/g; s/"/\\"/g'
+}
+
+if [ ! -f "$OS_RELEASE_FILE" ]; then
+	echo >&2 "Missing $OS_RELEASE_FILE"
+	exit 1
+fi
+
+start() {
+	if [ ! -f "$API_KEY_FILE" ]; then
+		echo -c 15 "Generating API key"
+		new_key=$(head -c 32 /dev/urandom | hexdump -e '32/1 "%02x" "\n"')
+		echo "$new_key" >"$API_KEY_FILE"
+		chmod 600 "$API_KEY_FILE"
+	fi
+
+	hostname="$(hostname -s)"
+	timezone="$(cat /etc/timezone 2>/dev/null || echo UTC)"
+	image_id="$(awk -F= '/^IMAGE_ID=/{gsub(/"/, "", $2); print $2}' "$OS_RELEASE_FILE")"
+	build_time="$(awk -F= '/^BUILD_TIME=/{gsub(/"/, "", $2); print $2}' "$OS_RELEASE_FILE")"
+	build_commit="$(awk -F'[=,"]' '/^COMMIT_ID/{print $3}' "$OS_RELEASE_FILE")"
+	# NOTE (timps overlay): configs/common.thingino.json ships a "motors"
+	# object with empty gpio_pan/gpio_tilt as a disabled-by-default
+	# placeholder, merged into EVERY board's /etc/thingino.json unless that
+	# board overrides it. The stock check here was `jct get motors` succeeding
+	# on key PRESENCE alone, so it read "true" for that placeholder too - any
+	# non-PTZ board without its own motors override got the preview joystick
+	# overlay. Check the actual GPIO pins are configured instead.
+	motors_enabled="false"
+	motors_pan="$(jct /etc/thingino.json get motors.gpio_pan 2>/dev/null)"
+	motors_tilt="$(jct /etc/thingino.json get motors.gpio_tilt 2>/dev/null)"
+	if [ -n "$motors_pan" ] && [ -n "$motors_tilt" ]; then
+		motors_enabled="true"
+	fi
+	flash_operations_enabled="false"
+	if [ -f /var/www/tool-upgrade.html ]; then
+		flash_operations_enabled="true"
+	fi
+	soc="$(soc -f)"
+
+	{
+		echo "// generated at $(date +%c)"
+		echo "window.thinginoUIConfig = window.thinginoUIConfig || {};"
+		echo "window.thinginoUIConfig.footer = Object.assign({}, window.thinginoUIConfig.footer, {"
+		echo "  host: \"$(escape "$hostname")\","
+		echo "  buildInfo: \"$(escape "$image_id · $build_commit · $build_time")\""
+		echo "});"
+		echo "window.thinginoUIConfig.device = Object.assign({}, window.thinginoUIConfig.device, {"
+		echo "  timezone: \"$(escape "$timezone")\","
+		echo "  motors: $motors_enabled,"
+		echo "  flashOperations: $flash_operations_enabled,"
+		echo "  soc: \"$soc\""
+		echo "});"
+		echo "window.thinginoFooterConfig = window.thinginoUIConfig.footer;"
+	} >"$WEBUI_JS_CONFIG"
+}
+
+stop() {
+	true
+}
+
+case "$1" in
+	start)
+		start
+		;;
+	stop)
+		stop
+		;;
+	*)
+		echo "Usage: $0 [start|stop]"
+		exit 1
+		;;
+esac
+
+exit 0

--- a/package/timps/files/play
+++ b/package/timps/files/play
@@ -1,0 +1,132 @@
+#!/bin/sh
+set -eu
+
+FIFO="/run/timps/audio_out"
+
+usage() {
+	cat <<'EOF'
+Usage: play [-v volume] [-g gain] [-r rate] [-f format] [-l loop] [-d delay_ms] [-A] [-s] [path|url|-]
+       play stop
+
+Wraps timps's audio FIFO so you can enqueue PLAY commands without manually
+crafting the control line.
+
+Options:
+	-v volume   Set volume (0-100)
+	-g gain     Set gain (0-31)
+	-r rate     Override sample rate in Hz
+	-f format   Force decoder (pcm|wav|aac|opus|mp3|flac)
+	-l loop     Repeat playback N times (max 32)
+	-d delay_ms Pause this many milliseconds between loops (max 5000)
+	-A          Append without clearing the queue (append=1)
+	-s          Read audio data from stdin (spooled to /tmp before playback)
+	-h          Show this help
+
+Examples:
+	play /usr/share/sounds/chime_1.opus
+	play -v 80 -g 20 -l 3 -d 300 /usr/share/sounds/chime_2.opus
+	curl ... | play -s -f aac
+EOF
+}
+
+VOL=""
+GAIN=""
+RATE=""
+FORMAT=""
+LOOP=""
+DELAY=""
+APPEND=0
+READ_STDIN=0
+TMP_FILE=""
+
+cleanup() {
+	if [ -n "$TMP_FILE" ] && [ -f "$TMP_FILE" ]; then
+		rm -f "$TMP_FILE"
+	fi
+}
+
+trap cleanup INT TERM EXIT
+
+while getopts "v:g:r:f:l:d:Ash" opt; do
+	case "$opt" in
+		v) VOL=$OPTARG ;;
+		g) GAIN=$OPTARG ;;
+		r) RATE=$OPTARG ;;
+		f) FORMAT=$OPTARG ;;
+		l) LOOP=$OPTARG ;;
+		d) DELAY=$OPTARG ;;
+		A) APPEND=1 ;;
+		s) READ_STDIN=1 ;;
+		h) usage; exit 0 ;;
+		*) usage >&2; exit 1 ;;
+	esac
+done
+shift $((OPTIND - 1))
+
+PATH_ARG=${1:-}
+
+case "$PATH_ARG" in
+	stop)
+		timeout 2 sh -c 'echo "STOP" > "$1"' -- "$FIFO" || true
+		exit 0
+		;;
+	*)
+		true
+		;;
+esac
+
+is_remote_path() {
+	case "$1" in
+		*://*)
+			return 0
+			;;
+		*)
+			return 1
+			;;
+	esac
+}
+
+if [ "$READ_STDIN" -eq 1 ] || [ "$PATH_ARG" = "-" ]; then
+	TMP_FILE=$(mktemp /tmp/play-stdin.XXXXXX)
+	if ! cat > "$TMP_FILE"; then
+		echo "play: failed to capture stdin" >&2
+		exit 1
+	fi
+	PATH_ARG=$TMP_FILE
+elif [ -z "$PATH_ARG" ]; then
+	usage >&2
+	exit 1
+fi
+
+if is_remote_path "$PATH_ARG"; then
+	: # skip local existence check for URLs
+elif [ ! -e "$PATH_ARG" ]; then
+	echo "play: '$PATH_ARG' not found" >&2
+	exit 1
+fi
+
+wait_attempt=0
+wait_limit=5
+while [ ! -p "$FIFO" ]; do
+	wait_attempt=$((wait_attempt + 1))
+	if [ $wait_attempt -ge $wait_limit ]; then
+		echo "play: $FIFO did not appear within ${wait_limit}s"
+		exit 1
+	fi
+	sleep 0.5
+done
+
+CMD="PLAY url=$PATH_ARG"
+[ -n "$VOL" ] && CMD="$CMD vol=$VOL"
+[ -n "$GAIN" ] && CMD="$CMD gain=$GAIN"
+[ -n "$RATE" ] && CMD="$CMD rate=$RATE"
+[ -n "$FORMAT" ] && CMD="$CMD format=$FORMAT"
+[ -n "$LOOP" ] && CMD="$CMD loop=$LOOP"
+[ -n "$DELAY" ] && CMD="$CMD delay=$DELAY"
+[ "$APPEND" -eq 1 ] && CMD="$CMD append=1"
+
+if ! timeout 2 sh -c 'printf "%s\n" "$1" > "$2"' -- "$CMD" "$FIFO" 2>/dev/null; then
+	echo "play: timed out writing to FIFO (timps not responding)" >&2
+	exit 1
+fi
+echo "Queued: $CMD"

--- a/package/timps/files/www/a/config-audio.js
+++ b/package/timps/files/www/a/config-audio.js
@@ -7,8 +7,11 @@
  *        LIVE controls are enabled only when their timps key is listed in
  *        caps.audio (the SoC capability matrix); the persist+restart keys
  *        (codec/samplerate/bitrate) are deliberately NOT in caps.audio, so
- *        they enable when the audio object carries them. Speaker and stereo
- *        controls stay greyed out: timps has no audio-output (AO) pipeline.
+ *        they enable when the audio object carries them. Speaker volume/gain
+ *        are live too (caps.audio carries spk_volume/spk_gain when an AO
+ *        pipeline is compiled in); speaker sampling and stereo capture stay
+ *        greyed out. A test-sound control (dropdown + Play/Stop) is shown when
+ *        caps.play.available is set, driving the play queue via /control.
  * Save:  LIVE keys (volume/gain/alc_gain/high_pass/agc/agc_target_dbfs/
  *        agc_compression_db/ns) go straight to timpsApi.set({audio:{...}}),
  *        debounced so slider drags coalesce into one POST; timps applies
@@ -44,11 +47,14 @@
     audio_mic_format: { key: "codec", live: false },
     audio_mic_sample_rate: { key: "samplerate", live: false },
     audio_mic_bitrate: { key: "bitrate", live: false },
-    // ONVIF backchannel (client -> camera speaker via /bin/iac): a separate
-    // pipeline from the AO controls below, gated on caps.backchannel.available
-    // (compiled in AND /bin/iac present) instead of "value present in audio{}"
-    // - the backend always echoes these three keys even when the feature is
-    // compiled out, so BC_FIELDS gets its own enable check in load().
+    // speaker AO volume/gain: live, gated on caps.audio carrying spk_volume/
+    // spk_gain (only when timps is built with a play or backchannel pipeline).
+    audio_spk_vol: { key: "spk_volume", live: true },
+    audio_spk_gain: { key: "spk_gain", live: true },
+    // ONVIF backchannel (client -> camera speaker via native IMP_AO): gated on
+    // caps.backchannel.available (compiled in) instead of "value present in
+    // audio{}" - the backend always echoes these three keys even when the
+    // feature is compiled out, so BC_FIELDS gets its own enable check in load().
     audio_backchannel_enabled: { key: "backchannel", live: false },
     audio_backchannel_codec: { key: "backchannel_codec", live: false },
     audio_backchannel_rate: { key: "backchannel_rate", live: false },
@@ -60,12 +66,11 @@
     "audio_backchannel_rate",
   ];
 
-  // no audio output (AO) pipeline in timps: these controls never enable.
-  // (Distinct from the backchannel card above, which uses its own /bin/iac
-  // speaker path and is NOT covered by this limitation.)
+  // no control surface for these in timps: the speaker sampling rate is fixed
+  // by the pipeline (not a settable AO attribute) and stereo capture is not
+  // supported. Speaker volume/gain ARE live now (see FIELD_MAP), so they are
+  // no longer here.
   var UNSUPPORTED = [
-    "audio_spk_vol",
-    "audio_spk_gain",
     "audio_spk_sample_rate",
     "audio_force_stereo",
   ];
@@ -193,6 +198,53 @@
     }
   }
 
+  // Test-sound control: a dropdown of system sounds (from caps.play.sounds)
+  // plus Play/Stop. Hidden entirely unless caps.play.available (the play queue
+  // is compiled in) - see applyPlayCaps().
+  function wireTestSound() {
+    var playBtn = $id("audio_spk_test_play");
+    var stopBtn = $id("audio_spk_test_stop");
+    var sel = $id("audio_spk_test_sound");
+    if (playBtn)
+      playBtn.addEventListener("click", function () {
+        if (!sel || !sel.value || !window.timpsApi) return;
+        playBtn.classList.add("opacity-75");
+        window.timpsApi
+          .set({ speaker: { play: sel.value } })
+          .catch(function (err) {
+            toast("danger", "Play failed: " + (err.message || err));
+          })
+          .then(function () { playBtn.classList.remove("opacity-75"); });
+      });
+    if (stopBtn)
+      stopBtn.addEventListener("click", function () {
+        if (!window.timpsApi) return;
+        window.timpsApi.set({ speaker: { stop: 1 } }).catch(function (err) {
+          toast("danger", "Stop failed: " + (err.message || err));
+        });
+      });
+  }
+
+  // show/populate (or hide) the test-sound control from GET caps.play
+  function applyPlayCaps(caps) {
+    var wrap = $id("spk-test-wrap");
+    if (!wrap) return;
+    var play = (caps && caps.play) || {};
+    if (!play.available) { wrap.classList.add("d-none"); return; }
+    wrap.classList.remove("d-none");
+    var sel = $id("audio_spk_test_sound");
+    if (sel && sel.dataset.soundsReady !== "1") {
+      sel.innerHTML = '<option value="">- Select sound -</option>';
+      (play.sounds || []).forEach(function (name) {
+        var opt = document.createElement("option");
+        opt.value = name;
+        opt.textContent = name;
+        sel.appendChild(opt);
+      });
+      sel.dataset.soundsReady = "1";
+    }
+  }
+
   function wireControls() {
     populateDynamicSelect($id("audio_mic_sample_rate"));
     populateDynamicSelect($id("audio_mic_bitrate"));
@@ -217,22 +269,10 @@
       el.addEventListener("change", function () { send(id); });
     });
 
-    // speaker + stereo: no AO pipeline in timps, keep greyed out + a note
+    // speaker sampling + stereo capture: no control surface, keep greyed out
     UNSUPPORTED.forEach(function (id) { setEnabled(id, false); });
-    var spkHead = Array.prototype.find.call(
-      document.querySelectorAll("main h4"),
-      function (h) { return /speaker/i.test(h.textContent); },
-    );
-    if (spkHead && !$id("timps-no-ao-note")) {
-      var note = document.createElement("small");
-      note.id = "timps-no-ao-note";
-      note.className = "d-block text-warning";
-      note.textContent =
-        "Not available: timps has no direct audio-output pipeline for these " +
-        "controls, and stereo capture is not supported either. (ONVIF two-way " +
-        "audio uses a separate /bin/iac backchannel - see below.)";
-      spkHead.parentNode.insertBefore(note, spkHead.nextSibling);
-    }
+
+    wireTestSound();
 
     // timps applies + persists every change immediately; the button is
     // kept only to reassure users trained on the old save-to-file step.
@@ -300,13 +340,15 @@
 
         // backchannel keys are always echoed in audio{} even when the
         // feature is compiled out, so gate them on caps.backchannel.available
-        // (USE_BACKCHANNEL compiled in AND /bin/iac present) instead.
+        // (USE_BACKCHANNEL compiled in; speaker output is native IMP_AO) instead.
         var bcAvailable = !!(
           json.caps &&
           json.caps.backchannel &&
           json.caps.backchannel.available
         );
         BC_FIELDS.forEach(function (id) { setEnabled(id, bcAvailable); });
+
+        applyPlayCaps(json.caps);
         var bcNote = $id("timps-no-bc-note");
         if (!bcAvailable) {
           if (!bcNote) {
@@ -317,8 +359,8 @@
               bcNote.id = "timps-no-bc-note";
               bcNote.className = "d-block text-warning mb-2";
               bcNote.textContent =
-                "Not available: backchannel is either not compiled into this " +
-                "build or /bin/iac (ingenic-audiodaemon) is missing on the device.";
+                "Not available: the audio backchannel is not compiled into this " +
+                "build.";
               body.insertBefore(bcNote, body.firstChild);
             }
           }

--- a/package/timps/files/www/a/config-photosensing.js
+++ b/package/timps/files/www/a/config-photosensing.js
@@ -7,13 +7,21 @@
  *   #daynight_enabled                     -> daynight.enabled
  *   #daynight_total_gain_night_threshold  -> daynight.total_gain_night_threshold
  *   #daynight_total_gain_day_threshold    -> daynight.total_gain_day_threshold
+ *   #daynight_mode                        -> daynight.mode (sensor/time/sun)
+ *   #daynight_time_night_start/day_start  -> daynight.time_night_start/day_start
+ *   #daynight_sun_latitude/longitude      -> daynight.sun_latitude/longitude
+ *   #daynight_sun_sunrise/sunset_offset_min -> daynight.sun_sunrise/sunset_offset_min
  * timps persists them into /etc/timps.conf itself and the detection thread
- * picks them up live (gain-based decision, prudynt scale: 256 = 1x gain,
- * lower gain = brighter = day).
+ * picks them up live. The Override Mode selector chooses the decision source:
+ * sensor (gain-based, default), a fixed local-clock window, or today's real
+ * sunrise/sunset for a lat/long. All three are timps-native.
  *
- * The Controls (color/ircut/IR850/IR940/white) and Time Schedule columns
- * configure the BOARD daynight script, not timps - they stay on the stock
- * /x/json-config-daynight.cgi backend, loaded and saved best-effort. */
+ * The Controls (color/ircut/IR850/IR940/white) column is a SEPARATE feature:
+ * it configures the BOARD daynight script (/sbin/daynight hardware toggles),
+ * not timps, and legitimately stays on the stock /x/json-config-daynight.cgi
+ * backend, loaded and saved best-effort. (The old "Time Schedule" column that
+ * also lived on that cgi was dead orphaned config nothing read - it has been
+ * replaced by the timps-native Override Mode above.) */
 (function () {
   "use strict";
 
@@ -23,9 +31,8 @@
     return;
   }
 
-  var LEGACY = "/x/json-config-daynight.cgi"; // board script config (controls/schedule)
+  var LEGACY = "/x/json-config-daynight.cgi"; // board script config (controls only)
   var CONTROLS = ["color", "ircut", "ir850", "ir940", "white"];
-  var SCHEDULE = ["enabled", "start_at", "stop_at"];
 
   var $ = function (id) { return document.getElementById(id); };
 
@@ -37,34 +44,96 @@
     else console.log("[photosensing]", type + ":", msg);
   }
 
-  /* ---- timps part: enabled + gain thresholds -------------------------- */
+  /* ---- mode UI: show only the selected sub-fields ---------------------- */
+
+  function syncModeUI() {
+    var sel = $("daynight_mode");
+    var mode = sel ? sel.value : "sensor";
+    var timeF = $("daynight_time_fields");
+    var sunF = $("daynight_sun_fields");
+    if (timeF) timeF.hidden = (mode !== "time");
+    if (sunF) sunF.hidden = (mode !== "sun");
+  }
+
+  /* ---- timps part: enabled + gain thresholds + override mode ---------- */
+
+  var NUM_FIELDS = [
+    "total_gain_night_threshold", "total_gain_day_threshold",
+    "sun_latitude", "sun_longitude",
+    "sun_sunrise_offset_min", "sun_sunset_offset_min",
+  ];
+  var STR_FIELDS = ["time_night_start", "time_day_start"];
 
   function fillTimps(dn) {
     dn = dn || {};
     var en = $("daynight_enabled");
     if (en) en.checked = (dn.enabled === true || dn.enabled === 1);
+
+    var mode = $("daynight_mode");
+    if (mode && typeof dn.dn_mode === "string") mode.value = dn.dn_mode;
+
+    // gain thresholds are rounded ints; the rest keep their given value
     ["total_gain_night_threshold", "total_gain_day_threshold"].forEach(function (k) {
       var el = $("daynight_" + k);
       if (!el) return;
       var v = dn[k];
       el.value = (v === null || typeof v === "undefined") ? "" : Math.round(v);
     });
+    ["sun_latitude", "sun_longitude",
+     "sun_sunrise_offset_min", "sun_sunset_offset_min"].forEach(function (k) {
+      var el = $("daynight_" + k);
+      if (!el) return;
+      var v = dn[k];
+      el.value = (v === null || typeof v === "undefined") ? "" : v;
+    });
+    STR_FIELDS.forEach(function (k) {
+      var el = $("daynight_" + k);
+      if (el) el.value = dn[k] || "";
+    });
+
+    // read-only computed sunrise/sunset feedback for the sun mode
+    var sr = $("daynight_sun_computed_sunrise");
+    var ss = $("daynight_sun_computed_sunset");
+    if (sr) sr.textContent = dn.sun_computed_sunrise || "--:--";
+    if (ss) ss.textContent = dn.sun_computed_sunset || "--:--";
+
+    syncModeUI();
   }
 
   function collectTimps() {
     var out = {};
     var en = $("daynight_enabled");
     if (en) out.enabled = !!en.checked;
+
+    var mode = $("daynight_mode");
+    if (mode) out.mode = mode.value;
+
     ["total_gain_night_threshold", "total_gain_day_threshold"].forEach(function (k) {
       var el = $("daynight_" + k);
       if (!el) return;
       var v = parseInt(el.value, 10);
       if (!isNaN(v) && v >= 0) out[k] = v;
     });
+    ["sun_latitude", "sun_longitude"].forEach(function (k) {
+      var el = $("daynight_" + k);
+      if (!el || el.value === "") return;
+      var v = parseFloat(el.value);
+      if (!isNaN(v)) out[k] = v;
+    });
+    ["sun_sunrise_offset_min", "sun_sunset_offset_min"].forEach(function (k) {
+      var el = $("daynight_" + k);
+      if (!el || el.value === "") return;
+      var v = parseInt(el.value, 10);      // negatives allowed
+      if (!isNaN(v)) out[k] = v;
+    });
+    STR_FIELDS.forEach(function (k) {
+      var el = $("daynight_" + k);
+      if (el && el.value) out[k] = el.value;   // "HH:MM"
+    });
     return out;
   }
 
-  /* ---- legacy part: controls + schedule (board daynight script) ------- */
+  /* ---- legacy part: controls only (board daynight script) ------------- */
 
   function fillLegacy(dn) {
     dn = dn || {};
@@ -73,26 +142,15 @@
       if (el && Object.prototype.hasOwnProperty.call(dn.controls, c))
         el.checked = !!dn.controls[c];
     });
-    if (dn.schedule) SCHEDULE.forEach(function (p) {
-      var el = $("daynight_schedule_" + p);
-      if (!el || !Object.prototype.hasOwnProperty.call(dn.schedule, p)) return;
-      if (el.type === "checkbox") el.checked = !!dn.schedule[p];
-      else el.value = dn.schedule[p] || "";
-    });
   }
 
   function collectLegacy() {
-    var controls = {}, schedule = {};
+    var controls = {};
     CONTROLS.forEach(function (c) {
       var el = $("daynight_controls_" + c);
       if (el) controls[c] = !!el.checked;
     });
-    SCHEDULE.forEach(function (p) {
-      var el = $("daynight_schedule_" + p);
-      if (!el) return;
-      schedule[p] = (el.type === "checkbox") ? !!el.checked : (el.value || "");
-    });
-    return { controls: controls, schedule: schedule };
+    return { controls: controls };
   }
 
   function loadLegacy() {
@@ -100,7 +158,7 @@
       .then(function (res) { return res.ok ? res.json() : null; })
       .then(function (data) { if (data) fillLegacy(data); })
       .catch(function () {
-        console.warn("[photosensing] " + LEGACY + " unavailable - controls/schedule not loaded");
+        console.warn("[photosensing] " + LEGACY + " unavailable - controls not loaded");
       });
   }
 
@@ -133,13 +191,13 @@
     if (ev) { ev.preventDefault(); ev.stopImmediatePropagation(); }
     if (saveBtn) saveBtn.disabled = true;
     window.timpsApi.set({ daynight: collectTimps() }).then(function () {
-      // controls/schedule stay on the board-script backend; best-effort
+      // controls stay on the board-script backend; best-effort
       return saveLegacy().catch(function (e) {
-        toast("warning", "Thresholds saved to timps.conf, but controls/schedule not saved (" +
+        toast("warning", "Photosensing saved to timps.conf, but controls not saved (" +
           (e.message || e) + ").", 6000);
       });
     }).then(function () {
-      toast("success", "Photosensing settings saved (thresholds live in timps.conf).", 4000);
+      toast("success", "Photosensing settings saved (live in timps.conf).", 4000);
       load();
     }).catch(function (e) {
       toast("danger", "Failed to save photosensing settings: " + (e.message || e));
@@ -148,12 +206,19 @@
     });
   }
 
-  /* ---- live sync: another open tab/client changing enabled/thresholds ---- */
+  /* ---- live sync: another open tab/client changing a timps field ------- */
 
   var TIMPS_REVERSE = {
     "daynight.enabled": "daynight_enabled",
+    "daynight.mode": "daynight_mode",
     "daynight.total_gain_night_threshold": "daynight_total_gain_night_threshold",
     "daynight.total_gain_day_threshold": "daynight_total_gain_day_threshold",
+    "daynight.time_night_start": "daynight_time_night_start",
+    "daynight.time_day_start": "daynight_time_day_start",
+    "daynight.sun_latitude": "daynight_sun_latitude",
+    "daynight.sun_longitude": "daynight_sun_longitude",
+    "daynight.sun_sunrise_offset_min": "daynight_sun_sunrise_offset_min",
+    "daynight.sun_sunset_offset_min": "daynight_sun_sunset_offset_min",
   };
 
   function onConfigEvent(type, data) {
@@ -164,12 +229,22 @@
     var el = $(id);
     // don't fight the user mid-edit on this same field
     if (!el || document.activeElement === el) return;
-    if (id === "daynight_enabled") el.checked = (data.value === "1" || data.value === "true");
-    else el.value = Math.round(Number(data.value));
+    if (id === "daynight_enabled") {
+      el.checked = (data.value === "1" || data.value === "true");
+    } else if (id === "daynight_mode") {
+      el.value = data.value;
+      syncModeUI();
+    } else if (data.key.indexOf("threshold") !== -1) {
+      el.value = Math.round(Number(data.value));
+    } else {
+      el.value = data.value;   // times ("HH:MM"), lat/long, offsets
+    }
   }
 
   if (saveBtn) saveBtn.addEventListener("click", save, { capture: true });
   if (reloadBtn) reloadBtn.addEventListener("click", load);
+  var modeSel = $("daynight_mode");
+  if (modeSel) modeSel.addEventListener("change", syncModeUI);
   window.timpsApi.events("config", onConfigEvent);
 
   if (document.readyState === "loading")

--- a/package/timps/files/www/a/streamer-osd.js
+++ b/package/timps/files/www/a/streamer-osd.js
@@ -5,41 +5,61 @@
  * wiring in a/preview.js is gated off here; preview.js keeps only the live
  * preview <img>, which already loads straight from timps).
  *
- * Stream:  detected from the page's body id (page-streamer-osd0 -> timps
- *          section "osd0", page-streamer-osd1 -> "osd1"). Each video stream
- *          carries its own independent overlay item set. Item layout (the
- *          timps default, same one the bridge used):
- *            0 = time, 1 = user text, 2 = uptime, 3 = logo
- * Load:    timpsApi.get() -> populate every control from this page's osdS
- *          object + the global "osd" master switch; enable only the controls
- *          whose timps item leaf key is listed in caps.osd.
- * Save:    per-item leaves (enabled/text/x/y/font_size/color/transparency/
- *          outline/outline_color) apply LIVE via timpsApi.set({osdS:{N:{..}}})
- *          and persist immediately. The global osd.enabled master switch is
- *          persist+restart, and enabling an overlay that was off when the
- *          streamer started cannot be applied live either (its region only
- *          exists when it was enabled at startup) - both show the existing
- *          "Restart streamer" hint (the menu entry calls
- *          /x/restart-prudynt.cgi).
- * Colors:  the page's <input type=color> (#rrggbb) plus its "-alpha" range
- *          slider make up the timps color "0xAARRGGBB" and back.
- * Offline: if timps is unreachable the controls stay disabled and a small
- *          notice appears; nothing throws.
+ * Phase 1 (this file): the UI is DATA-DRIVEN. Each video stream carries its
+ * own independent set of up to MS_MAX_OSD (=8) generic overlay items; every
+ * item is a text-or-logo slot with the same field set (enabled/text/x/y/
+ * font_size/color/transparency/outline/outline_color). Instead of four
+ * hard-coded named boxes (time/usertext/uptime/logo) this page renders one
+ * "card" per in-use item index and lets the user add/remove items (0..8),
+ * edit every field, and drive both streams' item N at once.
+ *
+ * Stream:  detected from the page's body id (page-streamer-osd0 -> section
+ *          "osd0", page-streamer-osd1 -> "osd1"). Index IS the identity - old
+ *          configs (0=time,1=user text,2=uptime,3=logo) load unchanged by
+ *          index, distinguished text-vs-logo by each item's "type".
+ * Load:    timpsApi.get() returns BOTH streams' item sets in one shot; we
+ *          populate this stream's cards and remember the other stream's items
+ *          (for the "apply to both" scope + its restart bookkeeping).
+ * Save:    per-item changed leaves apply LIVE via
+ *          timpsApi.set({osdS:{N:{leaf:val}}}) and persist immediately. A card
+ *          scoped to "both streams" POSTs the same leaves to osd0.N AND osd1.N.
+ * Restart: the global osd.enabled master switch is persist+restart, and
+ *          enabling an item that was OFF when the streamer started cannot be
+ *          applied live (its IMP region only exists when enabled at startup).
+ *          Both surface the "Restart streamer" hint; each card shows a
+ *          per-item Live / Needs-restart / Off status pill.
+ * Caps:    caps.osd lists the item leaf keys this build/SoC applies live
+ *          (text,x,y,font_size,color,transparency,outline,outline_color).
+ *          Each per-leaf control greys out when its key is absent. enabled,
+ *          x/y position and the structural controls are NOT caps-gated
+ *          (enabled is structural, never advertised in caps.osd).
+ * Type:    switching an item text<->logo (and logo upload) is Phase 2 - it
+ *          needs a persist-only "type"/"logo_path" leaf the streamer does not
+ *          accept over /control yet, so the type selector is disabled with a
+ *          tooltip and simply reflects the item's current type.
+ * Colors:  <input type=color> (#rrggbb) + its "-alpha" range make up the timps
+ *          "0xAARRGGBB" color and back. This is separate from "transparency"
+ *          (a 0..255 group alpha over the whole item).
+ * Offline: if timps is unreachable the page shows a notice and no cards; it
+ *          never throws.
  */
 (function () {
   "use strict";
 
   var m = document.body && /^page-streamer-osd([01])$/.exec(document.body.id);
   if (!m) return;
-  var S = m[1]; // "0" or "1": this page's stream
-  var SEC = "osd" + S; // timps /control section (and the page id prefix)
+  var S = parseInt(m[1], 10); // 0 or 1: this page's stream
+  var OTHER = 1 - S;
+  var SEC = "osd" + S; // timps /control section for this stream
+  var MAX_OSD = 8; // MS_MAX_OSD
 
-  // page element groups -> timps item indexes (the timps default layout)
-  var ITEMS = { time: 0, usertext: 1, uptime: 2, logo: 3 };
-  var TEXT_ITEMS = [0, 1, 2]; // items driven by the page-level size/shadow
+  var STREAM_NAME = { 0: "Main stream", 1: "Substream" };
+  var LIVE_LEAVES = [
+    "enabled", "text", "x", "y", "font_size",
+    "color", "transparency", "outline", "outline_color",
+  ];
 
   function $id(id) { return document.getElementById(id); }
-  function el(name) { return $id(SEC + "_" + name); }
 
   function toast(type, message, ms) {
     if (typeof window.showAlert === "function")
@@ -55,7 +75,7 @@
     );
   }
 
-  // ---- conversions ----
+  // ---- conversions -----------------------------------------------------
 
   // timps "0xAARRGGBB" -> {color:"#rrggbb", alpha:0..255}
   function fromTimpsColor(v) {
@@ -70,56 +90,37 @@
     var rgb = /^#?([0-9a-f]{6})/i.exec(hex || "");
     if (!rgb) return null;
     var a = Math.min(255, Math.max(0, isNaN(alpha) ? 255 : alpha));
-    return (
-      "0x" + a.toString(16).padStart(2, "0").toUpperCase() +
-      rgb[1].toUpperCase()
-    );
+    return "0x" + a.toString(16).padStart(2, "0").toUpperCase() +
+      rgb[1].toUpperCase();
   }
 
-  // one color picker + its "-alpha" slider -> timps color string
-  function colorValue(name) {
-    var picker = el(name);
-    var alphaEl = el(name + "-alpha");
-    var a = 255;
-    if (alphaEl && alphaEl.value !== "") {
-      var parsed = parseInt(alphaEl.value, 10);
-      if (!isNaN(parsed)) a = parsed;
-    }
-    return toTimpsColor(picker ? picker.value : "#ffffff", a);
+  // signed coordinate (negative = from the right/bottom edge) <-> the
+  // magnitude+anchor pair the position widget shows. 0 and positive => start
+  // edge (left/top); negative => end edge (right/bottom), magnitude = -v.
+  function posToAnchor(v) {
+    var n = parseInt(v, 10);
+    if (isNaN(n)) n = 0;
+    return n < 0 ? { anchor: "end", mag: -n } : { anchor: "start", mag: n };
+  }
+  function anchorToPos(anchor, mag) {
+    var n = parseInt(mag, 10);
+    if (isNaN(n) || n < 0) n = 0;
+    return anchor === "end" ? -n : n;
   }
 
-  // "x,y" (negative = from the right/bottom edge, same convention on both
-  // sides) -> {x,y}, or null when the field does not parse
-  function parsePosition(v) {
-    var p = /^\s*(-?\d+)\s*,\s*(-?\d+)\s*$/.exec(String(v || ""));
-    return p ? { x: parseInt(p[1], 10), y: parseInt(p[2], 10) } : null;
-  }
+  // ---- shared state ----------------------------------------------------
 
-  // ---- state / wiring ----
+  var capsOsd = []; // leaf keys this build applies live
+  // item enabled state at streamer boot, per stream: enabling an item that
+  // was off at boot has no IMP region, so the live enable is a no-op until a
+  // restart. Captured for BOTH streams (the single GET returns both) so the
+  // "both streams" scope can flag a restart on either side.
+  var bootEnabled = { 0: {}, 1: {} };
+  // last loaded item snapshot per stream (for the other stream in "both"
+  // scope auto-detect and to remember a card's current type)
+  var itemData = { 0: {}, 1: {} };
 
-  // item enabled state as loaded from timps: enabling an item that this
-  // snapshot says is off gets the restart hint (its region only exists when
-  // the item was enabled when the streamer started; timps refuses the live
-  // enable and applies it on the next restart)
-  var loadedEnabled = {};
-
-  function setEnabled(id, on) {
-    var e = $id(id);
-    if (!e) return;
-    e.disabled = !on;
-    var wrap =
-      e.closest("p, .number-range, .select, .boolean, .file, .form-switch") ||
-      e.parentElement;
-    if (wrap) wrap.classList.toggle("disabled", !on);
-  }
-
-  // POST one item's changed leaves: {"osdS":{"N":{key:val,...}}}
-  function sendItem(item, leaves, busyEl) {
-    var body = {};
-    body[SEC] = {};
-    body[SEC][String(item)] = leaves;
-    return sendBody(body, busyEl);
-  }
+  // ---- POST helpers ----------------------------------------------------
 
   function sendBody(body, busyEl) {
     if (busyEl) busyEl.classList.add("opacity-75");
@@ -134,167 +135,385 @@
       });
   }
 
-  // per-element control wiring: name = page control suffix, item = timps
-  // item index, build(el) = item leaves for the POST (null = ignore input)
-  function wire(name, item, build) {
-    var e = el(name);
-    if (!e) return;
-    e.addEventListener("change", function () {
-      var leaves = build(e);
-      if (!leaves) return;
-      var p = sendItem(item, leaves, e);
-      // enabling an overlay that was off when the state was loaded:
-      // persisted, but the live enable is refused without a region
-      if (
-        leaves.enabled === 1 &&
-        !loadedEnabled[item]
-      )
-        p.then(restartHint);
+  // POST one item's changed leaves. scope "both" writes osd0.N AND osd1.N.
+  function sendItem(item, leaves, scope, busyEl) {
+    var body = {};
+    var secs = scope === "both" ? ["osd" + S, "osd" + OTHER] : [SEC];
+    secs.forEach(function (sec) {
+      body[sec] = {};
+      body[sec][String(item)] = leaves;
+    });
+    return sendBody(body, busyEl);
+  }
+
+  // ---- caps gating (per leaf; structural fields never gated) ------------
+
+  function leafSupported(leaf) {
+    // enabled + x/y position are structural, always available; enabled is
+    // never even advertised in caps.osd. Everything else is caps-gated.
+    if (leaf === "enabled" || leaf === "x" || leaf === "y") return true;
+    return capsOsd.indexOf(leaf) >= 0;
+  }
+
+  function applyCaps(card) {
+    var fields = card.querySelectorAll("[data-leaf]");
+    Array.prototype.forEach.call(fields, function (f) {
+      var leaf = f.getAttribute("data-leaf");
+      // the type selector is Phase 2 (disabled regardless of caps)
+      if (leaf === "type") return;
+      var ok = leafSupported(leaf);
+      f.classList.toggle("disabled", !ok);
+      var inputs = f.querySelectorAll("input, select, button");
+      Array.prototype.forEach.call(inputs, function (el) { el.disabled = !ok; });
     });
   }
 
-  function wireControls() {
-    // everything starts greyed out until timps confirms support
-    ALL_CONTROLS.forEach(function (name) {
-      setEnabled(SEC + "_" + name, false);
-    });
+  // ---- status pill -----------------------------------------------------
 
-    // global master switch: config-only in timps (imp_osd_setup runs once at
-    // startup), so it always gets the restart hint
-    var master = el("enabled");
-    if (master) {
-      master.addEventListener("change", function () {
-        sendBody({ osd: { enabled: master.checked ? 1 : 0 } }, master).then(
-          restartHint,
-        );
-      });
+  // three states derived purely from data we already have:
+  //  off            - item not enabled
+  //  live           - enabled AND it was enabled at streamer boot (has region)
+  //  needs-restart  - enabled now but off at boot (no region until restart)
+  function updatePill(card) {
+    var item = parseInt(card.getAttribute("data-item"), 10);
+    var pill = card.querySelector(".osd-status");
+    var enabled = card.querySelector(".osd-enabled").checked;
+    if (!enabled) {
+      pill.className = "osd-status badge text-bg-secondary";
+      pill.textContent = "Off";
+      return;
+    }
+    if (bootEnabled[S][item]) {
+      pill.className = "osd-status badge text-bg-success";
+      pill.textContent = "Live";
+    } else {
+      pill.className = "osd-status badge text-bg-warning";
+      pill.textContent = "Needs restart";
+    }
+  }
+
+  // whether enabling this item (for the active scope) requires a restart on
+  // any targeted stream
+  function enableNeedsRestart(item, scope) {
+    if (!bootEnabled[S][item]) return true;
+    if (scope === "both" && !bootEnabled[OTHER][item]) return true;
+    return false;
+  }
+
+  // ---- card construction ----------------------------------------------
+
+  function cardScope(card) {
+    var sel = card.querySelector(".osd-scope");
+    return sel ? sel.value : "this";
+  }
+
+  // read the combined position from a card's x/y widgets -> {x, y}
+  function readPosition(card) {
+    var xa = card.querySelector(".osd-x-anchor").value;
+    var xm = card.querySelector(".osd-x-mag").value;
+    var ya = card.querySelector(".osd-y-anchor").value;
+    var ym = card.querySelector(".osd-y-mag").value;
+    return { x: anchorToPos(xa, xm), y: anchorToPos(ya, ym) };
+  }
+
+  var CARD_HTML =
+    '<div class="card-header d-flex flex-wrap align-items-center gap-2">' +
+      '<span class="badge text-bg-secondary osd-index"></span>' +
+      '<div class="form-check form-switch m-0" data-leaf="enabled">' +
+        '<input class="form-check-input osd-enabled" type="checkbox" role="switch">' +
+      '</div>' +
+      '<select class="form-select form-select-sm osd-type" style="width:auto" ' +
+        'data-leaf="type" disabled ' +
+        'title="Switching an overlay between text and logo needs a streamer update (coming soon)">' +
+        '<option value="text">Text</option>' +
+        '<option value="logo">Logo</option>' +
+      '</select>' +
+      '<span class="osd-status badge text-bg-secondary">Off</span>' +
+      '<div class="ms-auto d-flex align-items-center gap-2">' +
+        '<label class="small text-body-secondary mb-0">Apply to</label>' +
+        '<select class="form-select form-select-sm osd-scope" style="width:auto">' +
+          '<option value="this"></option>' +
+          '<option value="both">Both streams</option>' +
+        '</select>' +
+        '<button type="button" class="btn btn-sm btn-outline-danger osd-remove" ' +
+          'title="Remove overlay"><i class="bi bi-trash"></i></button>' +
+      '</div>' +
+    '</div>' +
+    '<div class="card-body">' +
+      '<div class="osd-text-body">' +
+        '<p class="mb-2" data-leaf="text">' +
+          '<label class="form-label mb-1">Text / template</label>' +
+          '<input type="text" class="form-control osd-text" ' +
+            'placeholder="e.g. %F %T  or  {hostname}">' +
+          '<span class="form-text">strftime %codes plus {hostname}/{ip}/{uptime}/{fps} placeholders</span>' +
+        '</p>' +
+        '<div class="row g-2">' +
+          '<div class="col-6 col-md-3" data-leaf="font_size">' +
+            '<label class="form-label mb-1">Font size</label>' +
+            '<input type="number" min="8" max="256" class="form-control osd-fontsize">' +
+          '</div>' +
+          '<div class="col-6 col-md-3" data-leaf="outline">' +
+            '<label class="form-label mb-1">Outline</label>' +
+            '<input type="number" min="0" max="64" class="form-control osd-outline">' +
+          '</div>' +
+          '<div class="col-6 col-md-3" data-leaf="color">' +
+            '<label class="form-label mb-1">Color</label>' +
+            '<div class="d-flex align-items-center gap-1">' +
+              '<input type="color" class="form-control form-control-color osd-fill">' +
+              '<input type="range" min="0" max="255" step="1" class="form-range osd-fill-alpha" title="Color alpha">' +
+            '</div>' +
+          '</div>' +
+          '<div class="col-6 col-md-3" data-leaf="outline_color">' +
+            '<label class="form-label mb-1">Outline color</label>' +
+            '<div class="d-flex align-items-center gap-1">' +
+              '<input type="color" class="form-control form-control-color osd-stroke">' +
+              '<input type="range" min="0" max="255" step="1" class="form-range osd-stroke-alpha" title="Outline alpha">' +
+            '</div>' +
+          '</div>' +
+        '</div>' +
+      '</div>' +
+      '<div class="osd-logo-body">' +
+        '<p class="mb-2 text-body-secondary"><i class="bi bi-image me-1"></i>' +
+          'Logo overlay. The image file is set in the streamer configuration; ' +
+          'position and transparency are editable here.</p>' +
+      '</div>' +
+      '<div class="row g-2 mt-1 align-items-end">' +
+        '<div class="col-12 col-md-6" data-leaf="x">' +
+          '<label class="form-label mb-1">Position</label>' +
+          '<div class="input-group input-group-sm">' +
+            '<select class="form-select osd-x-anchor" style="max-width:6rem">' +
+              '<option value="start">Left +</option>' +
+              '<option value="end">Right -</option>' +
+            '</select>' +
+            '<input type="number" min="0" class="form-control osd-x-mag" placeholder="x">' +
+            '<select class="form-select osd-y-anchor" style="max-width:6rem">' +
+              '<option value="start">Top +</option>' +
+              '<option value="end">Bottom -</option>' +
+            '</select>' +
+            '<input type="number" min="0" class="form-control osd-y-mag" placeholder="y">' +
+          '</div>' +
+          '<span class="form-text">distance in px from the chosen edges</span>' +
+        '</div>' +
+        '<div class="col-12 col-md-6" data-leaf="transparency">' +
+          '<label class="form-label mb-1">Transparency ' +
+            '<span class="osd-trans-val text-body-secondary"></span></label>' +
+          '<input type="range" min="0" max="255" step="1" class="form-range osd-trans">' +
+        '</div>' +
+      '</div>' +
+      '<div class="osd-both-note alert alert-info py-1 px-2 mt-2 mb-0 small d-none">' +
+        '<i class="bi bi-link-45deg me-1"></i>Also applied to ' + STREAM_NAME[OTHER] +
+      '</div>' +
+    '</div>';
+
+  function buildCard(item, data) {
+    data = data || {};
+    var card = document.createElement("div");
+    card.className = "card mb-2 osd-card";
+    card.setAttribute("data-item", String(item));
+    card.innerHTML = CARD_HTML;
+
+    card.querySelector(".osd-index").textContent = "#" + item;
+    card.querySelector(".osd-scope option[value='this']").textContent =
+      "This stream (" + STREAM_NAME[S] + ")";
+
+    // ---- populate from the loaded item ----
+    var type = data.type === "logo" ? "logo" : "text";
+    card.querySelector(".osd-type").value = type;
+    card.setAttribute("data-type", type);
+    card.querySelector(".osd-text-body").classList.toggle("d-none", type === "logo");
+    card.querySelector(".osd-logo-body").classList.toggle("d-none", type !== "logo");
+
+    card.querySelector(".osd-enabled").checked = !!Number(data.enabled);
+    if (type !== "logo") {
+      if (data.text !== undefined) card.querySelector(".osd-text").value = data.text;
+      if (data.font_size !== undefined)
+        card.querySelector(".osd-fontsize").value = data.font_size;
+      if (data.outline !== undefined)
+        card.querySelector(".osd-outline").value = data.outline;
+      var fc = fromTimpsColor(data.color);
+      if (fc) {
+        card.querySelector(".osd-fill").value = fc.color;
+        card.querySelector(".osd-fill-alpha").value = fc.alpha;
+      }
+      var sc = fromTimpsColor(data.outline_color);
+      if (sc) {
+        card.querySelector(".osd-stroke").value = sc.color;
+        card.querySelector(".osd-stroke-alpha").value = sc.alpha;
+      }
+    }
+    var px = posToAnchor(data.x);
+    card.querySelector(".osd-x-anchor").value = px.anchor;
+    card.querySelector(".osd-x-mag").value = px.mag;
+    var py = posToAnchor(data.y);
+    card.querySelector(".osd-y-anchor").value = py.anchor;
+    card.querySelector(".osd-y-mag").value = py.mag;
+    var tr = (data.transparency === undefined) ? 255 : Number(data.transparency);
+    card.querySelector(".osd-trans").value = tr;
+    card.querySelector(".osd-trans-val").textContent = "(" + tr + ")";
+
+    // ---- scope: default "this"; auto-detect "both" only when this item is
+    // enabled and byte-identical on both streams (a nice-to-have, never for
+    // empty/default slots) ----
+    if (Number(data.enabled) && itemsIdentical(item)) {
+      card.querySelector(".osd-scope").value = "both";
+    }
+    syncBothNote(card);
+
+    wireCard(card);
+    applyCaps(card);
+    updatePill(card);
+    return card;
+  }
+
+  function itemsIdentical(item) {
+    var a = itemData[0][item], b = itemData[1][item];
+    if (!a || !b) return false;
+    return LIVE_LEAVES.every(function (k) {
+      return String(a[k]) === String(b[k]);
+    });
+  }
+
+  function syncBothNote(card) {
+    var both = cardScope(card) === "both";
+    card.querySelector(".osd-both-note").classList.toggle("d-none", !both);
+  }
+
+  // ---- per-card wiring -------------------------------------------------
+
+  function wireCard(card) {
+    var item = parseInt(card.getAttribute("data-item"), 10);
+
+    function push(leaves, busyEl) {
+      return sendItem(item, leaves, cardScope(card), busyEl);
     }
 
-    // page-level font size / shadow width drive every text item (timps
-    // keeps font_size/outline per item) - applied live
-    var fontsize = el("fontsize");
-    if (fontsize) {
+    // enable toggle: applies live for a boot-enabled item; for an item that
+    // was off at boot (incl. every freshly added item) it persists but only
+    // renders after a restart
+    var en = card.querySelector(".osd-enabled");
+    en.addEventListener("change", function () {
+      var restart = en.checked && enableNeedsRestart(item, cardScope(card));
+      var p = push({ enabled: en.checked ? 1 : 0 }, en);
+      updatePill(card);
+      if (restart) p.then(restartHint);
+    });
+
+    // scope change: no POST by itself; just re-flags the "both" note. Existing
+    // values are re-pushed to the other stream on the next edit (nudge any
+    // field to copy immediately).
+    card.querySelector(".osd-scope").addEventListener("change", function () {
+      syncBothNote(card);
+    });
+
+    var text = card.querySelector(".osd-text");
+    if (text)
+      text.addEventListener("change", function () {
+        push({ text: text.value }, text);
+      });
+
+    var fontsize = card.querySelector(".osd-fontsize");
+    if (fontsize)
       fontsize.addEventListener("change", function () {
         var v = parseInt(fontsize.value, 10);
-        if (isNaN(v)) return;
-        var body = {};
-        body[SEC] = {};
-        TEXT_ITEMS.forEach(function (i) {
-          body[SEC][String(i)] = { font_size: v };
-        });
-        sendBody(body, fontsize);
+        if (!isNaN(v)) push({ font_size: v }, fontsize);
       });
-    }
-    var strokesize = el("strokesize");
-    if (strokesize) {
-      strokesize.addEventListener("change", function () {
-        var v = parseInt(strokesize.value, 10);
-        if (isNaN(v)) return;
-        var body = {};
-        body[SEC] = {};
-        TEXT_ITEMS.forEach(function (i) {
-          body[SEC][String(i)] = { outline: v };
-        });
-        sendBody(body, strokesize);
-      });
-    }
 
-    Object.keys(ITEMS).forEach(function (group) {
-      var item = ITEMS[group];
-      wire(group + "_enabled", item, function (e) {
-        return { enabled: e.checked ? 1 : 0 };
+    var outline = card.querySelector(".osd-outline");
+    if (outline)
+      outline.addEventListener("change", function () {
+        var v = parseInt(outline.value, 10);
+        if (!isNaN(v)) push({ outline: v }, outline);
       });
-      wire(group + "_position", item, function (e) {
-        return parsePosition(e.value);
+
+    function fillColor() {
+      var picker = card.querySelector(".osd-fill");
+      var alpha = parseInt(card.querySelector(".osd-fill-alpha").value, 10);
+      return toTimpsColor(picker.value, alpha);
+    }
+    function strokeColor() {
+      var picker = card.querySelector(".osd-stroke");
+      var alpha = parseInt(card.querySelector(".osd-stroke-alpha").value, 10);
+      return toTimpsColor(picker.value, alpha);
+    }
+    ["osd-fill", "osd-fill-alpha"].forEach(function (cls) {
+      var el = card.querySelector("." + cls);
+      if (el) el.addEventListener("change", function () {
+        var c = fillColor();
+        if (c) push({ color: c }, el);
       });
-      if (group === "logo") return; // colors/format are text-item-only
-      wire(group + "_fillcolor", item, function () {
-        var c = colorValue(group + "_fillcolor");
-        return c ? { color: c } : null;
-      });
-      wire(group + "_fillcolor-alpha", item, function () {
-        var c = colorValue(group + "_fillcolor");
-        return c ? { color: c } : null;
-      });
-      wire(group + "_strokecolor", item, function () {
-        var c = colorValue(group + "_strokecolor");
-        return c ? { outline_color: c } : null;
-      });
-      wire(group + "_strokecolor-alpha", item, function () {
-        var c = colorValue(group + "_strokecolor");
-        return c ? { outline_color: c } : null;
-      });
-      if (group === "uptime") return; // no format field on the page
-      wire(group + "_format", item, function (e) {
-        // timps text template: strftime %.. plus {hostname}/{ip}/{uptime}/
-        // {fps}/... placeholders - passed through unchanged
-        return { text: e.value };
+    });
+    ["osd-stroke", "osd-stroke-alpha"].forEach(function (cls) {
+      var el = card.querySelector("." + cls);
+      if (el) el.addEventListener("change", function () {
+        var c = strokeColor();
+        if (c) push({ outline_color: c }, el);
       });
     });
 
-    // timps applies + persists every change immediately; the button is
-    // kept only to reassure users trained on the old save-to-file step.
-    var saveBtn = $id("save-prudynt-config");
-    if (saveBtn) {
-      saveBtn.addEventListener("click", function () {
-        toast(
-          "success",
-          "Nothing to do: OSD settings are applied live and already saved to the streamer configuration.",
-          4000,
-        );
+    // position: any of the four widgets pushes the combined {x,y}
+    ["osd-x-anchor", "osd-x-mag", "osd-y-anchor", "osd-y-mag"].forEach(function (cls) {
+      var el = card.querySelector("." + cls);
+      if (el) el.addEventListener("change", function () {
+        push(readPosition(card), el);
       });
+    });
+
+    var trans = card.querySelector(".osd-trans");
+    trans.addEventListener("input", function () {
+      card.querySelector(".osd-trans-val").textContent = "(" + trans.value + ")";
+    });
+    trans.addEventListener("change", function () {
+      var v = parseInt(trans.value, 10);
+      if (!isNaN(v)) push({ transparency: v }, trans);
+    });
+
+    // remove: disable (live-hide + persist) and drop the card. A fixed slot
+    // is never destroyed server-side; disabling it frees it for reuse.
+    card.querySelector(".osd-remove").addEventListener("click", function () {
+      push({ enabled: 0 }, card);
+      card.parentNode.removeChild(card);
+      refreshSlotUI();
+    });
+  }
+
+  // ---- list management -------------------------------------------------
+
+  function shownItems() {
+    var out = {};
+    var cards = document.querySelectorAll("#osd-items .osd-card");
+    Array.prototype.forEach.call(cards, function (c) {
+      out[parseInt(c.getAttribute("data-item"), 10)] = true;
+    });
+    return out;
+  }
+
+  function refreshSlotUI() {
+    var count = document.querySelectorAll("#osd-items .osd-card").length;
+    var empty = $id("osd-items-empty");
+    if (empty) empty.classList.toggle("d-none", count > 0);
+    var addBtn = $id("osd-add-item");
+    if (addBtn) addBtn.disabled = count >= MAX_OSD;
+    var counter = $id("osd-slot-count");
+    if (counter) counter.textContent = count + " of " + MAX_OSD + " overlays used";
+  }
+
+  function addItem() {
+    var shown = shownItems();
+    var idx = -1;
+    for (var i = 0; i < MAX_OSD; i++) {
+      if (!shown[i]) { idx = i; break; }
     }
+    if (idx < 0) return;
+    // seed a fresh card from whatever the streamer currently holds at that
+    // index (defaults: disabled text at a small offset), enabled off
+    var seed = itemData[S][idx] || { type: "text", enabled: 0, x: 10, y: 10 };
+    var card = buildCard(idx, seed);
+    $id("osd-items").appendChild(card);
+    refreshSlotUI();
+    card.scrollIntoView({ behavior: "smooth", block: "nearest" });
   }
 
-  // every page control suffix (for the initial grey-out + caps mapping)
-  var ALL_CONTROLS = [
-    "enabled", "fontsize", "strokesize",
-    "logo_enabled", "logo_position",
-    "time_enabled", "time_position", "time_fillcolor", "time_fillcolor-alpha",
-    "time_strokecolor", "time_strokecolor-alpha", "time_format",
-    "uptime_enabled", "uptime_position", "uptime_fillcolor",
-    "uptime_fillcolor-alpha", "uptime_strokecolor", "uptime_strokecolor-alpha",
-    "usertext_enabled", "usertext_position", "usertext_fillcolor",
-    "usertext_fillcolor-alpha", "usertext_strokecolor",
-    "usertext_strokecolor-alpha", "usertext_format",
-  ];
-
-  // control suffix pattern -> the timps item leaf key that must be in
-  // caps.osd for the control to enable
-  function capsKeyFor(name) {
-    if (name === "enabled") return "enabled"; // master switch
-    if (name === "fontsize") return "font_size";
-    if (name === "strokesize") return "outline";
-    if (/_enabled$/.test(name)) return "enabled";
-    if (/_position$/.test(name)) return "x";
-    if (/_fillcolor(-alpha)?$/.test(name)) return "color";
-    if (/_strokecolor(-alpha)?$/.test(name)) return "outline_color";
-    if (/_format$/.test(name)) return "text";
-    return null;
-  }
-
-  function populateColor(name, timpsColor) {
-    var c = fromTimpsColor(timpsColor);
-    if (!c) return;
-    var picker = el(name);
-    if (picker) picker.value = c.color;
-    var alphaEl = el(name + "-alpha");
-    if (alphaEl) alphaEl.value = c.alpha;
-  }
-
-  function populateItem(group, item) {
-    if (!item) return;
-    var checkbox = el(group + "_enabled");
-    if (checkbox) checkbox.checked = !!Number(item.enabled);
-    var pos = el(group + "_position");
-    if (pos && item.x !== undefined && item.y !== undefined)
-      pos.value = item.x + "," + item.y;
-    if (group === "logo") return;
-    populateColor(group + "_fillcolor", item.color);
-    populateColor(group + "_strokecolor", item.outline_color);
-    var format = el(group + "_format");
-    if (format && item.text !== undefined) format.value = item.text;
-  }
+  // ---- load ------------------------------------------------------------
 
   function offlineNotice() {
     if ($id("timps-offline-notice")) return;
@@ -307,7 +526,15 @@
       "Check that the timps service is running, then reload this page.";
     var h3 = document.querySelector("main h3");
     if (h3 && h3.parentNode) h3.parentNode.insertBefore(div, h3.nextSibling);
-    else document.querySelector("main .container")?.appendChild(div);
+    else {
+      var c = document.querySelector("main .container");
+      if (c) c.appendChild(div);
+    }
+  }
+
+  function inUse(it) {
+    return it && (Number(it.enabled) ||
+      (it.text && String(it.text).length) || it.type === "logo");
   }
 
   function load() {
@@ -319,32 +546,31 @@
     window.timpsApi
       .get()
       .then(function (json) {
-        var set = json[SEC] || {}; // THIS stream's independent item set
-        var capsOsd = (json.caps && json.caps.osd) || [];
-
-        Object.keys(ITEMS).forEach(function (group) {
-          var item = set[String(ITEMS[group])];
-          populateItem(group, item);
-          loadedEnabled[ITEMS[group]] = !!(item && Number(item.enabled));
+        capsOsd = (json.caps && json.caps.osd) || [];
+        [0, 1].forEach(function (s) {
+          var set = json["osd" + s] || {};
+          itemData[s] = {};
+          bootEnabled[s] = {};
+          for (var i = 0; i < MAX_OSD; i++) {
+            var it = set[String(i)] || {};
+            itemData[s][i] = it;
+            bootEnabled[s][i] = !!Number(it.enabled);
+          }
         });
 
-        // master switch + the page-level size/shadow (mirrors of the first
-        // text item; timps keeps them per item)
-        var master = el("enabled");
+        // master switch
+        var master = $id("osd-master");
         if (master && json.osd && json.osd.enabled !== undefined)
           master.checked = !!Number(json.osd.enabled);
-        var first = set["0"] || {};
-        var fontsize = el("fontsize");
-        if (fontsize && first.font_size !== undefined)
-          fontsize.value = first.font_size;
-        var strokesize = el("strokesize");
-        if (strokesize && first.outline !== undefined)
-          strokesize.value = first.outline;
 
-        ALL_CONTROLS.forEach(function (name) {
-          var key = capsKeyFor(name);
-          setEnabled(SEC + "_" + name, !!key && capsOsd.indexOf(key) >= 0);
-        });
+        // render one card per in-use item on THIS stream
+        var host = $id("osd-items");
+        host.innerHTML = "";
+        for (var i = 0; i < MAX_OSD; i++) {
+          if (inUse(itemData[S][i]))
+            host.appendChild(buildCard(i, itemData[S][i]));
+        }
+        refreshSlotUI();
       })
       .catch(function (err) {
         console.warn("timps unreachable, OSD controls stay disabled:", err);
@@ -352,11 +578,35 @@
       });
   }
 
-  // OSD item leaves interact (color+alpha share one "color" value, position
-  // is one combined "x,y" field), so a remote change for THIS stream's
-  // section (osdS.N.* or the shared osd.enabled master) just re-runs the
-  // normal full load instead of patching a single leaf - cheap (one GET) and
-  // always internally consistent.
+  // ---- static wiring (master switch, add button, save button) ----------
+
+  function wireStatic() {
+    var master = $id("osd-master");
+    if (master) {
+      master.addEventListener("change", function () {
+        sendBody({ osd: { enabled: master.checked ? 1 : 0 } }, master).then(
+          restartHint,
+        );
+      });
+    }
+    var addBtn = $id("osd-add-item");
+    if (addBtn) addBtn.addEventListener("click", addItem);
+
+    var saveBtn = $id("save-prudynt-config");
+    if (saveBtn) {
+      saveBtn.addEventListener("click", function () {
+        toast(
+          "success",
+          "Nothing to do: OSD settings are applied live and already saved to the streamer configuration.",
+          4000,
+        );
+      });
+    }
+  }
+
+  // remote change for this stream (osdS.N.* or the shared osd.enabled master)
+  // just re-runs the full load - cheap and always internally consistent. Don't
+  // fight the user mid-edit on this page.
   function onConfigEvent(type, data) {
     if (!data) return;
     if (!data.resync) {
@@ -364,14 +614,14 @@
       if (key !== "osd.enabled" && key.indexOf(SEC + ".") !== 0) return;
     }
     var ae = document.activeElement;
-    // don't fight the user mid-edit on this page
-    if (ae && (ae.tagName === "INPUT" || ae.tagName === "SELECT" || ae.tagName === "TEXTAREA"))
+    if (ae && (ae.tagName === "INPUT" || ae.tagName === "SELECT" ||
+      ae.tagName === "TEXTAREA"))
       return;
     load();
   }
 
   function init() {
-    wireControls();
+    wireStatic();
     load();
     if (window.timpsApi) window.timpsApi.events("config", onConfigEvent);
   }

--- a/package/timps/files/www/config-audio.html
+++ b/package/timps/files/www/config-audio.html
@@ -135,7 +135,7 @@
               <p class="col number-range">
                 <label for="audio_spk_vol">Speaker volume</label>
                 <span class="input-group">
-                  <input type="text" id="audio_spk_vol" name="audio_spk_vol" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="-30" data-max="120" data-step="1">
+                  <input type="text" id="audio_spk_vol" name="audio_spk_vol" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="0" data-max="100" data-step="1">
                   <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
                 </span>
               </p>
@@ -153,13 +153,32 @@
                 </select>
               </p>
             </div><!-- .row -->
+
+            <!-- test-sound control: shown by config-audio.js only when the
+                 play queue is compiled in (caps.play.available) -->
+            <div class="row row-cols-1 row-cols-md-2 mb-1 d-none" id="spk-test-wrap">
+              <p class="col select">
+                <label for="audio_spk_test_sound">Test sound</label>
+                <select class="form-select" id="audio_spk_test_sound" name="audio_spk_test_sound">
+                  <option value="">- Select sound -</option>
+                </select>
+              </p>
+              <p class="col align-self-end">
+                <button type="button" id="audio_spk_test_play" class="btn btn-outline-primary">
+                  <i class="bi bi-play-fill me-1"></i> Play
+                </button>
+                <button type="button" id="audio_spk_test_stop" class="btn btn-outline-secondary">
+                  <i class="bi bi-stop-fill me-1"></i> Stop
+                </button>
+              </p>
+            </div><!-- #spk-test-wrap -->
           </div><!-- .card-body -->
         </div><!-- .card -->
 
         <div class="card mb-3" id="backchannel-card">
           <div class="card-header">
             <h2 class="card-title">ONVIF Audio Backchannel</h2>
-            <small>Two-way audio: an ONVIF client sends audio to the camera over RTSP, played out via <code>/bin/iac</code>. Requires the <code>ingenic-audiodaemon</code> package on the device. Changes apply after a streamer restart.</small>
+            <small>Two-way audio: an ONVIF client sends audio to the camera over RTSP, played out natively through the camera speaker (IMP_AO). Changes apply after a streamer restart.</small>
           </div><!-- .card-header -->
           <div class="card-body">
             <div class="row row-cols-1 row-cols-md-3 mb-3">

--- a/package/timps/files/www/config-photosensing.html
+++ b/package/timps/files/www/config-photosensing.html
@@ -87,21 +87,55 @@
                 </p>
               </div>
               <div class="col">
-                <h4>Time Schedule</h4>
-                <small>Enable/disable photosensing at specific times</small>
-                <p class="form-switch mt-3">
-                  <input type="hidden" id="daynight_schedule_enabled-false" name="daynight_schedule_enabled" value="false">
-                  <input type="checkbox" id="daynight_schedule_enabled" name="daynight_schedule_enabled" value="true" role="switch" class="form-check-input">
-                  <label for="daynight_schedule_enabled" class="form-check-label">Use time-based schedule</label>
+                <h4>Override Mode</h4>
+                <small>Choose what drives the Day/Night decision</small>
+                <p class="mt-3">
+                  <label for="daynight_mode" class="form-label">Decision source</label>
+                  <select id="daynight_mode" name="daynight_mode" class="form-select">
+                    <option value="sensor">Sensor (light level)</option>
+                    <option value="time">Fixed time window</option>
+                    <option value="sun">Sunrise / sunset</option>
+                  </select>
                 </p>
-                <p>
-                  <label for="daynight_schedule_start_at">Start photosensing at</label>
-                  <input type="time" id="daynight_schedule_start_at" name="daynight_schedule_start_at" class="form-control" value="">
-                </p>
-                <p>
-                  <label for="daynight_schedule_stop_at">Stop photosensing at</label>
-                  <input type="time" id="daynight_schedule_stop_at" name="daynight_schedule_stop_at" class="form-control" value="">
-                </p>
+
+                <!-- Fixed time window (mode=time) -->
+                <div id="daynight_time_fields" hidden>
+                  <p>
+                    <label for="daynight_time_night_start">Switch to night at</label>
+                    <input type="time" id="daynight_time_night_start" name="daynight_time_night_start" class="form-control" value="">
+                  </p>
+                  <p>
+                    <label for="daynight_time_day_start">Switch to day at</label>
+                    <input type="time" id="daynight_time_day_start" name="daynight_time_day_start" class="form-control" value="">
+                  </p>
+                  <small class="text-secondary">Local camera clock. The night window may wrap past midnight (e.g. night 20:00, day 06:30).</small>
+                </div>
+
+                <!-- Sunrise / sunset (mode=sun) -->
+                <div id="daynight_sun_fields" hidden>
+                  <div class="row g-2">
+                    <p class="col">
+                      <label for="daynight_sun_latitude">Latitude</label>
+                      <input type="number" step="any" id="daynight_sun_latitude" name="daynight_sun_latitude" class="form-control text-end" value="" placeholder="52.52">
+                    </p>
+                    <p class="col">
+                      <label for="daynight_sun_longitude">Longitude</label>
+                      <input type="number" step="any" id="daynight_sun_longitude" name="daynight_sun_longitude" class="form-control text-end" value="" placeholder="13.40">
+                    </p>
+                  </div>
+                  <div class="row g-2">
+                    <p class="col">
+                      <label for="daynight_sun_sunrise_offset_min">Sunrise offset (min)</label>
+                      <input type="number" step="1" id="daynight_sun_sunrise_offset_min" name="daynight_sun_sunrise_offset_min" class="form-control text-end" value="" placeholder="0">
+                    </p>
+                    <p class="col">
+                      <label for="daynight_sun_sunset_offset_min">Sunset offset (min)</label>
+                      <input type="number" step="1" id="daynight_sun_sunset_offset_min" name="daynight_sun_sunset_offset_min" class="form-control text-end" value="" placeholder="0">
+                    </p>
+                  </div>
+                  <small class="text-secondary">Positive/negative minutes shift the switch relative to the real sun (e.g. -30 = switch to night 30 min before sunset). Today at this location:
+                    day <span id="daynight_sun_computed_sunrise">--:--</span> &rarr; night <span id="daynight_sun_computed_sunset">--:--</span>.</small>
+                </div>
               </div>
             </div>
           </div>

--- a/package/timps/files/www/streamer-osd0.html
+++ b/package/timps/files/www/streamer-osd0.html
@@ -24,122 +24,37 @@
 
     <h3>Main Stream OSD</h3>
     <p><small>This page configures the main stream's own overlay set &mdash; the
-      substream has its independent set on the Substream OSD page. Text, position,
-      size, color, alpha and the shadow/stroke outline apply live; the master OSD
-      switch (shared by both streams) and enabling an overlay that is currently off
-      take effect after a streamer restart. Greyed-out controls are not supported by
-      the running streamer.</small></p>
+      substream has its independent set on the Substream OSD page. Each overlay is
+      a text or logo slot: add up to 8, remove any, and edit text, position, size,
+      color, transparency and the outline. Everything applies live except the master
+      OSD switch (shared by both streams) and enabling an overlay that was off when
+      the streamer last started &mdash; those take effect after a streamer restart,
+      flagged per overlay. Greyed-out controls are not supported by the running
+      streamer.</small></p>
 
     <div class="row mb-3">
       <div class="col-12 col-xl-4">
         <div id="frame" class="position-relative">
           <img id="preview" src="/a/nostream.svg" class="img-fluid" alt="Image: Preview" tabindex="-1" data-stream="ch0">
         </div>
+        <p class="form-switch mt-3">
+          <input type="checkbox" id="osd-master" role="switch" class="form-check-input">
+          <label for="osd-master" class="form-check-label">OSD enabled (master switch, both streams &mdash; restart)</label>
+        </p>
+        <p>
+          <label class="d-block">Font file</label>
+          <button type="button" class="btn btn-outline-secondary w-100" data-bs-toggle="modal" data-bs-target="#mdFont">Upload or restore default font</button>
+        </p>
       </div>
       <div class="col col-xl-8">
-        <div class="row g-2">
-          <div class="col">
-            <p class="form-switch">
-              <input type="hidden" id="osd0_enabled-false" name="osd0_enabled" value="false">
-              <input type="checkbox" id="osd0_enabled" name="osd0_enabled" value="true" role="switch" class="form-check-input">
-              <label for="osd0_enabled" class="form-check-label">OSD enabled</label>
-            </p>
-            <p>
-              <label class="d-block">Font file</label>
-              <button type="button" class="btn btn-outline-secondary w-100" data-bs-toggle="modal" data-bs-target="#mdFont">Upload or restore default font</button>
-            </p>
-            <p>
-              <label for="osd0_fontsize">Size</label>
-              <input type="text" id="osd0_fontsize" name="osd0_fontsize" class="form-control" value="">
-            </p>
-            <p>
-              <label for="osd0_strokesize">Shadow</label>
-              <input type="text" id="osd0_strokesize" name="osd0_strokesize" class="form-control" value="">
-            </p>
-          </div><!-- .col -->
-          <div class="col">
-            <p class="form-switch">
-              <input type="hidden" id="osd0_logo_enabled-false" name="osd0_logo_enabled" value="false">
-              <input type="checkbox" id="osd0_logo_enabled" name="osd0_logo_enabled" value="true" role="switch" class="form-check-input">
-              <label for="osd0_logo_enabled" class="form-check-label">Logo</label>
-            </p>
-            <p>
-              <label for="osd0_logo_position">Position (x,y)</label>
-              <input type="text" id="osd0_logo_position" name="osd0_logo_position" class="form-control" value="">
-            </p>
-          </div><!-- .col -->
-          <div class="col">
-            <p class="form-switch">
-              <input type="hidden" id="osd0_time_enabled-false" name="osd0_time_enabled" value="false">
-              <input type="checkbox" id="osd0_time_enabled" name="osd0_time_enabled" value="true" role="switch" class="form-check-input">
-              <label for="osd0_time_enabled" class="form-check-label">Time</label>
-            </p>
-            <p>
-              <label for="osd0_time_position">Position (x,y)</label>
-              <input type="text" id="osd0_time_position" name="osd0_time_position" class="form-control" value="">
-            </p>
-            <p id="osd0_time_fillcolor_wrap" class="file">
-              <label for="osd0_time_fillcolor">Color</label>
-              <input type="color" id="osd0_time_fillcolor" name="osd0_time_fillcolor" class="form-control input-color">
-              <input type="range" id="osd0_time_fillcolor-alpha" name="osd0_time_fillcolor-alpha" min=0 max=255 step=1 class="expert">
-            </p>
-            <p id="osd0_time_strokecolor_wrap" class="file">
-              <label for="osd0_time_strokecolor">Shadow</label>
-              <input type="color" id="osd0_time_strokecolor" name="osd0_time_strokecolor" class="form-control input-color">
-              <input type="range" id="osd0_time_strokecolor-alpha" name="osd0_time_strokecolor-alpha" min=0 max=255 step=1 class="expert">
-            </p>
-            <p>
-              <label for="osd0_time_format">Format</label>
-              <input type="text" id="osd0_time_format" name="osd0_time_format" class="form-control" value="">
-            </p>
-          </div><!-- .col -->
-          <div class="col">
-            <p class="form-switch">
-              <input type="hidden" id="osd0_uptime_enabled-false" name="osd0_uptime_enabled" value="false">
-              <input type="checkbox" id="osd0_uptime_enabled" name="osd0_uptime_enabled" value="true" role="switch" class="form-check-input">
-              <label for="osd0_uptime_enabled" class="form-check-label">Uptime</label>
-            </p>
-            <p>
-              <label for="osd0_uptime_position">Position (x,y)</label>
-              <input type="text" id="osd0_uptime_position" name="osd0_uptime_position" class="form-control" value="">
-            </p>
-            <p>
-              <label for="osd0_uptime_fillcolor">Color</label>
-              <input type="color" id="osd0_uptime_fillcolor" name="osd0_uptime_fillcolor" class="form-control input-color">
-              <input type="range" id="osd0_uptime_fillcolor-alpha" name="osd0_uptime_fillcolor-alpha" min=0 max=255 step=1 class="expert">
-            </p>
-            <p>
-              <label for="osd0_uptime_strokecolor">Shadow</label>
-              <input type="color" id="osd0_uptime_strokecolor" name="osd0_uptime_strokecolor" class="form-control input-color">
-              <input type="range" id="osd0_uptime_strokecolor-alpha" name="osd0_uptime_strokecolor-alpha" min=0 max=255 step=1 class="expert">
-            </p>
-          </div><!-- .col -->
-          <div class="col">
-            <p class="form-switch">
-              <input type="hidden" id="osd0_usertext_enabled-false" name="osd0_usertext_enabled" value="false">
-              <input type="checkbox" id="osd0_usertext_enabled" name="osd0_usertext_enabled" value="true" role="switch" class="form-check-input">
-              <label for="osd0_usertext_enabled" class="form-check-label">User text</label>
-            </p>
-            <p>
-              <label for="osd0_usertext_position">Position (x,y)</label>
-              <input type="text" id="osd0_usertext_position" name="osd0_usertext_position" class="form-control" value="">
-            </p>
-            <p>
-              <label for="osd0_usertext_fillcolor">Color</label>
-              <input type="color" id="osd0_usertext_fillcolor" name="osd0_usertext_fillcolor" class="form-control input-color">
-              <input type="range" id="osd0_usertext_fillcolor-alpha" name="osd0_usertext_fillcolor-alpha" min=0 max=255 step=1 class="expert">
-            </p>
-            <p>
-              <label for="osd0_usertext_strokecolor">Shadow</label>
-              <input type="color" id="osd0_usertext_strokecolor" name="osd0_usertext_strokecolor" class="form-control input-color">
-              <input type="range" id="osd0_usertext_strokecolor-alpha" name="osd0_usertext_strokecolor-alpha" min=0 max=255 step=1 class="expert">
-            </p>
-            <p>
-              <label for="osd0_usertext_format">Format</label>
-              <input type="text" id="osd0_usertext_format" name="osd0_usertext_format" class="form-control" value="">
-            </p>
-          </div><!-- .col -->
-        </div><!-- .row -->
+        <div id="osd-items"></div>
+        <p id="osd-items-empty" class="text-body-secondary">No overlays configured for this stream. Use &ldquo;Add overlay&rdquo; to create one.</p>
+        <div class="d-flex align-items-center gap-3 mt-2">
+          <button type="button" id="osd-add-item" class="btn btn-outline-primary">
+            <i class="bi bi-plus-lg me-1"></i> Add overlay
+          </button>
+          <span id="osd-slot-count" class="small text-body-secondary"></span>
+        </div>
       </div><!-- .col -->
     </div><!-- .row -->
 

--- a/package/timps/files/www/streamer-osd1.html
+++ b/package/timps/files/www/streamer-osd1.html
@@ -24,122 +24,37 @@
 
     <h3>Substream OSD</h3>
     <p><small>This page configures the substream's own overlay set &mdash; the main
-      stream has its independent set on the Main Stream OSD page. Text, position,
-      size, color, alpha and the shadow/stroke outline apply live; the master OSD
-      switch (shared by both streams) and enabling an overlay that is currently off
-      take effect after a streamer restart. Greyed-out controls are not supported by
-      the running streamer.</small></p>
+      stream has its independent set on the Main Stream OSD page. Each overlay is
+      a text or logo slot: add up to 8, remove any, and edit text, position, size,
+      color, transparency and the outline. Everything applies live except the master
+      OSD switch (shared by both streams) and enabling an overlay that was off when
+      the streamer last started &mdash; those take effect after a streamer restart,
+      flagged per overlay. Greyed-out controls are not supported by the running
+      streamer.</small></p>
 
     <div class="row mb-3">
       <div class="col-12 col-xl-4">
         <div id="frame" class="position-relative">
           <img id="preview" src="/a/nostream.svg" class="img-fluid" alt="Image: Preview" tabindex="-1" data-stream="ch1">
         </div>
+        <p class="form-switch mt-3">
+          <input type="checkbox" id="osd-master" role="switch" class="form-check-input">
+          <label for="osd-master" class="form-check-label">OSD enabled (master switch, both streams &mdash; restart)</label>
+        </p>
+        <p>
+          <label class="d-block">Font file</label>
+          <button type="button" class="btn btn-outline-secondary w-100" data-bs-toggle="modal" data-bs-target="#mdFont">Upload or restore default font</button>
+        </p>
       </div>
       <div class="col col-xl-8">
-        <div class="row g-2">
-          <div class="col">
-            <p class="form-switch">
-              <input type="hidden" id="osd1_enabled-false" name="osd1_enabled" value="false">
-              <input type="checkbox" id="osd1_enabled" name="osd1_enabled" value="true" role="switch" class="form-check-input">
-              <label for="osd1_enabled" class="form-check-label">OSD enabled</label>
-            </p>
-            <p>
-              <label class="d-block">Font file</label>
-              <button type="button" class="btn btn-outline-secondary w-100" data-bs-toggle="modal" data-bs-target="#mdFont">Upload or restore default font</button>
-            </p>
-            <p>
-              <label for="osd1_fontsize">Size</label>
-              <input type="text" id="osd1_fontsize" name="osd1_fontsize" class="form-control" value="">
-            </p>
-            <p>
-              <label for="osd1_strokesize">Shadow</label>
-              <input type="text" id="osd1_strokesize" name="osd1_strokesize" class="form-control" value="">
-            </p>
-          </div><!-- .col -->
-          <div class="col">
-            <p class="form-switch">
-              <input type="hidden" id="osd1_logo_enabled-false" name="osd1_logo_enabled" value="false">
-              <input type="checkbox" id="osd1_logo_enabled" name="osd1_logo_enabled" value="true" role="switch" class="form-check-input">
-              <label for="osd1_logo_enabled" class="form-check-label">Logo</label>
-            </p>
-            <p>
-              <label for="osd1_logo_position">Position (x,y)</label>
-              <input type="text" id="osd1_logo_position" name="osd1_logo_position" class="form-control" value="">
-            </p>
-          </div><!-- .col -->
-          <div class="col">
-            <p class="form-switch">
-              <input type="hidden" id="osd1_time_enabled-false" name="osd1_time_enabled" value="false">
-              <input type="checkbox" id="osd1_time_enabled" name="osd1_time_enabled" value="true" role="switch" class="form-check-input">
-              <label for="osd1_time_enabled" class="form-check-label">Time</label>
-            </p>
-            <p>
-              <label for="osd1_time_position">Position (x,y)</label>
-              <input type="text" id="osd1_time_position" name="osd1_time_position" class="form-control" value="">
-            </p>
-            <p id="osd1_time_fillcolor_wrap" class="file">
-              <label for="osd1_time_fillcolor">Color</label>
-              <input type="color" id="osd1_time_fillcolor" name="osd1_time_fillcolor" class="form-control input-color">
-              <input type="range" id="osd1_time_fillcolor-alpha" name="osd1_time_fillcolor-alpha" min=0 max=255 step=1 class="expert">
-            </p>
-            <p id="osd1_time_strokecolor_wrap" class="file">
-              <label for="osd1_time_strokecolor">Shadow</label>
-              <input type="color" id="osd1_time_strokecolor" name="osd1_time_strokecolor" class="form-control input-color">
-              <input type="range" id="osd1_time_strokecolor-alpha" name="osd1_time_strokecolor-alpha" min=0 max=255 step=1 class="expert">
-            </p>
-            <p>
-              <label for="osd1_time_format">Format</label>
-              <input type="text" id="osd1_time_format" name="osd1_time_format" class="form-control" value="">
-            </p>
-          </div><!-- .col -->
-          <div class="col">
-            <p class="form-switch">
-              <input type="hidden" id="osd1_uptime_enabled-false" name="osd1_uptime_enabled" value="false">
-              <input type="checkbox" id="osd1_uptime_enabled" name="osd1_uptime_enabled" value="true" role="switch" class="form-check-input">
-              <label for="osd1_uptime_enabled" class="form-check-label">Uptime</label>
-            </p>
-            <p>
-              <label for="osd1_uptime_position">Position (x,y)</label>
-              <input type="text" id="osd1_uptime_position" name="osd1_uptime_position" class="form-control" value="">
-            </p>
-            <p>
-              <label for="osd1_uptime_fillcolor">Color</label>
-              <input type="color" id="osd1_uptime_fillcolor" name="osd1_uptime_fillcolor" class="form-control input-color">
-              <input type="range" id="osd1_uptime_fillcolor-alpha" name="osd1_uptime_fillcolor-alpha" min=0 max=255 step=1 class="expert">
-            </p>
-            <p>
-              <label for="osd1_uptime_strokecolor">Shadow</label>
-              <input type="color" id="osd1_uptime_strokecolor" name="osd1_uptime_strokecolor" class="form-control input-color">
-              <input type="range" id="osd1_uptime_strokecolor-alpha" name="osd1_uptime_strokecolor-alpha" min=0 max=255 step=1 class="expert">
-            </p>
-          </div><!-- .col -->
-          <div class="col">
-            <p class="form-switch">
-              <input type="hidden" id="osd1_usertext_enabled-false" name="osd1_usertext_enabled" value="false">
-              <input type="checkbox" id="osd1_usertext_enabled" name="osd1_usertext_enabled" value="true" role="switch" class="form-check-input">
-              <label for="osd1_usertext_enabled" class="form-check-label">User text</label>
-            </p>
-            <p>
-              <label for="osd1_usertext_position">Position (x,y)</label>
-              <input type="text" id="osd1_usertext_position" name="osd1_usertext_position" class="form-control" value="">
-            </p>
-            <p>
-              <label for="osd1_usertext_fillcolor">Color</label>
-              <input type="color" id="osd1_usertext_fillcolor" name="osd1_usertext_fillcolor" class="form-control input-color">
-              <input type="range" id="osd1_usertext_fillcolor-alpha" name="osd1_usertext_fillcolor-alpha" min=0 max=255 step=1 class="expert">
-            </p>
-            <p>
-              <label for="osd1_usertext_strokecolor">Shadow</label>
-              <input type="color" id="osd1_usertext_strokecolor" name="osd1_usertext_strokecolor" class="form-control input-color">
-              <input type="range" id="osd1_usertext_strokecolor-alpha" name="osd1_usertext_strokecolor-alpha" min=0 max=255 step=1 class="expert">
-            </p>
-            <p>
-              <label for="osd1_usertext_format">Format</label>
-              <input type="text" id="osd1_usertext_format" name="osd1_usertext_format" class="form-control" value="">
-            </p>
-          </div><!-- .col -->
-        </div><!-- .row -->
+        <div id="osd-items"></div>
+        <p id="osd-items-empty" class="text-body-secondary">No overlays configured for this stream. Use &ldquo;Add overlay&rdquo; to create one.</p>
+        <div class="d-flex align-items-center gap-3 mt-2">
+          <button type="button" id="osd-add-item" class="btn btn-outline-primary">
+            <i class="bi bi-plus-lg me-1"></i> Add overlay
+          </button>
+          <span id="osd-slot-count" class="small text-body-secondary"></span>
+        </div>
       </div><!-- .col -->
     </div><!-- .row -->
 

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,7 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.5.0
+TIMPS_VERSION = v1.6.0
 TIMPS_LICENSE = MIT
 # Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
 # once it exists so legal-info can capture it.
@@ -35,13 +35,16 @@ ifeq ($(BR2_PACKAGE_TIMPS_SRT),y)
 	TIMPS_DEPENDENCIES += libsrt
 endif
 
-# Audio backchannel: timps only runtime-execs /bin/iac, it does NOT link the
-# audiodaemon - so we deliberately do NOT depend on/select ingenic-audiodaemon
-# here (that pulls libwebsockets, which fails on some uClibc toolchains). Enable
-# BR2_PACKAGE_INGENIC_AUDIODAEMON separately if you want /bin/iac on the image.
-# AAC decode, however, IS linked, so libhelix-aac stays a hard dependency.
+# Audio backchannel drives the speaker via native IMP_AO now (no /bin/iac /
+# ingenic-audiodaemon dependency). AAC backchannel decode IS linked, so
+# libhelix-aac stays a hard dependency when it is enabled.
 ifeq ($(BR2_PACKAGE_TIMPS_BC_AAC),y)
 	TIMPS_DEPENDENCIES += libhelix-aac
+endif
+
+# Opus playback in the play queue links opusfile (which pulls opus + libogg).
+ifeq ($(BR2_PACKAGE_TIMPS_PLAY_OPUS),y)
+	TIMPS_DEPENDENCIES += opusfile
 endif
 
 # CFLAGS inherit TARGET_CFLAGS for arch-specific flags (critical for XBurst CPUs
@@ -85,6 +88,26 @@ ifeq ($(BR2_PACKAGE_TIMPS_BC_AAC),y)
 	TIMPS_LIBS += -lhelix-aac
 endif
 
+ifeq ($(BR2_PACKAGE_TIMPS_PLAY_OPUS),y)
+	TIMPS_LIBS += -lopusfile -lopus -logg
+endif
+
+# Ingenic SDK blobs (libimp/libalog/libsysutils) reference libc symbols their
+# original vendor toolchain exported that modern uClibc-ng/musl dropped (e.g.
+# the glibc-2.2-era __ctype_b/__ctype_tolower bare-pointer symbols T10/T20/T21/
+# T30's libalog still calls). ingenic-uclibc/ingenic-musl (already a
+# TIMPS_DEPENDENCIES above) build libuclibcshim/libmuslshim to paper over
+# exactly this gap - link it, same as prudynt-t does (PRUDYNT_SHIM_LIB).
+# --no-as-needed/--as-needed: nothing in timps calls these symbols directly
+# (only the vendor blob does), so the linker's default --as-needed would
+# otherwise drop the shim from DT_NEEDED as "unused".
+ifeq ($(BR2_TOOLCHAIN_USES_MUSL),y)
+	TIMPS_LIBS += -Wl,--no-as-needed -lmuslshim -Wl,--as-needed
+endif
+ifeq ($(BR2_TOOLCHAIN_USES_UCLIBC),y)
+	TIMPS_LIBS += -Wl,--no-as-needed -luclibcshim -Wl,--as-needed
+endif
+
 define TIMPS_BUILD_CMDS
 	$(MAKE) \
 		CROSS_COMPILE=$(TARGET_CROSS) \
@@ -107,6 +130,10 @@ define TIMPS_BUILD_CMDS
 		USE_BC_AAC=$(if $(BR2_PACKAGE_TIMPS_BC_AAC),1,0) \
 		HELIXLIB="-lhelix-aac" \
 		HELIX_INC=$(STAGING_DIR)/usr/include \
+		USE_PLAY=$(if $(BR2_PACKAGE_TIMPS_PLAY),1,0) \
+		USE_PLAY_OPUS=$(if $(BR2_PACKAGE_TIMPS_PLAY_OPUS),1,0) \
+		OPUSLIB="-lopusfile -lopus -logg" \
+		OPUS_INC=$(STAGING_DIR)/usr/include \
 		-C $(@D) target
 endef
 
@@ -132,6 +159,15 @@ define TIMPS_INSTALL_TARGET_CMDS
 	# Install the self-test helper
 	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/timps-selftest.sh \
 		$(TARGET_DIR)/usr/bin/timps-selftest
+
+	# System-sound play wrapper: enqueues PLAY/STOP onto timps's /run/timps/
+	# audio_out FIFO (native IMP_AO). Same interface prudynt/raptor ship, so the
+	# WiFi-portal / sysupgrade-chime / ESPHome media_player integrations that
+	# shell out to `play` work on a timps image too.
+	if [ "$(BR2_PACKAGE_TIMPS_PLAY)" = "y" ]; then \
+		$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/play \
+			$(TARGET_DIR)/usr/sbin/play; \
+	fi
 
 	# Motion->send2 bridge. timps.conf's motion.on_motion points at this path, so
 	# install it unconditionally: otherwise imp_motion.c runs system() on a
@@ -222,6 +258,23 @@ endef
 TIMPS_TARGET_FINALIZE_HOOKS += TIMPS_INSTALL_WEBUI_CGIS
 endif
 
+# NOTE: motors-detection fix. Stock S48webui-config reports
+# window.thinginoUIConfig.device.motors=true whenever /etc/thingino.json HAS a
+# "motors" key at all - but configs/common.thingino.json ships one on every
+# board (empty gpio_pan/gpio_tilt, a disabled-by-default placeholder), so any
+# board without its OWN motors override (i.e. every non-PTZ camera) still
+# shows the preview page's PTZ joystick overlay. Our copy checks the actual
+# GPIO pins are configured instead. Independent of TIMPS_CONTROL - it's about
+# the preview page in general, not the /control API - so only gated on the
+# WebUI being present at all (nothing to override otherwise).
+ifeq ($(BR2_PACKAGE_THINGINO_WEBUI),y)
+define TIMPS_INSTALL_WEBUI_CONFIG_FIX
+	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/S48webui-config \
+		$(TARGET_DIR)/etc/init.d/S48webui-config
+endef
+TIMPS_TARGET_FINALIZE_HOOKS += TIMPS_INSTALL_WEBUI_CONFIG_FIX
+endif
+
 # NOTE: send-to-* notification toolkit (email/ftp/ntfy/storage/telegram/
 # webhook + the send2common helper they share). The unmodified send2* tools and
 # prudynt-helpers are re-installed as-is from package/prudynt-t/files/. The two
@@ -282,22 +335,25 @@ TIMPS_TARGET_FINALIZE_HOOKS += TIMPS_INSTALL_PREVIEW
 endif
 
 # NOTE: native day/night. When timps detects day/night itself
-# (BR2_PACKAGE_TIMPS_DAYNIGHT), the standalone daynightd daemon must never
-# autostart (double switching), and the WebUI "Photosensing" page (which
-# configures daynightd) is dropped from the navigation. Done as a finalize
-# hook so it wins regardless of package build order; both steps are
-# idempotent and no-ops when the files are absent.
+# (BR2_PACKAGE_TIMPS_DAYNIGHT), the standalone daynightd system daemon must
+# never autostart (it would double-switch against timps's own detection
+# thread), so its init script is removed. Done as a finalize hook so it wins
+# regardless of package build order; idempotent, a no-op when absent.
+#
+# The WebUI "Photosensing" page is deliberately KEPT: files/www/a/
+# config-photosensing.js is a timps-native overlay that talks straight to
+# /control (daynight.enabled / daynight.total_gain_{night,day}_threshold - see
+# its header) and is the config UI for timps's own detection, NOT the stock
+# page that drove daynightd. Earlier revisions of this hook deleted the page and
+# tried to strip its nav entry; that left the control-bar.js "Photosensing
+# Config" link (shipped unchanged from thingino-webui) pointing at a removed
+# page, so it dead-ended on Preview. Keeping the page - installed by the
+# TIMPS_INSTALL_WEBUI_CGIS overlay above - makes that link resolve correctly.
+# (The page's Controls/Schedule columns still use the board daynight script's
+# legacy /x/json-config-daynight.cgi best-effort; absent-CGI is handled in-page.)
 ifeq ($(BR2_PACKAGE_TIMPS_DAYNIGHT),y)
 define TIMPS_DISABLE_DAYNIGHTD
 	rm -f $(TARGET_DIR)/etc/init.d/S97daynightd
-	if [ -f $(TARGET_DIR)/var/www/a/navigation.js ]; then \
-		sed -i '/config-photosensing\.html/d' \
-			$(TARGET_DIR)/var/www/a/navigation.js ; \
-	fi
-	# Also drop the page + script so the orphaned "Photosensing" config (it
-	# drives the now-disabled daynightd) isn't reachable by direct URL.
-	rm -f $(TARGET_DIR)/var/www/config-photosensing.html \
-	      $(TARGET_DIR)/var/www/a/config-photosensing.js
 endef
 TIMPS_TARGET_FINALIZE_HOOKS += TIMPS_DISABLE_DAYNIGHTD
 endif


### PR DESCRIPTION
## Summary

Brings the `timps` package (and its bundled thingino WebUI pages) up to date with [timps v1.6.0](https://github.com/Lu-Fi/timps/releases/tag/v1.6.0).

### Native speaker output (backchannel + system-sound play), drops `/bin/iac`
timps now owns `IMP_AO` directly instead of piping decoded audio to `/bin/iac` (`ingenic-audiodaemon`). One arbiter (`src/rtsp/speaker.c`) handles two producers:
- **ONVIF audio backchannel** (`BR2_PACKAGE_TIMPS_BACKCHANNEL`, optional AAC via `BR2_PACKAGE_TIMPS_BC_AAC`) - unchanged from the caller's perspective, just native now.
- **System-sound play queue** (`BR2_PACKAGE_TIMPS_PLAY`, optional Opus via `BR2_PACKAGE_TIMPS_PLAY_OPUS`) - a FIFO speaking the same `PLAY url=... / STOP` protocol `/usr/sbin/play` already uses, so the WiFi captive-portal chime, the post-upgrade sound, and the ESPHome `media_player`/TTS integration all get a working speaker on a timps image with no extra glue.

New `BR2_PACKAGE_TIMPS_AUDIO_PRESET_{FULL,MINIMAL}` Kconfig presets bundle the backchannel+play+sounds-format combinations known to work. `MINIMAL` fits flash-constrained boards (~5MB rootfs) with G.711-only (pairs with the companion `thingino-sounds` G.711 format PR); `FULL` is Opus quality on boards with headroom.

### Day/night: time-window and sunrise/sunset override modes
`daynight.mode` (`sensor`/`time`/`sun`) adds two sensor-independent modes on top of the existing ISP-brightness detection - a fixed local-clock window, or real sunrise/sunset for a configured lat/long. The Photosensing page gained an "Override Mode" section, replacing a "Time Schedule" UI block that (found while working on this) never actually did anything - it POSTed to a legacy CGI endpoint nothing ever read.

### WebUI OSD page: Phase 1 of a redesign
The backend supports up to 8 independent overlay items per stream; the WebUI only ever exposed 4 in fixed, hardcoded roles. `streamer-osd.js` now renders items as a dynamic card list (add/remove, any of the 8 slots, per-card live-vs-restart-required status), adds a transparency control that existed on the backend but was never exposed, and an "apply to both streams" convenience per card. Also fixes a pre-existing bug where the enable checkbox was gated on a `caps.osd` capability key the backend never actually advertises.

### Also included
- Live speaker volume/gain slider + system-sound test-play control on the Audio Settings page.
- `S48webui-config`: fixes a false-positive PTZ-capability check that showed the pan/tilt overlay on boards without motors.
- `TIMPS_VERSION` bumped to v1.6.0.

## Test plan
Built and flashed to real hardware across the T20/T23/T31/T31L family (Wyze Cam v2, a Cinnado T23 and T31L, a Galayou Y4 T23, a Wuuk T31), verified via `timps-qa.sh` (RTSP/ONVIF/motion/OSD/recording integrity) plus real acoustic verification of the speaker path (RTSP-mic self-loopback, comparing played-clip audible span against source content). Day/night modes verified forcing real switches against a live sensor reading in both directions, manual-mode suppression, garbage-input rejection. OSD redesign verified via `/control` round-trips (transparency, both-streams scope, backward-compat load of the classic 4-item layout) and rendered-frame snapshots showing a live transparency change.

See the [timps CHANGELOG](https://github.com/Lu-Fi/timps/blob/main/CHANGELOG.md) for full technical detail on the daemon-side changes.

Companion PRs (separate packages):
- `thingino-sounds` G.711 format option
- `ingenic-sdk` T31 speaker-amp probe fix
- `ingenic-audiodaemon` patch fix
- `wifi` .wav fallback
- `thingino-onvif` per-profile framerate/bitrate patch
- `rcS` TZ live-reload fix