### PR TITLE
pack: write a buildscope size report when the tool is available

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -799,6 +799,18 @@ else
 	@if [ $(FIRMWARE_BIN_FULL_SIZE) -gt $(FLASH_SIZE) ]; then $(RED) "OVERSIZE"; fi
 	@echo "Image: $(FIRMWARE_BIN_FULL)"
 endif
+# Per-build size and composition report, written to
+# $(OUTPUT_DIR)/images/buildscope-report.json and renderable at
+# buildscope.thingino.com. It attributes the rootfs to the packages that
+# installed it and reads real usage out of every image, which needs the build
+# tree that pack still has and distclean removes.
+#
+# BR2_PACKAGE_HOST_BUILDSCOPE installs the tool into $(HOST_DIR); a copy on
+# PATH is used otherwise, so the report is available without enabling the
+# package. A missing tool or a failed report never fails the build.
+	@BUILDSCOPE="$(HOST_DIR)/bin/buildscope"; \
+		if [ ! -x "$$BUILDSCOPE" ]; then BUILDSCOPE=$$(command -v buildscope 2>/dev/null || true); fi; \
+		if [ -n "$$BUILDSCOPE" ]; then "$$BUILDSCOPE" scan -q "$(OUTPUT_DIR)" || true; fi
 	@echo ""
 	@ELAPSED=$$(( $$(date +%s) - $(THINGINO_BUILD_START_EPOCH) )); \
 		H=$$((ELAPSED / 3600)); M=$$(((ELAPSED % 3600) / 60)); S=$$((ELAPSED % 60)); \

--- a/Makefile
+++ b/Makefile
@@ -800,7 +800,7 @@ else
 	@echo "Image: $(FIRMWARE_BIN_FULL)"
 endif
 # Per-build size and composition report, written to
-# $(OUTPUT_DIR)/images/buildscope-report.json and renderable at
+# $(OUTPUT_DIR)/buildscope-report.json and renderable at
 # buildscope.thingino.com. It attributes the rootfs to the packages that
 # installed it and reads real usage out of every image, which needs the build
 # tree that pack still has and distclean removes.


### PR DESCRIPTION
Adds the `pack` hook that writes a per-build size and composition report to
`$(OUTPUT_DIR)/buildscope-report.json`. It attributes the rootfs to the
packages that installed it and reads real usage out of every image, which
needs the build tree that `pack` still has and `distclean` removes.

This is the same hook already on `master`; `ciao` needs it so builds from
this branch produce reports too.

### Does nothing unless the tool is present

```make
@BUILDSCOPE="$(HOST_DIR)/bin/buildscope"; \
	if [ ! -x "$$BUILDSCOPE" ]; then BUILDSCOPE=$$(command -v buildscope 2>/dev/null || true); fi; \
	if [ -n "$$BUILDSCOPE" ]; then "$$BUILDSCOPE" scan -q "$(OUTPUT_DIR)" || true; fi
```

It prefers the copy `BR2_PACKAGE_HOST_BUILDSCOPE` installs into `$(HOST_DIR)`
and falls back to `PATH`. With neither, nothing runs; and the scan itself is
`|| true`, so a missing tool or a failed report can never fail a build.

### What consumes it

The `firmware-master` and `firmware-stable` workflows put a prebuilt
`buildscope` on `PATH`, collect each camera's report, and publish a fleet
snapshot to the release. Those are already on `master`. Reports render at
https://buildscope.thingino.com/ .

12 lines, `Makefile` only.
