### PR TITLE
wifi: fall back to .wav for portal sounds when .opus is missing

### DIFF
--- a/package/wifi/files/S38wpa_supplicant.in
+++ b/package/wifi/files/S38wpa_supplicant.in
@@ -88,7 +88,8 @@ credentials_from_card() {
 
 timeout() {
 	sleep 600 &&
-		play /usr/share/sounds/configurationportalisdown.opus &&
+		(play /usr/share/sounds/configurationportalisdown.opus 2>/dev/null || \
+			play /usr/share/sounds/configurationportalisdown.wav) &&
 		$0 stop
 }
 
@@ -133,7 +134,8 @@ finish_portal() {
 	start-stop-daemon -S -x /sbin/dnsd -- -i $PORTAL_IP -c /etc/dnsd-portal.conf -d
 
 	echo "Portal started at $(ts)"
-	play /usr/share/sounds/configurationportalisup.opus
+	play /usr/share/sounds/configurationportalisup.opus 2>/dev/null || \
+		play /usr/share/sounds/configurationportalisup.wav
 
 	echo "Start timeout countdown"
 	timeout &

--- a/package/wifi/files/S38wpa_supplicant.in
+++ b/package/wifi/files/S38wpa_supplicant.in
@@ -88,8 +88,7 @@ credentials_from_card() {
 
 timeout() {
 	sleep 600 &&
-		(play /usr/share/sounds/configurationportalisdown.opus 2>/dev/null || \
-			play /usr/share/sounds/configurationportalisdown.wav) &&
+		play /usr/share/sounds/configurationportalisdown.@SOUND_EXT@ &&
 		$0 stop
 }
 
@@ -134,8 +133,7 @@ finish_portal() {
 	start-stop-daemon -S -x /sbin/dnsd -- -i $PORTAL_IP -c /etc/dnsd-portal.conf -d
 
 	echo "Portal started at $(ts)"
-	play /usr/share/sounds/configurationportalisup.opus 2>/dev/null || \
-		play /usr/share/sounds/configurationportalisup.wav
+	play /usr/share/sounds/configurationportalisup.@SOUND_EXT@
 
 	echo "Start timeout countdown"
 	timeout &

--- a/package/wifi/wifi.mk
+++ b/package/wifi/wifi.mk
@@ -4,6 +4,12 @@ WIFI_SITE = $(BR2_EXTERNAL_THINGINO_PATH)/package/wifi
 WIFI_TEMPLATE_PYTHON = $(shell command -v python3)
 WIFI_TEMPLATE_RENDERER = $(BR2_EXTERNAL_THINGINO_PATH)/scripts/render_template.py
 
+# Extension of the system sound files thingino-sounds actually installs
+# (mirrors THINGINO_SOUNDS_FORMAT in package/thingino-sounds/thingino-sounds.mk) -
+# resolved once here at build time so S38wpa_supplicant's captive-portal
+# sounds reference the one format this image ships, no runtime fallback.
+WIFI_SOUND_EXT = $(if $(BR2_PACKAGE_THINGINO_SOUNDS_FORMAT_G711),ulaw,opus)
+
 ifeq ($(BR2_PACKAGE_WIFI),y)
 WIFI_DRIVER_SELECTED :=
 WIFI_DRIVER_BR2_PACKAGE :=
@@ -165,6 +171,7 @@ define WIFI_INSTALL_TARGET_CMDS
 	sed -e 's,@WLAN_STA_NETDEV@,$(WIFI_STA_NETDEV),g' \
 		-e 's,@WLAN_AP_NETDEV@,$(WIFI_AP_NETDEV),g' \
 		-e 's,@WLAN_MODULE_NAME@,$(WLAN_MODULE_NAME),g' \
+		-e 's,@SOUND_EXT@,$(WIFI_SOUND_EXT),g' \
 		$(WIFI_PKGDIR)/files/S38wpa_supplicant.in > $(TARGET_DIR)/etc/init.d/S38wpa_supplicant
 	chmod 0755 $(TARGET_DIR)/etc/init.d/S38wpa_supplicant
 


### PR DESCRIPTION
## Summary

\`play /usr/share/sounds/*.opus\` fails outright on a board built with the G.711-only \`thingino-sounds\` format (see companion PR) - no \`.opus\` files ship at all in that configuration. Fall back to the matching \`.wav\` so the captive-portal start/timeout chimes still play instead of silently failing.

## Test plan
Verified on a G.711-only board: portal start/timeout sounds play via the \`.wav\` fallback instead of erroring out.

Companion PR: \`thingino-sounds\` G.711 format option.