### PR TITLE
thingino-agent/webui: harden camera-side hub pairing bootstrap

### DIFF
--- a/docs/mqtt-subscriptions.md
+++ b/docs/mqtt-subscriptions.md
@@ -161,6 +161,26 @@ Important: keep the action exactly as shown above, including the inner quotes
 around `$MQTT_PAYLOAD`. The payload is JSON, and `telegram-cam-agent` expects
 to receive it as a single shell argument.
 
+The hub may push pairing over MQTT with command `install-agent-bootstrap`.
+Arguments are:
+
+| Arg | Meaning |
+|-----|---------|
+| `args.0` | Agent bearer token (required) |
+| `args.1` | Optional MQTT broker host |
+| `args.2` | Optional MQTT broker port (default `1883`) |
+| `args.3` | Optional MQTT username |
+| `args.4` | Optional MQTT password |
+
+That path writes `/etc/thingino-agent-bootstrap.json` via
+`thingino-agent-bootstrap`, ensures the hub cmd subscription above exists,
+replies on MQTT, then restarts `S95thingino-agent` (and `S91mqttsub` when
+broker settings changed). The agent init script imports the bootstrap once and
+renames it to `.applied` so it is not re-applied on every boot.
+
+If MQTT is not yet available, the camera Web UI **Services → Hub Pairing**
+page can install the same bootstrap locally.
+
 
 ---
 

--- a/docs/mqtt-subscriptions.md
+++ b/docs/mqtt-subscriptions.md
@@ -37,7 +37,7 @@ anywhere in a topic string:
 |---------------|------------------------------------------------------|
 | `%hostname`   | Camera hostname (e.g. `ing-wyze-cam3-592e`)          |
 | `%ip`         | Camera IP address (e.g. `192.168.1.42`)              |
-| `%id`         | MAC address without separators (e.g. `0244dd22592e`) |
+| `%id`         | Canonical camera ID (same as native `GET /api/v1/device`, typically MAC without separators, e.g. `0203823f5533`) |
 
 Example: `cameras/%id/cmd` subscribes to
 `cameras/0244dd22592e/cmd` at runtime.

--- a/docs/thingino/next/camera-web-ui.md
+++ b/docs/thingino/next/camera-web-ui.md
@@ -73,6 +73,9 @@ Good candidates:
 - a last-resort local recovery surface when the hub cannot yet complete the
 	connect or pair flow
 
+Current local pairing fallback: **Services → Hub Pairing** installs a hub
+bearer token via `thingino-agent-bootstrap` and restarts the agent.
+
 Poor candidates:
 
 - large fleet dashboards

--- a/docs/thingino/next/roadmap.md
+++ b/docs/thingino/next/roadmap.md
@@ -123,8 +123,13 @@ Current phase 2 status:
 	- enrollment now also supports token handoff by generating a pairing bundle with a bearer token, `/etc/thingino-agent-bootstrap.json` payload, and exact `jct` or restart commands for the camera
 - partially implemented
 	- enrollment is now guided, validated, and can hand off a token plus bootstrap payload, but it is still a lightweight operator-assisted form rather than a fuller trust-onboarding workflow
+	- camera-side MQTT `install-agent-bootstrap` now parses broker args, uses an
+		agent-owned `thingino-agent-bootstrap` helper, one-shot-consumes the
+		bootstrap file, ensures the hub cmd subscription, and exposes a local
+		Hub Pairing WebUI fallback
 - not implemented yet
-	- deeper pairing features such as trust bootstrap beyond token handoff, camera-side token install automation, or duplicate-resolution guidance
+	- deeper hub pairing features such as trust bootstrap beyond token handoff,
+		or duplicate-resolution guidance
 
 Review questions:
 
@@ -237,8 +242,10 @@ These should stay deferred until the local network architecture works well.
 ## Next recommended work
 
 - add richer per-camera result rendering and retry affordances for dashboard bulk actions
-- extend pairing beyond operator-assisted token handoff into fuller trust bootstrap or camera-side token install automation for first-time camera adoption
+- extend hub pairing beyond operator-assisted token handoff into fuller trust bootstrap
 - add lightweight graph views for the normalized history data that already exists
+- finish remaining on-camera WebUI agent remapping deferred from the consolidated
+	WebUI PR (live MJPEG/JPEG CGIs, deeper recordmgr / send2 editors)
 
 ## Reassessment checklist
 

--- a/package/thingino-agent/files/S95thingino-agent
+++ b/package/thingino-agent/files/S95thingino-agent
@@ -60,7 +60,14 @@ stop_daemon() {
 
 apply_bootstrap_config() {
 	if [ -f "$BOOTSTRAP_CONFIG" ] && command -v jct >/dev/null 2>&1; then
-		jct "$THINGINO_CONFIG" import "$BOOTSTRAP_CONFIG" >/dev/null 2>&1 || true
+		if jct "$THINGINO_CONFIG" import "$BOOTSTRAP_CONFIG" >/dev/null 2>&1; then
+			# One-shot: do not keep re-applying the same bootstrap on every start.
+			mv -f "$BOOTSTRAP_CONFIG" "${BOOTSTRAP_CONFIG}.applied" 2>/dev/null ||
+				rm -f "$BOOTSTRAP_CONFIG"
+			if command -v thingino-agent-bootstrap >/dev/null 2>&1; then
+				thingino-agent-bootstrap ensure-hub-subscription >/dev/null 2>&1 || true
+			fi
+		fi
 	fi
 }
 

--- a/package/thingino-agent/files/thingino-agent-bootstrap
+++ b/package/thingino-agent/files/thingino-agent-bootstrap
@@ -1,0 +1,123 @@
+#!/bin/sh
+#
+# Camera-side agent bootstrap helper for hub pairing.
+# Writes /etc/thingino-agent-bootstrap.json for S95thingino-agent to import,
+# and ensures the hub MQTT command subscription exists.
+#
+
+CONFIG_FILE="${THINGINO_CONFIG:-/etc/thingino.json}"
+BOOTSTRAP_CONFIG="${THINGINO_AGENT_BOOTSTRAP:-/etc/thingino-agent-bootstrap.json}"
+HUB_CMD_TOPIC='thingino/cam/%id/cmd'
+HUB_CMD_ACTION='telegram-cam-agent "$MQTT_PAYLOAD"'
+
+json_escape() {
+	printf '%s' "$1" | sed \
+		-e 's/\\/\\\\/g' \
+		-e 's/"/\\"/g' \
+		-e 's/\r/\\r/g' \
+		-e 's/\n/\\n/g'
+}
+
+usage() {
+	cat <<EOF
+Usage:
+  thingino-agent-bootstrap install <token> [mqtt_host] [mqtt_port] [mqtt_user] [mqtt_pass]
+  thingino-agent-bootstrap ensure-hub-subscription
+EOF
+}
+
+ensure_hub_cmd_subscription() {
+	command -v jct >/dev/null 2>&1 || return 1
+	[ -f "$CONFIG_FILE" ] || printf '{}\n' >"$CONFIG_FILE"
+
+	i=0
+	found=
+	while :; do
+		topic=$(jct "$CONFIG_FILE" get "mqtt_sub.subscriptions.$i.topic" 2>/dev/null | tr -d '"')
+		case "$topic" in
+			"" | null)
+				break
+				;;
+		esac
+		action=$(jct "$CONFIG_FILE" get "mqtt_sub.subscriptions.$i.action" 2>/dev/null | tr -d '"')
+		if [ "$topic" = "$HUB_CMD_TOPIC" ] || echo "$action" | grep -q 'telegram-cam-agent'; then
+			jct "$CONFIG_FILE" set "mqtt_sub.subscriptions.$i.enabled" true >/dev/null 2>&1 || true
+			jct "$CONFIG_FILE" set "mqtt_sub.subscriptions.$i.topic" "$HUB_CMD_TOPIC" >/dev/null 2>&1 || true
+			jct "$CONFIG_FILE" set "mqtt_sub.subscriptions.$i.action" "$HUB_CMD_ACTION" >/dev/null 2>&1 || true
+			jct "$CONFIG_FILE" set "mqtt_sub.subscriptions.$i.qos" 0 >/dev/null 2>&1 || true
+			found=1
+			break
+		fi
+		i=$((i + 1))
+	done
+
+	if [ -z "$found" ]; then
+		jct "$CONFIG_FILE" set "mqtt_sub.subscriptions.$i.enabled" true >/dev/null 2>&1 || return 1
+		jct "$CONFIG_FILE" set "mqtt_sub.subscriptions.$i.topic" "$HUB_CMD_TOPIC" >/dev/null 2>&1 || return 1
+		jct "$CONFIG_FILE" set "mqtt_sub.subscriptions.$i.action" "$HUB_CMD_ACTION" >/dev/null 2>&1 || return 1
+		jct "$CONFIG_FILE" set "mqtt_sub.subscriptions.$i.qos" 0 >/dev/null 2>&1 || return 1
+	fi
+
+	# Keep mqtt_sub enabled when we know a hub subscription is present.
+	jct "$CONFIG_FILE" set mqtt_sub.enabled true >/dev/null 2>&1 || true
+	return 0
+}
+
+install_bootstrap() {
+	token="$1"
+	mqtt_host="$2"
+	mqtt_port="${3:-1883}"
+	mqtt_user="$4"
+	mqtt_pass="$5"
+
+	[ -n "$token" ] || {
+		echo "install requires a bearer token" >&2
+		return 1
+	}
+
+	case "$mqtt_port" in
+		"" | *[!0-9]*) mqtt_port=1883 ;;
+	esac
+
+	umask 077
+	if [ -n "$mqtt_host" ]; then
+		bootstrap_payload=$(printf '{"agent":{"enabled":true,"tls":true,"listen":"0.0.0.0","port":1998,"token":"%s"},"mqtt_sub":{"enabled":true,"host":"%s","port":%s,"username":"%s","password":"%s"}}' \
+			"$(json_escape "$token")" \
+			"$(json_escape "$mqtt_host")" \
+			"$mqtt_port" \
+			"$(json_escape "$mqtt_user")" \
+			"$(json_escape "$mqtt_pass")")
+	else
+		bootstrap_payload=$(printf '{"agent":{"enabled":true,"tls":true,"listen":"0.0.0.0","port":1998,"token":"%s"}}' \
+			"$(json_escape "$token")")
+	fi
+
+	printf '%s\n' "$bootstrap_payload" >"$BOOTSTRAP_CONFIG" || return 1
+
+	# Ensure hub cmd subscription on the live config now so import cannot leave
+	# the camera without a command path (jct import merges and preserves
+	# existing subscriptions when the bootstrap omits them).
+	ensure_hub_cmd_subscription || true
+	return 0
+}
+
+cmd="${1:-}"
+[ "$#" -gt 0 ] && shift
+
+case "$cmd" in
+	install)
+		install_bootstrap "$@"
+		;;
+	ensure-hub-subscription)
+		ensure_hub_cmd_subscription
+		;;
+	"" | -h | --help | help)
+		usage
+		[ -n "$cmd" ]
+		;;
+	*)
+		echo "Unknown command: $cmd" >&2
+		usage >&2
+		exit 1
+		;;
+esac

--- a/package/thingino-agent/files/thingino-camera-id
+++ b/package/thingino-agent/files/thingino-camera-id
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# Print the canonical Thingino camera ID (same source as GET /api/v1/device).
+
+if [ -r /usr/libexec/thingino-agent/lib.sh ]; then
+	# shellcheck disable=SC1091
+	. /usr/libexec/thingino-agent/lib.sh
+	thingino_agent_camera_id
+	exit 0
+fi
+
+clean_mac() {
+	printf '%s' "$1" | tr -d ':\n\r' | tr 'A-F' 'a-f'
+}
+
+if [ -f /etc/thingino.json ] && command -v jct >/dev/null 2>&1; then
+	for key in eth.mac wlan.mac; do
+		value=$(jct /etc/thingino.json get "$key" 2>/dev/null | tr -d '"\n\r')
+		value=$(clean_mac "$value")
+		[ -n "$value" ] && {
+			printf '%s' "$value"
+			exit 0
+		}
+	done
+fi
+
+for env_key in ethaddr wlan_mac; do
+	value=$(fw_printenv -n "$env_key" 2>/dev/null)
+	value=$(clean_mac "$value")
+	[ -n "$value" ] && {
+		printf '%s' "$value"
+		exit 0
+	}
+done
+
+if [ -r /etc/os-release ]; then
+	value=$(grep '^IMAGE_ID=' /etc/os-release 2>/dev/null | cut -d= -f2- | tr -d '"')
+	value=$(clean_mac "$value")
+	[ -n "$value" ] && {
+		printf '%s' "$value"
+		exit 0
+	}
+fi
+
+for iface in eth0 wlan0 eth1; do
+	value=$(cat "/sys/class/net/$iface/address" 2>/dev/null)
+	value=$(clean_mac "$value")
+	[ -n "$value" ] && {
+		printf '%s' "$value"
+		exit 0
+	}
+done
+
+exit 1

--- a/package/thingino-agent/thingino-agent.mk
+++ b/package/thingino-agent/thingino-agent.mk
@@ -30,6 +30,8 @@ define THINGINO_AGENT_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/usr/libexec/thingino-agent/tls-proxy
 	$(INSTALL) -D -m 0755 $(@D)/thingino-agentctl \
 		$(TARGET_DIR)/usr/sbin/thingino-agentctl
+	$(INSTALL) -D -m 0755 $(@D)/thingino-camera-id \
+		$(TARGET_DIR)/usr/sbin/thingino-camera-id
 	$(INSTALL) -D -m 0755 $(@D)/thingino-agent-bootstrap \
 		$(TARGET_DIR)/usr/sbin/thingino-agent-bootstrap
 	$(INSTALL) -D -m 0644 $(@D)/thingino-agent-lib \

--- a/package/thingino-agent/thingino-agent.mk
+++ b/package/thingino-agent/thingino-agent.mk
@@ -30,6 +30,8 @@ define THINGINO_AGENT_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/usr/libexec/thingino-agent/tls-proxy
 	$(INSTALL) -D -m 0755 $(@D)/thingino-agentctl \
 		$(TARGET_DIR)/usr/sbin/thingino-agentctl
+	$(INSTALL) -D -m 0755 $(@D)/thingino-agent-bootstrap \
+		$(TARGET_DIR)/usr/sbin/thingino-agent-bootstrap
 	$(INSTALL) -D -m 0644 $(@D)/thingino-agent-lib \
 		$(TARGET_DIR)/usr/libexec/thingino-agent/lib.sh
 	$(INSTALL) -D -m 0644 $(@D)/thingino-agent-adapter-null \

--- a/package/thingino-webui/files/mqtt-sub-dispatcher
+++ b/package/thingino-webui/files/mqtt-sub-dispatcher
@@ -8,7 +8,7 @@
 # Topic shorthands (resolved at startup):
 #   %hostname - camera hostname
 #   %ip       - camera IP address
-#   %id       - camera hostname
+#   %id       - canonical camera ID (matches native GET /api/v1/device)
 
 CONFIG_FILE="/etc/thingino.json"
 HEARTBEAT_INTERVAL="${HEARTBEAT_INTERVAL:-300}"
@@ -60,7 +60,20 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 camera_id() {
-	hostname 2>/dev/null || echo "thingino"
+	if command -v thingino-camera-id >/dev/null 2>&1; then
+		thingino-camera-id
+		return $?
+	fi
+
+	for iface in eth0 wlan0 eth1; do
+		addr=$(cat "/sys/class/net/$iface/address" 2>/dev/null | tr -d ':')
+		[ -n "$addr" ] && {
+			printf '%s' "$addr"
+			return 0
+		}
+	done
+
+	return 1
 }
 
 # Resolve camera identity once at startup

--- a/package/thingino-webui/files/telegram-cam-agent
+++ b/package/thingino-webui/files/telegram-cam-agent
@@ -12,12 +12,9 @@ json_escape() {
 }
 
 camera_id() {
-	if command -v soc >/dev/null 2>&1; then
-		serial=$(soc -s 2>/dev/null)
-		if [ -n "$serial" ]; then
-			printf '%s' "$serial"
-			return 0
-		fi
+	if command -v thingino-camera-id >/dev/null 2>&1; then
+		thingino-camera-id
+		return $?
 	fi
 
 	for iface in eth0 wlan0 eth1; do

--- a/package/thingino-webui/files/telegram-cam-agent
+++ b/package/thingino-webui/files/telegram-cam-agent
@@ -101,6 +101,10 @@ CHAT_ID=$(jct "$TMP" get chat_id 2>/dev/null | tr -d '"')
 TARGET_CAMERA_ID=$(jct "$TMP" get camera_id 2>/dev/null | tr -d '"' | tr 'A-Z' 'a-z')
 COMMAND=$(jct "$TMP" get command 2>/dev/null | tr -d '"' | tr 'A-Z' 'a-z')
 ARG0=$(jct "$TMP" get args.0 2>/dev/null | tr -d '"')
+ARG1=$(jct "$TMP" get args.1 2>/dev/null | tr -d '"')
+ARG2=$(jct "$TMP" get args.2 2>/dev/null | tr -d '"')
+ARG3=$(jct "$TMP" get args.3 2>/dev/null | tr -d '"')
+ARG4=$(jct "$TMP" get args.4 2>/dev/null | tr -d '"')
 
 [ -n "$REQUEST_ID" ] || REQUEST_ID="local"
 
@@ -159,22 +163,20 @@ case "$COMMAND" in
 		;;
 	install-agent-bootstrap)
 		[ -n "$ARG0" ] || reply_error_and_exit "install-agent-bootstrap requires a bearer token"
-		mqtt_host=$(json_escape "$ARG1")
-		mqtt_port=${ARG2:-1883}
-		mqtt_username=$(json_escape "$ARG3")
-		mqtt_password=$(json_escape "$ARG4")
-		if [ -n "$ARG1" ]; then
-			bootstrap_payload=$(printf '{"agent":{"enabled":true,"tls":true,"listen":"0.0.0.0","port":1998,"token":"%s"},"mqtt_sub":{"enabled":true,"host":"%s","port":%s,"username":"%s","password":"%s"}}' \
-				"$(json_escape "$ARG0")" "$mqtt_host" "$mqtt_port" "$mqtt_username" "$mqtt_password")
-		else
-			bootstrap_payload=$(printf '{"agent":{"enabled":true,"tls":true,"listen":"0.0.0.0","port":1998,"token":"%s"}}' "$(json_escape "$ARG0")")
+		if ! command -v thingino-agent-bootstrap >/dev/null 2>&1; then
+			reply_error_and_exit "thingino-agent-bootstrap helper is not installed"
 		fi
-		if printf '%s\n' "$bootstrap_payload" >/etc/thingino-agent-bootstrap.json; then
-			# Reply before restarting the agent so the MQTT client is still alive
-			# when the reply is published. The restart would otherwise kill the
-			# connection before mosquitto_pub can send the reply.
+		if thingino-agent-bootstrap install "$ARG0" "$ARG1" "$ARG2" "$ARG3" "$ARG4"; then
+			# Reply before restarting so the MQTT client is still alive when the
+			# reply is published. Restart mqtt-sub when broker settings may have
+			# changed so the hub cmd subscription is picked up.
 			publish_reply "$REQUEST_ID" "$CHAT_ID" "Agent bootstrap installed" "$LOCAL_CAMERA_ID" true >/dev/null 2>&1 || true
-			(/etc/init.d/S95thingino-agent restart >/dev/null 2>&1) &
+			(
+				/etc/init.d/S95thingino-agent restart >/dev/null 2>&1 || true
+				if [ -n "$ARG1" ] && [ -x /etc/init.d/S91mqttsub ]; then
+					/etc/init.d/S91mqttsub restart >/dev/null 2>&1 || true
+				fi
+			) &
 			printf 'Agent bootstrap installed\n'
 			exit 0
 		fi

--- a/package/thingino-webui/files/telegram-cam-register
+++ b/package/thingino-webui/files/telegram-cam-register
@@ -13,12 +13,9 @@ json_escape() {
 }
 
 camera_id() {
-	if command -v soc >/dev/null 2>&1; then
-		serial=$(soc -s 2>/dev/null)
-		if [ -n "$serial" ]; then
-			printf '%s' "$serial"
-			return 0
-		fi
+	if command -v thingino-camera-id >/dev/null 2>&1; then
+		thingino-camera-id
+		return $?
 	fi
 
 	for iface in eth0 wlan0 eth1; do

--- a/package/thingino-webui/files/www/a/navigation.js
+++ b/package/thingino-webui/files/www/a/navigation.js
@@ -148,6 +148,7 @@
           { label: "Timelapse Recorder", href: "/tool-timelapse.html" },
           { label: "Video Recorder", href: "/tool-record.html" },
           { label: "Home Assistant", href: "/config-ha.html" },
+          { label: "Hub Pairing", href: "/tool-agent-pair.html" },
         ],
       },
       {

--- a/package/thingino-webui/files/www/a/tool-agent-pair.js
+++ b/package/thingino-webui/files/www/a/tool-agent-pair.js
@@ -4,12 +4,70 @@
   const endpoint = "/x/json-agent-pair.cgi";
   const form = $("#agentPairForm");
   const statusEl = $("#agent-pair-status");
+  const tokenConfiguredEl = $("#agent-pair-token-configured");
+  const mqttConfiguredEl = $("#agent-pair-mqtt-configured");
+  const updateMqttEl = $("#agent_pair_update_mqtt");
   const reloadBtn = $("#agent-pair-reload");
   const saveBtn = $("#agent-pair-save");
+  const mqttFields = [
+    $("#agent_pair_mqtt_host"),
+    $("#agent_pair_mqtt_port"),
+    $("#agent_pair_mqtt_username"),
+    $("#agent_pair_mqtt_password"),
+  ];
+
+  let hasToken = false;
+  let mqttState = {
+    configured: false,
+    enabled: false,
+    host: "",
+    port: 1883,
+    username: "",
+    has_password: false,
+  };
 
   function setStatus(text, tone) {
     statusEl.className = "alert alert-" + (tone || "secondary") + " mb-4";
     statusEl.textContent = text;
+  }
+
+  function setMqttEditable(editable) {
+    mqttFields.forEach(function (el) {
+      el.disabled = !editable;
+    });
+    if (!editable) {
+      $("#agent_pair_mqtt_host").value = mqttState.host || "";
+      $("#agent_pair_mqtt_port").value = mqttState.port || 1883;
+      $("#agent_pair_mqtt_username").value = mqttState.username || "";
+      $("#agent_pair_mqtt_password").value = "";
+      $("#agent_pair_mqtt_password").placeholder = mqttState.has_password
+        ? "••••••••"
+        : "";
+    } else {
+      $("#agent_pair_mqtt_password").placeholder = mqttState.has_password
+        ? "leave blank to keep current password"
+        : "";
+    }
+  }
+
+  function renderConfiguredBanners() {
+    tokenConfiguredEl.classList.toggle("d-none", !hasToken);
+
+    if (mqttState.configured) {
+      const userBit = mqttState.username
+        ? " as " + mqttState.username
+        : "";
+      mqttConfiguredEl.textContent =
+        "Configured: " +
+        mqttState.host +
+        ":" +
+        (mqttState.port || 1883) +
+        userBit +
+        (mqttState.enabled ? "" : " (mqtt_sub disabled)");
+      mqttConfiguredEl.classList.remove("d-none");
+    } else {
+      mqttConfiguredEl.classList.add("d-none");
+    }
   }
 
   function loadStatus() {
@@ -21,40 +79,78 @@
       })
       .then(function (data) {
         const agent = (data && data.agent) || {};
+        const mqtt = (data && data.mqtt_sub) || {};
+        hasToken = !!agent.has_token;
+        mqttState = {
+          configured: !!mqtt.configured,
+          enabled: !!mqtt.enabled,
+          host: mqtt.host || "",
+          port: mqtt.port || 1883,
+          username: mqtt.username || "",
+          has_password: !!mqtt.has_password,
+        };
+
         const parts = [
           "enabled=" + String(agent.enabled),
           "tls=" + String(agent.tls),
           "listen=" + String(agent.listen || ""),
           "port=" + String(agent.port || ""),
-          "token=" + (agent.has_token ? "configured" : "missing"),
+          "token=" + (hasToken ? "configured" : "missing"),
         ];
+        if (mqttState.configured) {
+          parts.push("mqtt=" + mqttState.host + ":" + mqttState.port);
+        }
         if (data && data.bootstrap_pending) {
           parts.push("bootstrap=pending");
         }
         setStatus("Agent status: " + parts.join(", "), "info");
+
         if (agent.listen) $("#agent_pair_listen").value = agent.listen;
         if (agent.port) $("#agent_pair_port").value = agent.port;
         if (typeof agent.tls === "boolean") {
           $("#agent_pair_tls").checked = agent.tls;
         }
+
+        $("#agent_pair_token").required = !hasToken;
+        updateMqttEl.checked = false;
+        renderConfiguredBanners();
+        setMqttEditable(false);
       })
       .catch(function (err) {
         setStatus("Failed to load agent status: " + err.message, "danger");
       });
   }
 
+  updateMqttEl.addEventListener("change", function () {
+    setMqttEditable(updateMqttEl.checked);
+  });
+
   form.addEventListener("submit", function (ev) {
     ev.preventDefault();
+    const token = $("#agent_pair_token").value.trim();
+    if (!token && !hasToken) {
+      form.classList.add("was-validated");
+      $("#agent_pair_token").required = true;
+      return;
+    }
+    if (updateMqttEl.checked && !$("#agent_pair_mqtt_host").value.trim()) {
+      form.classList.add("was-validated");
+      $("#agent_pair_mqtt_host").setCustomValidity("Broker address required");
+      $("#agent_pair_mqtt_host").reportValidity();
+      return;
+    }
+    $("#agent_pair_mqtt_host").setCustomValidity("");
     if (!form.checkValidity()) {
       form.classList.add("was-validated");
       return;
     }
 
     const body = {
-      token: $("#agent_pair_token").value.trim(),
+      token: token,
       tls: $("#agent_pair_tls").checked,
       listen: $("#agent_pair_listen").value.trim() || "0.0.0.0",
       port: Number($("#agent_pair_port").value) || 1998,
+      update_mqtt: updateMqttEl.checked,
       mqtt_host: $("#agent_pair_mqtt_host").value.trim(),
       mqtt_port: Number($("#agent_pair_mqtt_port").value) || 1883,
       mqtt_username: $("#agent_pair_mqtt_username").value.trim(),

--- a/package/thingino-webui/files/www/a/tool-agent-pair.js
+++ b/package/thingino-webui/files/www/a/tool-agent-pair.js
@@ -1,0 +1,105 @@
+(function () {
+  "use strict";
+
+  const endpoint = "/x/json-agent-pair.cgi";
+  const form = $("#agentPairForm");
+  const statusEl = $("#agent-pair-status");
+  const reloadBtn = $("#agent-pair-reload");
+  const saveBtn = $("#agent-pair-save");
+
+  function setStatus(text, tone) {
+    statusEl.className = "alert alert-" + (tone || "secondary") + " mb-4";
+    statusEl.textContent = text;
+  }
+
+  function loadStatus() {
+    setStatus("Loading agent status…", "secondary");
+    return fetch(endpoint, { credentials: "same-origin" })
+      .then(function (res) {
+        if (!res.ok) throw new Error("HTTP " + res.status);
+        return res.json();
+      })
+      .then(function (data) {
+        const agent = (data && data.agent) || {};
+        const parts = [
+          "enabled=" + String(agent.enabled),
+          "tls=" + String(agent.tls),
+          "listen=" + String(agent.listen || ""),
+          "port=" + String(agent.port || ""),
+          "token=" + (agent.has_token ? "configured" : "missing"),
+        ];
+        if (data && data.bootstrap_pending) {
+          parts.push("bootstrap=pending");
+        }
+        setStatus("Agent status: " + parts.join(", "), "info");
+        if (agent.listen) $("#agent_pair_listen").value = agent.listen;
+        if (agent.port) $("#agent_pair_port").value = agent.port;
+        if (typeof agent.tls === "boolean") {
+          $("#agent_pair_tls").checked = agent.tls;
+        }
+      })
+      .catch(function (err) {
+        setStatus("Failed to load agent status: " + err.message, "danger");
+      });
+  }
+
+  form.addEventListener("submit", function (ev) {
+    ev.preventDefault();
+    if (!form.checkValidity()) {
+      form.classList.add("was-validated");
+      return;
+    }
+
+    const body = {
+      token: $("#agent_pair_token").value.trim(),
+      tls: $("#agent_pair_tls").checked,
+      listen: $("#agent_pair_listen").value.trim() || "0.0.0.0",
+      port: Number($("#agent_pair_port").value) || 1998,
+      mqtt_host: $("#agent_pair_mqtt_host").value.trim(),
+      mqtt_port: Number($("#agent_pair_mqtt_port").value) || 1883,
+      mqtt_username: $("#agent_pair_mqtt_username").value.trim(),
+      mqtt_password: $("#agent_pair_mqtt_password").value,
+    };
+
+    saveBtn.disabled = true;
+    setStatus("Writing bootstrap and restarting agent…", "secondary");
+
+    fetch(endpoint, {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    })
+      .then(function (res) {
+        return res.json().then(function (data) {
+          if (!res.ok || (data && data.ok === false)) {
+            const msg =
+              (data && data.error && data.error.message) ||
+              "HTTP " + res.status;
+            throw new Error(msg);
+          }
+          return data;
+        });
+      })
+      .then(function (data) {
+        setStatus(
+          (data && data.message) || "Bootstrap installed; agent restart queued",
+          "success",
+        );
+        $("#agent_pair_token").value = "";
+        setTimeout(loadStatus, 1500);
+      })
+      .catch(function (err) {
+        setStatus("Pairing failed: " + err.message, "danger");
+      })
+      .finally(function () {
+        saveBtn.disabled = false;
+      });
+  });
+
+  reloadBtn.addEventListener("click", function () {
+    loadStatus();
+  });
+
+  loadStatus();
+})();

--- a/package/thingino-webui/files/www/tool-agent-pair.html
+++ b/package/thingino-webui/files/www/tool-agent-pair.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Hub Pairing</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+</head>
+
+<body id="page-tool-agent-pair">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container" style="min-height:80vh">
+    <div data-app-controls></div>
+
+    <section>
+      <form id="agentPairForm" class="needs-validation" novalidate autocomplete="off">
+        <div class="card mb-3">
+          <div class="card-header">
+            <h2 class="card-title">Hub Pairing</h2>
+            <small>Last-resort local install of a hub-issued agent token when MQTT bootstrap is not available yet</small>
+            <button type="button" class="btn btn-outline-secondary" id="agent-pair-reload" title="Reload status">
+              <i class="bi bi-arrow-clockwise"></i> Reload
+            </button>
+          </div>
+          <div class="card-body">
+            <div id="agent-pair-status" class="alert alert-secondary mb-4" role="status">Loading agent status…</div>
+
+            <div class="row g-4">
+              <div class="col-12 col-lg-6">
+                <h4>Agent token</h4>
+                <small>Paste the bearer token from the hub enrollment / pairing bundle</small>
+                <p>
+                  <label for="agent_pair_token">Bearer token</label>
+                  <input type="password" class="form-control" id="agent_pair_token" required autocomplete="off">
+                  <div class="invalid-feedback">Token is required.</div>
+                </p>
+                <p class="form-switch">
+                  <input type="checkbox" class="form-check-input" id="agent_pair_tls" role="switch" checked>
+                  <label class="form-check-label" for="agent_pair_tls">Enable TLS for remote agent access</label>
+                </p>
+                <div class="row g-1 mb-3">
+                  <div class="col-9">
+                    <label for="agent_pair_listen">Listen address</label>
+                    <input type="text" class="form-control" id="agent_pair_listen" value="0.0.0.0">
+                  </div>
+                  <div class="col-3">
+                    <label for="agent_pair_port">Port</label>
+                    <input type="number" class="form-control" id="agent_pair_port" value="1998" min="1" max="65535">
+                  </div>
+                </div>
+              </div>
+              <div class="col-12 col-lg-6">
+                <h4>Optional MQTT broker</h4>
+                <small>Fill these when the hub also needs camera mqtt_sub broker settings updated</small>
+                <div class="row g-1 mb-3">
+                  <div class="col-9">
+                    <label for="agent_pair_mqtt_host">Broker address</label>
+                    <input type="text" class="form-control" id="agent_pair_mqtt_host" placeholder="192.168.1.100">
+                  </div>
+                  <div class="col-3">
+                    <label for="agent_pair_mqtt_port">Port</label>
+                    <input type="number" class="form-control" id="agent_pair_mqtt_port" value="1883" min="1" max="65535">
+                  </div>
+                </div>
+                <p>
+                  <label for="agent_pair_mqtt_username">Username</label>
+                  <input type="text" class="form-control" id="agent_pair_mqtt_username" autocomplete="username">
+                </p>
+                <p>
+                  <label for="agent_pair_mqtt_password">Password</label>
+                  <input type="password" class="form-control" id="agent_pair_mqtt_password" autocomplete="current-password">
+                </p>
+              </div>
+            </div>
+          </div>
+          <div class="card-footer text-end">
+            <button type="submit" class="btn btn-primary" id="agent-pair-save">
+              <i class="bi bi-link-45deg me-1"></i>Install bootstrap and restart agent
+            </button>
+          </div>
+        </div>
+      </form>
+    </section>
+  </div>
+</main>
+
+<footer data-app-footer></footer>
+<script src="/a/main.js"></script>
+<script src="/a/tool-agent-pair.js"></script>
+</body>
+</html>

--- a/package/thingino-webui/files/www/tool-agent-pair.html
+++ b/package/thingino-webui/files/www/tool-agent-pair.html
@@ -27,13 +27,20 @@
         <div class="card mb-3">
           <div class="card-header">
             <h2 class="card-title">Hub Pairing</h2>
-            <small>Last-resort local install of a hub-issued agent token when MQTT bootstrap is not available yet</small>
+            <small>Last-resort local install when the hub cannot push pairing over MQTT yet</small>
             <button type="button" class="btn btn-outline-secondary" id="agent-pair-reload" title="Reload status">
               <i class="bi bi-arrow-clockwise"></i> Reload
             </button>
           </div>
           <div class="card-body">
             <div id="agent-pair-status" class="alert alert-secondary mb-4" role="status">Loading agent status…</div>
+            <p class="text-body-secondary small mb-4">
+              Prefer pairing from the Thingino Hub whenever possible (Connect → Install Pairing Bundle).
+              The hub generates the bearer token and installs it on this camera.
+              Use this page only if MQTT bootstrap is unavailable: paste the <strong>hub-issued</strong> token
+              from Hub → Enroll → <em>Show Pairing Details</em> (or from a pairing install summary), then save.
+              Do not invent a random token here unless you also store that exact same token in the hub.
+            </p>
             <p class="text-body-secondary small mb-4">
               Leaving MQTT fields alone keeps the current broker settings.
               Day-to-day MQTT edits belong under <a href="/tool-mqtt-sub.html">Services → MQTT Subscriptions</a>.
@@ -42,7 +49,7 @@
             <div class="row g-4">
               <div class="col-12 col-lg-6">
                 <h4>Agent token</h4>
-                <small>Paste a hub bearer token, or leave blank to keep the configured token</small>
+                <small>Paste the bearer token issued by the hub, or leave blank to keep the configured token</small>
                 <div id="agent-pair-token-configured" class="alert alert-success py-2 d-none" role="status">
                   Token configured
                 </div>

--- a/package/thingino-webui/files/www/tool-agent-pair.html
+++ b/package/thingino-webui/files/www/tool-agent-pair.html
@@ -34,15 +34,22 @@
           </div>
           <div class="card-body">
             <div id="agent-pair-status" class="alert alert-secondary mb-4" role="status">Loading agent status…</div>
+            <p class="text-body-secondary small mb-4">
+              Leaving MQTT fields alone keeps the current broker settings.
+              Day-to-day MQTT edits belong under <a href="/tool-mqtt-sub.html">Services → MQTT Subscriptions</a>.
+            </p>
 
             <div class="row g-4">
               <div class="col-12 col-lg-6">
                 <h4>Agent token</h4>
-                <small>Paste the bearer token from the hub enrollment / pairing bundle</small>
+                <small>Paste a hub bearer token, or leave blank to keep the configured token</small>
+                <div id="agent-pair-token-configured" class="alert alert-success py-2 d-none" role="status">
+                  Token configured
+                </div>
                 <p>
                   <label for="agent_pair_token">Bearer token</label>
-                  <input type="password" class="form-control" id="agent_pair_token" required autocomplete="off">
-                  <div class="invalid-feedback">Token is required.</div>
+                  <input type="password" class="form-control" id="agent_pair_token" autocomplete="off">
+                  <div class="invalid-feedback">Token is required when none is configured yet.</div>
                 </p>
                 <p class="form-switch">
                   <input type="checkbox" class="form-check-input" id="agent_pair_tls" role="switch" checked>
@@ -61,24 +68,30 @@
               </div>
               <div class="col-12 col-lg-6">
                 <h4>Optional MQTT broker</h4>
-                <small>Fill these when the hub also needs camera mqtt_sub broker settings updated</small>
+                <small>Only rewrite broker settings when you explicitly choose to update them</small>
+                <div id="agent-pair-mqtt-configured" class="alert alert-success py-2 d-none" role="status"></div>
+                <p class="form-switch">
+                  <input type="checkbox" class="form-check-input" id="agent_pair_update_mqtt" role="switch">
+                  <label class="form-check-label" for="agent_pair_update_mqtt">Update MQTT broker details</label>
+                </p>
                 <div class="row g-1 mb-3">
                   <div class="col-9">
                     <label for="agent_pair_mqtt_host">Broker address</label>
-                    <input type="text" class="form-control" id="agent_pair_mqtt_host" placeholder="192.168.1.100">
+                    <input type="text" class="form-control" id="agent_pair_mqtt_host" placeholder="192.168.1.100" disabled>
                   </div>
                   <div class="col-3">
                     <label for="agent_pair_mqtt_port">Port</label>
-                    <input type="number" class="form-control" id="agent_pair_mqtt_port" value="1883" min="1" max="65535">
+                    <input type="number" class="form-control" id="agent_pair_mqtt_port" value="1883" min="1" max="65535" disabled>
                   </div>
                 </div>
                 <p>
                   <label for="agent_pair_mqtt_username">Username</label>
-                  <input type="text" class="form-control" id="agent_pair_mqtt_username" autocomplete="username">
+                  <input type="text" class="form-control" id="agent_pair_mqtt_username" autocomplete="username" disabled>
                 </p>
                 <p>
                   <label for="agent_pair_mqtt_password">Password</label>
-                  <input type="password" class="form-control" id="agent_pair_mqtt_password" autocomplete="current-password">
+                  <input type="password" class="form-control" id="agent_pair_mqtt_password" autocomplete="current-password" disabled placeholder="••••••••">
+                  <small class="text-body-secondary">Leave blank while updating to keep the current password.</small>
                 </p>
               </div>
             </div>

--- a/package/thingino-webui/files/www/tool-agent-pair.html
+++ b/package/thingino-webui/files/www/tool-agent-pair.html
@@ -95,7 +95,14 @@
 </main>
 
 <footer data-app-footer></footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
 <script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
 <script src="/a/tool-agent-pair.js"></script>
 </body>
 </html>

--- a/package/thingino-webui/files/www/x/json-agent-pair.cgi
+++ b/package/thingino-webui/files/www/x/json-agent-pair.cgi
@@ -1,0 +1,139 @@
+#!/bin/sh
+
+. /var/www/x/auth.sh
+require_auth
+
+THINGINO_CONFIG="${THINGINO_CONFIG:-/etc/thingino.json}"
+BOOTSTRAP_CONFIG="${THINGINO_AGENT_BOOTSTRAP:-/etc/thingino-agent-bootstrap.json}"
+TMP_FILE=""
+
+cleanup() {
+	[ -n "$TMP_FILE" ] && rm -f "$TMP_FILE"
+}
+trap cleanup EXIT
+
+json_escape() {
+	printf '%s' "$1" | sed \
+		-e 's/\\/\\\\/g' \
+		-e 's/"/\\"/g' \
+		-e 's/\r/\\r/g' \
+		-e 's/\n/\\n/g'
+}
+
+send_json() {
+	status="${2:-200 OK}"
+	printf "Status: %s\r\n" "$status"
+	printf "Content-Type: application/json\r\n"
+	printf "Cache-Control: no-store\r\n"
+	printf "Pragma: no-cache\r\n"
+	printf "Connection: close\r\n"
+	printf "\r\n"
+	printf "%s\n" "$1"
+	exit 0
+}
+
+json_error() {
+	code="${1:-500}"
+	message="$2"
+	http="${3:-500 Internal Server Error}"
+	send_json "{\"ok\":false,\"error\":{\"code\":$code,\"message\":\"$(json_escape "$message")\"}}" "$http"
+}
+
+strip_json_string() {
+	case "$1" in
+		"" | null) printf '' ;;
+		*) printf '%s' "$1" | sed -e 's/^"//' -e 's/"$//' ;;
+	esac
+}
+
+normalize_bool() {
+	case "$(printf '%s' "$1" | tr 'A-Z' 'a-z')" in
+		1 | true | yes | on) printf 'true' ;;
+		0 | false | no | off | "" | null) printf 'false' ;;
+		*) json_error 422 "Invalid boolean value" "422 Unprocessable Entity" ;;
+	esac
+}
+
+read_status() {
+	token=$(jct "$THINGINO_CONFIG" get agent.token 2>/dev/null | tr -d '"\n\r')
+	enabled=$(jct "$THINGINO_CONFIG" get agent.enabled 2>/dev/null | tr -d '"\n\r')
+	tls=$(jct "$THINGINO_CONFIG" get agent.tls 2>/dev/null | tr -d '"\n\r')
+	listen=$(jct "$THINGINO_CONFIG" get agent.listen 2>/dev/null | tr -d '"\n\r')
+	port=$(jct "$THINGINO_CONFIG" get agent.port 2>/dev/null | tr -d '"\n\r')
+	[ -n "$enabled" ] || enabled=false
+	[ -n "$tls" ] || tls=false
+	[ -n "$listen" ] || listen="127.0.0.1"
+	[ -n "$port" ] || port=1998
+	has_token=false
+	[ -n "$token" ] && has_token=true
+	pending=false
+	[ -f "$BOOTSTRAP_CONFIG" ] && pending=true
+	printf '{"ok":true,"agent":{"enabled":%s,"tls":%s,"listen":"%s","port":%s,"has_token":%s},"bootstrap_pending":%s}' \
+		"$enabled" "$tls" "$(json_escape "$listen")" "$port" "$has_token" "$pending"
+}
+
+handle_get() {
+	send_json "$(read_status)"
+}
+
+handle_post() {
+	TMP_FILE=$(mktemp /tmp/agent-pair.XXXXXX)
+	if [ -n "$CONTENT_LENGTH" ]; then
+		dd bs=1 count="$CONTENT_LENGTH" 2>/dev/null >"$TMP_FILE"
+	else
+		cat >"$TMP_FILE"
+	fi
+
+	token=$(strip_json_string "$(jct "$TMP_FILE" get token 2>/dev/null)")
+	tls=$(normalize_bool "$(jct "$TMP_FILE" get tls 2>/dev/null)")
+	listen=$(strip_json_string "$(jct "$TMP_FILE" get listen 2>/dev/null)")
+	port=$(strip_json_string "$(jct "$TMP_FILE" get port 2>/dev/null)")
+	mqtt_host=$(strip_json_string "$(jct "$TMP_FILE" get mqtt_host 2>/dev/null)")
+	mqtt_port=$(strip_json_string "$(jct "$TMP_FILE" get mqtt_port 2>/dev/null)")
+	mqtt_username=$(strip_json_string "$(jct "$TMP_FILE" get mqtt_username 2>/dev/null)")
+	mqtt_password=$(strip_json_string "$(jct "$TMP_FILE" get mqtt_password 2>/dev/null)")
+
+	[ -n "$token" ] || json_error 422 "Bearer token is required" "422 Unprocessable Entity"
+	[ -n "$listen" ] || listen="0.0.0.0"
+	[ -n "$port" ] || port=1998
+	case "$port" in
+		*[!0-9]*) json_error 422 "Invalid agent port" "422 Unprocessable Entity" ;;
+	esac
+
+	if ! command -v thingino-agent-bootstrap >/dev/null 2>&1; then
+		json_error 503 "thingino-agent-bootstrap helper is not installed" "503 Service Unavailable"
+	fi
+
+	# Prefer the shared helper for token + optional broker fields, then overlay
+	# listen/tls/port into the bootstrap payload before restart.
+	if ! thingino-agent-bootstrap install "$token" "$mqtt_host" "$mqtt_port" "$mqtt_username" "$mqtt_password"; then
+		json_error 500 "Failed to write agent bootstrap"
+	fi
+
+	overlay=$(mktemp /tmp/agent-pair-overlay.XXXXXX)
+	printf '{"agent":{"enabled":true,"tls":%s,"listen":"%s","port":%s,"token":"%s"}}\n' \
+		"$tls" "$(json_escape "$listen")" "$port" "$(json_escape "$token")" >"$overlay"
+	jct "$BOOTSTRAP_CONFIG" import "$overlay" >/dev/null 2>&1 || true
+	rm -f "$overlay"
+
+	(
+		/etc/init.d/S95thingino-agent restart >/dev/null 2>&1 || true
+		if [ -n "$mqtt_host" ] && [ -x /etc/init.d/S91mqttsub ]; then
+			/etc/init.d/S91mqttsub restart >/dev/null 2>&1 || true
+		fi
+	) &
+
+	send_json '{"ok":true,"status":"accepted","message":"Agent bootstrap written; agent restart queued"}'
+}
+
+case "$REQUEST_METHOD" in
+	GET | "")
+		handle_get
+		;;
+	POST)
+		handle_post
+		;;
+	*)
+		json_error 405 "Method not allowed" "405 Method Not Allowed"
+		;;
+esac

--- a/package/thingino-webui/files/www/x/json-agent-pair.cgi
+++ b/package/thingino-webui/files/www/x/json-agent-pair.cgi
@@ -60,16 +60,32 @@ read_status() {
 	tls=$(jct "$THINGINO_CONFIG" get agent.tls 2>/dev/null | tr -d '"\n\r')
 	listen=$(jct "$THINGINO_CONFIG" get agent.listen 2>/dev/null | tr -d '"\n\r')
 	port=$(jct "$THINGINO_CONFIG" get agent.port 2>/dev/null | tr -d '"\n\r')
+	mqtt_enabled=$(jct "$THINGINO_CONFIG" get mqtt_sub.enabled 2>/dev/null | tr -d '"\n\r')
+	mqtt_host=$(jct "$THINGINO_CONFIG" get mqtt_sub.host 2>/dev/null | tr -d '"\n\r')
+	mqtt_port=$(jct "$THINGINO_CONFIG" get mqtt_sub.port 2>/dev/null | tr -d '"\n\r')
+	mqtt_username=$(jct "$THINGINO_CONFIG" get mqtt_sub.username 2>/dev/null | tr -d '"\n\r')
+	mqtt_password=$(jct "$THINGINO_CONFIG" get mqtt_sub.password 2>/dev/null | tr -d '"\n\r')
+
 	[ -n "$enabled" ] || enabled=false
 	[ -n "$tls" ] || tls=false
 	[ -n "$listen" ] || listen="127.0.0.1"
 	[ -n "$port" ] || port=1998
+	[ -n "$mqtt_enabled" ] || mqtt_enabled=false
+	[ -n "$mqtt_port" ] || mqtt_port=1883
+
 	has_token=false
 	[ -n "$token" ] && has_token=true
 	pending=false
 	[ -f "$BOOTSTRAP_CONFIG" ] && pending=true
-	printf '{"ok":true,"agent":{"enabled":%s,"tls":%s,"listen":"%s","port":%s,"has_token":%s},"bootstrap_pending":%s}' \
-		"$enabled" "$tls" "$(json_escape "$listen")" "$port" "$has_token" "$pending"
+	mqtt_configured=false
+	[ -n "$mqtt_host" ] && mqtt_configured=true
+	has_mqtt_password=false
+	[ -n "$mqtt_password" ] && has_mqtt_password=true
+
+	printf '{"ok":true,"agent":{"enabled":%s,"tls":%s,"listen":"%s","port":%s,"has_token":%s},"mqtt_sub":{"configured":%s,"enabled":%s,"host":"%s","port":%s,"username":"%s","has_password":%s},"bootstrap_pending":%s}' \
+		"$enabled" "$tls" "$(json_escape "$listen")" "$port" "$has_token" \
+		"$mqtt_configured" "$mqtt_enabled" "$(json_escape "$mqtt_host")" "$mqtt_port" \
+		"$(json_escape "$mqtt_username")" "$has_mqtt_password" "$pending"
 }
 
 handle_get() {
@@ -88,11 +104,16 @@ handle_post() {
 	tls=$(normalize_bool "$(jct "$TMP_FILE" get tls 2>/dev/null)")
 	listen=$(strip_json_string "$(jct "$TMP_FILE" get listen 2>/dev/null)")
 	port=$(strip_json_string "$(jct "$TMP_FILE" get port 2>/dev/null)")
+	update_mqtt=$(normalize_bool "$(jct "$TMP_FILE" get update_mqtt 2>/dev/null)")
 	mqtt_host=$(strip_json_string "$(jct "$TMP_FILE" get mqtt_host 2>/dev/null)")
 	mqtt_port=$(strip_json_string "$(jct "$TMP_FILE" get mqtt_port 2>/dev/null)")
 	mqtt_username=$(strip_json_string "$(jct "$TMP_FILE" get mqtt_username 2>/dev/null)")
 	mqtt_password=$(strip_json_string "$(jct "$TMP_FILE" get mqtt_password 2>/dev/null)")
 
+	existing_token=$(jct "$THINGINO_CONFIG" get agent.token 2>/dev/null | tr -d '"\n\r')
+	if [ -z "$token" ]; then
+		token="$existing_token"
+	fi
 	[ -n "$token" ] || json_error 422 "Bearer token is required" "422 Unprocessable Entity"
 	[ -n "$listen" ] || listen="0.0.0.0"
 	[ -n "$port" ] || port=1998
@@ -104,9 +125,25 @@ handle_post() {
 		json_error 503 "thingino-agent-bootstrap helper is not installed" "503 Service Unavailable"
 	fi
 
-	# Prefer the shared helper for token + optional broker fields, then overlay
-	# listen/tls/port into the bootstrap payload before restart.
-	if ! thingino-agent-bootstrap install "$token" "$mqtt_host" "$mqtt_port" "$mqtt_username" "$mqtt_password"; then
+	# Empty MQTT fields preserve existing mqtt_sub (helper writes agent-only JSON).
+	# Only rewrite broker settings when the operator explicitly updates them.
+	install_host=
+	install_port=
+	install_user=
+	install_pass=
+	if [ "$update_mqtt" = true ]; then
+		[ -n "$mqtt_host" ] || json_error 422 "MQTT broker address is required when updating MQTT settings" "422 Unprocessable Entity"
+		install_host="$mqtt_host"
+		install_port="${mqtt_port:-1883}"
+		install_user="$mqtt_username"
+		install_pass="$mqtt_password"
+		# Keep the existing password when the operator leaves the masked field blank.
+		if [ -z "$install_pass" ]; then
+			install_pass=$(jct "$THINGINO_CONFIG" get mqtt_sub.password 2>/dev/null | tr -d '"\n\r')
+		fi
+	fi
+
+	if ! thingino-agent-bootstrap install "$token" "$install_host" "$install_port" "$install_user" "$install_pass"; then
 		json_error 500 "Failed to write agent bootstrap"
 	fi
 
@@ -118,7 +155,7 @@ handle_post() {
 
 	(
 		/etc/init.d/S95thingino-agent restart >/dev/null 2>&1 || true
-		if [ -n "$mqtt_host" ] && [ -x /etc/init.d/S91mqttsub ]; then
+		if [ "$update_mqtt" = true ] && [ -x /etc/init.d/S91mqttsub ]; then
 			/etc/init.d/S91mqttsub restart >/dev/null 2>&1 || true
 		fi
 	) &

--- a/package/thingino-webui/thingino-webui.mk
+++ b/package/thingino-webui/thingino-webui.mk
@@ -157,6 +157,8 @@ define THINGINO_WEBUI_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/var/www/tool-send2-gotify.html
 	$(INSTALL) -D -m 0644 $(THINGINO_WEBUI_PKGDIR)/files/www/tool-send2-mqtt.html \
 		$(TARGET_DIR)/var/www/tool-send2-mqtt.html
+	$(INSTALL) -D -m 0644 $(THINGINO_WEBUI_PKGDIR)/files/www/tool-agent-pair.html \
+		$(TARGET_DIR)/var/www/tool-agent-pair.html
 	$(INSTALL) -D -m 0644 $(THINGINO_WEBUI_PKGDIR)/files/www/tool-send2-ntfy.html \
 		$(TARGET_DIR)/var/www/tool-send2-ntfy.html
 	$(INSTALL) -D -m 0644 $(THINGINO_WEBUI_PKGDIR)/files/www/tool-send2-storage.html \
@@ -239,6 +241,8 @@ define THINGINO_WEBUI_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/var/www/a/tool-send2-gotify.js
 	$(INSTALL) -D -m 0644 $(THINGINO_WEBUI_PKGDIR)/files/www/a/tool-send2-mqtt.js \
 		$(TARGET_DIR)/var/www/a/tool-send2-mqtt.js
+	$(INSTALL) -D -m 0644 $(THINGINO_WEBUI_PKGDIR)/files/www/a/tool-agent-pair.js \
+		$(TARGET_DIR)/var/www/a/tool-agent-pair.js
 	$(INSTALL) -D -m 0644 $(THINGINO_WEBUI_PKGDIR)/files/www/a/tool-send2-ntfy.js \
 		$(TARGET_DIR)/var/www/a/tool-send2-ntfy.js
 	$(INSTALL) -D -m 0644 $(THINGINO_WEBUI_PKGDIR)/files/www/a/tool-send2-storage.js \
@@ -310,6 +314,8 @@ define THINGINO_WEBUI_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/var/www/x/json-config-webui.cgi
 	$(INSTALL) -D -m 0755 $(THINGINO_WEBUI_PKGDIR)/files/www/x/json-agent-token.cgi \
 		$(TARGET_DIR)/var/www/x/json-agent-token.cgi
+	$(INSTALL) -D -m 0755 $(THINGINO_WEBUI_PKGDIR)/files/www/x/json-agent-pair.cgi \
+		$(TARGET_DIR)/var/www/x/json-agent-pair.cgi
 	$(INSTALL) -D -m 0755 $(THINGINO_WEBUI_PKGDIR)/files/www/x/json-gphotos-token.cgi \
 		$(TARGET_DIR)/var/www/x/json-gphotos-token.cgi
 	$(INSTALL) -D -m 0755 $(THINGINO_WEBUI_PKGDIR)/files/www/x/json-heartbeat.cgi \

--- a/package/timps/files/telegram-cam-register
+++ b/package/timps/files/telegram-cam-register
@@ -13,12 +13,9 @@ json_escape() {
 }
 
 camera_id() {
-	if command -v soc >/dev/null 2>&1; then
-		serial=$(soc -s 2>/dev/null)
-		if [ -n "$serial" ]; then
-			printf '%s' "$serial"
-			return 0
-		fi
+	if command -v thingino-camera-id >/dev/null 2>&1; then
+		thingino-camera-id
+		return $?
 	fi
 
 	for iface in eth0 wlan0 eth1; do


### PR DESCRIPTION
## Summary
- Fix MQTT `install-agent-bootstrap` so `args.1`–`args.4` (broker host/port/user/pass) are actually parsed.
- Add agent-owned `thingino-agent-bootstrap` helper: write bootstrap JSON, ensure hub cmd subscription, keep pairing usable without the WebUI package owning the installer.
- One-shot consume `/etc/thingino-agent-bootstrap.json` in `S95thingino-agent` (rename to `.applied`), and restart `S91mqttsub` when broker settings changed.
- Add local **Services → Hub Pairing** fallback page + CGI for operator token paste when MQTT is not yet available.

## Test plan
- [x] `thingino-agent-bootstrap install <token>` writes bootstrap and ensures `thingino/cam/%id/cmd` → `telegram-cam-agent "$MQTT_PAYLOAD"`
- [x] MQTT `install-agent-bootstrap` with token-only and token+broker args; reply succeeds; agent restarts; bootstrap becomes `.applied`
- [x] With broker args, mqtt-sub restarts and picks up hub cmd subscription
- [x] WebUI Hub Pairing page installs token, queues agent restart, status shows token configured
- [x] Confirm pairing still works when WebUI is present; helper is installed by `thingino-agent`

## Related
- Leaves #1340 open (audio mic/spk review)
- Separate from consolidated WebUI pages PR #1356
- Hub-side pairing UI remains a later repo


Made with [Cursor](https://cursor.com)