### PR TITLE
kernel: T23/MMC1 SDIO patches for ATBM6441 support

### DIFF
--- a/package/all-patches/linux/3.10.14/0091-uncomment-MSC1_PORTB-for-MMC1-SDIO.patch
+++ b/package/all-patches/linux/3.10.14/0091-uncomment-MSC1_PORTB-for-MMC1-SDIO.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Thingino Custom Build <custom@thingino>
+Date: Thu, 2 Jul 2026 00:00:00 +0000
+Subject: [PATCH] Uncomment MSC1_PORTB pinmux for MMC1 SDIO
+
+The MSC1_PORTB entry in platform_devio_array was commented out,
+preventing PB8-PB14 from being muxed to MMC1 function when
+CONFIG_JZMMC_V12_MMC1_PB_4BIT is enabled. This breaks ATBM WiFi
+chips connected via SDIO on MMC1 port B.
+
+Uncomment it so the GPIO function is properly set up.
+---
+ arch/mips/xburst/soc-t23/common/platform.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/arch/mips/xburst/soc-t23/common/platform.c b/arch/mips/xburst/soc-t23/common/platform.c
+index aaaaaaaaa..bbbbbbbbb 100644
+--- a/arch/mips/xburst/soc-t23/common/platform.c
++++ b/arch/mips/xburst/soc-t23/common/platform.c
+@@ -38,9 +38,9 @@ struct jz_gpio_func_def platform_devio_array[] = {
+ #ifdef CONFIG_JZMMC_V12_MMC1_PA_4BIT
+ 	MSC1_PORTA,
+ #endif
+-//#ifdef CONFIG_JZMMC_V12_MMC1_PB_4BIT
+-//	MSC1_PORTB,
+-//#endif
++#ifdef CONFIG_JZMMC_V12_MMC1_PB_4BIT
++	MSC1_PORTB,
++#endif
+ #ifdef CONFIG_JZMMC_V12_MMC1_PC_4BIT
+ 	MSC1_PORTC,
+ #endif

--- a/package/all-patches/linux/3.10.14/0092-add-MMC1-force-1bit-option.patch
+++ b/package/all-patches/linux/3.10.14/0092-add-MMC1-force-1bit-option.patch
@@ -1,0 +1,49 @@
+Add CONFIG_JZMMC_V12_MMC1_FORCE_1BIT to drop MMC_CAP_4_BIT_DATA from MSC1
+pdata, for boards where the SDIO device only wires DAT0/DAT1 (e.g. Jooan
+S7-U ATBM6441: 4-bit CMD53 fails with write CRC errors, DAT2/3 float low).
+
+--- a/drivers/mmc/host/Kconfig	2026-07-03 19:07:47.332806187 +0800
++++ b/drivers/mmc/host/Kconfig	2026-07-03 19:08:57.841821034 +0800
+@@ -75,6 +75,16 @@
+ 	bool "GPIO C, Data width 4 bit"
+ endchoice
+ 
++config JZMMC_V12_MMC1_FORCE_1BIT
++	bool "Force 1-bit data width for MSC1"
++	depends on JZMMC_V12_MMC1
++	default n
++	help
++	  Do not advertise MMC_CAP_4_BIT_DATA for MSC1. Use this for boards
++	  where the SDIO device only has DAT0 (and optionally DAT1 for
++	  interrupts) wired, so 4-bit transfers would fail with CRC errors.
++	  If unsure, say N.
++
+ config MMC1_MAX_FREQ
+ 	int "MSC1 max frequency"
+ 	depends on JZMMC_V12_MMC1
+--- a/arch/mips/xburst/soc-t23/chip-t23/isvp/common/mmc.c	2026-07-03 19:07:47.334673080 +0800
++++ b/arch/mips/xburst/soc-t23/chip-t23/isvp/common/mmc.c	2026-07-03 19:08:57.843099128 +0800
+@@ -41,7 +41,11 @@
+ 	 .removal  			= MANUAL,
+ 	 .sdio_clk			= 1,
+ 	 .ocr_avail			= MMC_VDD_29_30 | MMC_VDD_30_31,
++#ifdef CONFIG_JZMMC_V12_MMC1_FORCE_1BIT
++	 .capacity  			= MMC_CAP_SDIO_IRQ,
++#else
+ 	 .capacity  			= MMC_CAP_4_BIT_DATA | MMC_CAP_SDIO_IRQ,
++#endif
+ 	 .max_freq                       = CONFIG_MMC1_MAX_FREQ,
+ 	 .recovery_info			= NULL,
+ 	 .gpio				= NULL,
+@@ -82,7 +86,11 @@
+ 	 .removal  			= MANUAL,
+ 	 .sdio_clk			= 1,
+ 	 .ocr_avail			= MMC_VDD_29_30 | MMC_VDD_30_31,
++#ifdef CONFIG_JZMMC_V12_MMC1_FORCE_1BIT
++	 .capacity  			= MMC_CAP_SDIO_IRQ,
++#else
+ 	 .capacity  			= MMC_CAP_4_BIT_DATA | MMC_CAP_SDIO_IRQ,
++#endif
+ 	 .max_freq                       = CONFIG_MMC1_MAX_FREQ,
+ 	 .recovery_info			= NULL,
+ 	 .gpio				= NULL,

--- a/package/all-patches/linux/3.10.14/0093-enable-uart0-portb-default.patch
+++ b/package/all-patches/linux/3.10.14/0093-enable-uart0-portb-default.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Thingino Custom Build <custom@thingino>
+Date: Sun, 6 Jul 2026 00:00:00 +0000
+Subject: [PATCH] Default UART0 to PORTB pinmux when UART0 is enabled
+
+The UART0 entry in platform_devio_array is gated on CONFIG_UART0_PB /
+CONFIG_UART0_PB_FC, but this kernel tree ships no Kconfig choice that
+defines either symbol. As a result, enabling CONFIG_SERIAL_JZ47XX_UART0
+registers /dev/ttyS0 but never muxes PB19/PB22 to the UART0 function,
+so nothing reaches the pins.
+
+On the Jooan S7-U board T23 UART0 (PB19 TXD / PB22 RXD, non-flow-control)
+is wired to the ATBM6441's UART, which is the vendor's MCU control/PIR
+channel (/dev/ttyS0). Default to the non-flow-control PORTB group when
+UART0 is enabled so the data pins get muxed. The flow-control variant is
+deliberately NOT the default: PB20/PB21 are used as PTZ tilt GPIOs on
+this board, so only UART0_PORTB_FC (opt-in) would collide.
+---
+ arch/mips/xburst/soc-t23/common/platform.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/arch/mips/xburst/soc-t23/common/platform.c b/arch/mips/xburst/soc-t23/common/platform.c
+index aaaaaaaaa..bbbbbbbbb 100644
+--- a/arch/mips/xburst/soc-t23/common/platform.c
++++ b/arch/mips/xburst/soc-t23/common/platform.c
+@@ -70,10 +70,10 @@ struct jz_gpio_func_def platform_devio_array[] = {
+
+
+ #ifdef CONFIG_SERIAL_JZ47XX_UART0
+-#if defined(CONFIG_UART0_PB)
+-	UART0_PORTB,
+-#elif defined(CONFIG_UART0_PB_FC)
++#if defined(CONFIG_UART0_PB_FC)
+ 	UART0_PORTB_FC,
++#else
++	UART0_PORTB,
+ #endif
+ #endif
+


### PR DESCRIPTION
## Summary

This PR adds three kernel patches for soc-t23 boards. #1358 was one combined PR for a new camera. This PR splits out just the kernel-level changes, per maintainer request.

## What this PR adds

**0091: uncomment the MSC1_PORTB pinmux group**
This group was commented out. Boards that wire an SDIO device (for example, a combo WiFi+MCU chip) to MMC1 need this pinmux group to mux the SDIO pins to the controller.

**0092: add CONFIG_JZMMC_V12_MMC1_FORCE_1BIT**
Some boards wire only 2 of the 4 SDIO data lines on MMC1. On these boards, 4-bit CMD53 transfers fail with write-CRC errors, because the unwired data lines float. This option forces 1-bit mode for MMC1.

**0093: default UART0 to the non-flow-control PORTB pinmux group**
The UART0 entry in `platform_devio_array` checks for `CONFIG_UART0_PB` or `CONFIG_UART0_PB_FC`. No Kconfig choice in this tree sets either symbol. This means no soc-t23 board can mux UART0's pins to a pinmux group, even when `CONFIG_SERIAL_JZ47XX_UART0` is on. This patch adds a default: use the non-flow-control group when no flow-control variant is set.

## Related PRs

This is part 1 of 3, split from #1358 per maintainer request:
1. This PR — kernel patches
2. Add ATBM6441 WiFi+MCU support (depends on this PR)
3. Add Jooan S7-U camera (depends on both of the above)

## Testing

All three patches were part of #1358, which I built with `make cleanbuild` and flash-tested on the Jooan S7-U (T23ZN, ATBM6441, 1-bit SDIO wiring).