### PR TITLE
timps: bump to v1.6.1

### DIFF
--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,7 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.6.0
+TIMPS_VERSION = v1.6.1
 TIMPS_LICENSE = MIT
 # Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
 # once it exists so legal-info can capture it.


### PR DESCRIPTION
## Summary

Bugfix release. The sub-stream (or any small-resolution encoder channel) could permanently stall delivering zero video after a single complex-scene IDR frame exceeded its AU assembly buffer's 128KB floor - the overflow handler's own recovery (force a fresh IDR) made it worse, since the replacement IDR was just as oversized and overflowed immediately too. Details: https://github.com/Lu-Fi/timps/releases/tag/v1.6.1

## Test plan
Reproduced and fixed on real hardware (a T23n board): the affected sub-stream went from zero decodable video across 20+ minutes and every reconnect to streaming correctly alongside the main stream, with zero overflow events since boot.