### PR TITLE
libhelix-aac, libhelix-mp3, libflac: fail the build instead of shipping a broken library

### DIFF
--- a/package/libflac/libflac.mk
+++ b/package/libflac/libflac.mk
@@ -10,7 +10,7 @@ LIBFLAC_SRC_DIR = src/libflac
 LIBFLAC_SO_NAME = libflac-lite.so
 
 define LIBFLAC_BUILD_CMDS
-	$(foreach src,$(wildcard $(@D)/$(LIBFLAC_SRC_DIR)/*.c), \
+	set -e; $(foreach src,$(wildcard $(@D)/$(LIBFLAC_SRC_DIR)/*.c), \
 		$(TARGET_CC) $(TARGET_CFLAGS) -I$(@D)/$(LIBFLAC_SRC_DIR) -I$(LIBFLAC_PKGDIR)/arduino_compat -fPIC -DUSE_DEFAULT_STDLIB -c $(src) -o $(patsubst %.c, %.o, $(src));)
 	find $(@D)/$(LIBFLAC_SRC_DIR) -type f -name '*.o' | xargs $(TARGET_CC) $(TARGET_LDFLAGS) -shared -o $(@D)/$(LIBFLAC_SO_NAME)
 endef

--- a/package/libhelix-aac/libhelix-aac.mk
+++ b/package/libhelix-aac/libhelix-aac.mk
@@ -9,8 +9,13 @@ LIBHELIX_AAC_INSTALL_TARGET = YES
 LIBHELIX_AAC_SRC_DIR = src/libhelix-aac
 LIBHELIX_AAC_SO_NAME = libhelix-aac.so
 
+# `set -e` is load-bearing. The compile step is a $(foreach ...) whose commands
+# are joined by ";", so without it a source that fails to compile does not stop
+# the loop, and the link below is "-shared" over whatever .o files happen to
+# exist -- which permits undefined symbols. The package then builds green and
+# installs a library that fails at first use rather than at build time.
 define LIBHELIX_AAC_BUILD_CMDS
-	$(foreach src,$(wildcard $(@D)/$(LIBHELIX_AAC_SRC_DIR)/*.c), \
+	set -e; $(foreach src,$(wildcard $(@D)/$(LIBHELIX_AAC_SRC_DIR)/*.c), \
 		$(TARGET_CC) $(TARGET_CFLAGS) -I$(@D)/$(LIBHELIX_AAC_SRC_DIR) -fPIC -DUSE_DEFAULT_STDLIB -c $(src) -o $(patsubst %.c, %.o, $(src));)
 	find $(@D)/$(LIBHELIX_AAC_SRC_DIR) -type f -name '*.o' | xargs $(TARGET_CC) $(TARGET_LDFLAGS) -shared -o $(@D)/$(LIBHELIX_AAC_SO_NAME)
 endef

--- a/package/libhelix-aac/libhelix-aac.mk
+++ b/package/libhelix-aac/libhelix-aac.mk
@@ -9,11 +9,6 @@ LIBHELIX_AAC_INSTALL_TARGET = YES
 LIBHELIX_AAC_SRC_DIR = src/libhelix-aac
 LIBHELIX_AAC_SO_NAME = libhelix-aac.so
 
-# `set -e` is load-bearing. The compile step is a $(foreach ...) whose commands
-# are joined by ";", so without it a source that fails to compile does not stop
-# the loop, and the link below is "-shared" over whatever .o files happen to
-# exist -- which permits undefined symbols. The package then builds green and
-# installs a library that fails at first use rather than at build time.
 define LIBHELIX_AAC_BUILD_CMDS
 	set -e; $(foreach src,$(wildcard $(@D)/$(LIBHELIX_AAC_SRC_DIR)/*.c), \
 		$(TARGET_CC) $(TARGET_CFLAGS) -I$(@D)/$(LIBHELIX_AAC_SRC_DIR) -fPIC -DUSE_DEFAULT_STDLIB -c $(src) -o $(patsubst %.c, %.o, $(src));)

--- a/package/libhelix-mp3/libhelix-mp3.mk
+++ b/package/libhelix-mp3/libhelix-mp3.mk
@@ -10,7 +10,7 @@ LIBHELIX_MP3_SRC_DIR = src/libhelix-mp3
 LIBHELIX_MP3_SO_NAME = libhelix-mp3.so
 
 define LIBHELIX_MP3_BUILD_CMDS
-	$(foreach src,$(wildcard $(@D)/$(LIBHELIX_MP3_SRC_DIR)/*.c), \
+	set -e; $(foreach src,$(wildcard $(@D)/$(LIBHELIX_MP3_SRC_DIR)/*.c), \
 		$(TARGET_CC) $(TARGET_CFLAGS) -I$(@D)/$(LIBHELIX_MP3_SRC_DIR) -I$(LIBHELIX_MP3_PKGDIR)/arduino_compat -fPIC -DUSE_DEFAULT_STDLIB -DARDUINO -c $(src) -o $(patsubst %.c, %.o, $(src));)
 	find $(@D)/$(LIBHELIX_MP3_SRC_DIR) -type f -name '*.o' | xargs $(TARGET_CC) $(TARGET_LDFLAGS) -shared -o $(@D)/$(LIBHELIX_MP3_SO_NAME)
 endef


### PR DESCRIPTION
All three packages share one `BUILD_CMDS` shape, and a grep says they are the only three in the tree that do: a `$(foreach ...)` whose commands are joined by `;`, followed by a link of `find ... | xargs $(TARGET_CC) -shared`.

Without `set -e`, a source that fails to compile does not stop the loop. The link that follows is `-shared` over whatever `.o` files exist, and a shared link permits undefined symbols — so the package builds green and installs a library missing whatever did not compile.

Found in `libhelix-aac` while building for a non-MIPS target, where 15 of its 28 sources hit `#error Unsupported platform in assembly.h` and the resulting `.so` contained 13 objects. Nothing failed; the first caller died with:

```
symbol lookup error: /lib/libhelix-aac.so: undefined symbol: UncoupleSBRNoise
```

The other two, per review:

- **`libhelix-mp3`** carries the identical gate — `assembly.h:353`, included by 8 of its 15 sources — and would fail the same way on the same target. It was not hit here only because that build does not select it.
- **`libflac`**'s own `#error Unsupported platform` is a narrower ppc-hwcaps path (`cpu.c:257`) rather than the same trigger, but its `BUILD_CMDS` has the same shape and the same silent partial-link outcome for any source that fails.

Reduced repro of the mechanism — same `$(foreach ...)`-joined-by-`;` structure, with a stub compiler that fails on one source:

```
########## BEFORE (no set -e) ##########
  compiling a.c
  compiling bad.c
  bad.c:1: #error Unsupported platform in assembly.h
  compiling c.c
  -> LINK RAN over the surviving .o files
make exit status: 0          <-- green

########## AFTER (set -e) ##########
  compiling a.c
  compiling bad.c
  bad.c:1: #error Unsupported platform in assembly.h
make: *** [fixed] Error 1
make exit status: 2
```

`set -e` is a no-op on any target where every source already compiles — it only changes what happens when one does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
