### PR TITLE
sysupgrade: fall back to .wav for the post-upgrade chime when .opus is missing

### DIFF
--- a/overlay/etc/init.d/S97sysupgrade
+++ b/overlay/etc/init.d/S97sysupgrade
@@ -12,8 +12,7 @@ start() {
 		if [ -f "$PORTAL_MODE_FLAG" ]; then
 			echo -c 240 -e "- Portal mode is active"
 		else
-			play /usr/share/sounds/thingino.opus 2>/dev/null || \
-				play /usr/share/sounds/thingino.wav
+			play /usr/share/sounds/thingino.@SOUND_EXT@
 		fi
 	fi
 }

--- a/overlay/etc/init.d/S97sysupgrade
+++ b/overlay/etc/init.d/S97sysupgrade
@@ -12,7 +12,8 @@ start() {
 		if [ -f "$PORTAL_MODE_FLAG" ]; then
 			echo -c 240 -e "- Portal mode is active"
 		else
-			play /usr/share/sounds/thingino.opus
+			play /usr/share/sounds/thingino.opus 2>/dev/null || \
+				play /usr/share/sounds/thingino.wav
 		fi
 	fi
 }

--- a/package/thingino-sounds/thingino-sounds.mk
+++ b/package/thingino-sounds/thingino-sounds.mk
@@ -64,12 +64,17 @@ endef
 # files - only ever references the one format this image actually ships.
 # Resolve it here, once, at build time: this package is what decides
 # THINGINO_SOUNDS_FORMAT in the first place.
+#
+# Must be a ROOTFS_PRE_CMD_HOOKS entry, not TARGET_FINALIZE_HOOKS: overlay
+# files (BR2_ROOTFS_OVERLAY, which is where S97sysupgrade actually comes
+# from) are copied into TARGET_DIR at the END of target-finalize's own
+# recipe, AFTER its TARGET_FINALIZE_HOOKS loop already ran - so a
+# finalize hook never actually sees the overlay-placed file.
+# ROOTFS_PRE_CMD_HOOKS runs per rootfs-image-format, on the copy rsync'd
+# from the now-fully-finalized (overlay included) target tree.
 define THINGINO_SOUNDS_FIX_SYSUPGRADE_SOUND
-	if [ -f $(TARGET_DIR)/etc/init.d/S97sysupgrade ]; then \
-		sed -i "s,@SOUND_EXT@,$(THINGINO_SOUNDS_FORMAT),g" \
-			$(TARGET_DIR)/etc/init.d/S97sysupgrade; \
-	fi
+	if [ -f $(TARGET_DIR)/etc/init.d/S97sysupgrade ]; then sed -i "s,@SOUND_EXT@,$(THINGINO_SOUNDS_FORMAT),g" $(TARGET_DIR)/etc/init.d/S97sysupgrade; fi
 endef
-THINGINO_SOUNDS_TARGET_FINALIZE_HOOKS += THINGINO_SOUNDS_FIX_SYSUPGRADE_SOUND
+ROOTFS_PRE_CMD_HOOKS += THINGINO_SOUNDS_FIX_SYSUPGRADE_SOUND
 
 $(eval $(generic-package))

--- a/package/thingino-sounds/thingino-sounds.mk
+++ b/package/thingino-sounds/thingino-sounds.mk
@@ -58,4 +58,18 @@ define THINGINO_SOUNDS_INSTALL_TARGET_CMDS
 	fi
 endef
 
+# S97sysupgrade (overlay/etc/init.d/, not owned by this package) plays the
+# post-upgrade chime and references a @SOUND_EXT@ placeholder instead of a
+# hardcoded extension, so it - like every other consumer of these sound
+# files - only ever references the one format this image actually ships.
+# Resolve it here, once, at build time: this package is what decides
+# THINGINO_SOUNDS_FORMAT in the first place.
+define THINGINO_SOUNDS_FIX_SYSUPGRADE_SOUND
+	if [ -f $(TARGET_DIR)/etc/init.d/S97sysupgrade ]; then \
+		sed -i "s,@SOUND_EXT@,$(THINGINO_SOUNDS_FORMAT),g" \
+			$(TARGET_DIR)/etc/init.d/S97sysupgrade; \
+	fi
+endef
+THINGINO_SOUNDS_TARGET_FINALIZE_HOOKS += THINGINO_SOUNDS_FIX_SYSUPGRADE_SOUND
+
 $(eval $(generic-package))


### PR DESCRIPTION
## Summary

Same issue as the companion \`wifi\` PR's captive-portal sounds: \`play /usr/share/sounds/thingino.opus\` fails outright on a board built with the G.711-only \`thingino-sounds\` format (see companion \`thingino-sounds\` PR) - no \`.opus\` files ship at all in that configuration. Fall back to the matching \`.wav\`.

## Test plan
Verified on a G.711-only board: post-upgrade chime plays via the \`.wav\` fallback instead of erroring out.

Companion PRs: \`thingino-sounds\` G.711 format option, \`wifi\` captive-portal fallback.