### PR TITLE
os-release: derive ARCHITECTURE instead of hardcoding mips

### DIFF
--- a/scripts/rootfs_script.sh
+++ b/scripts/rootfs_script.sh
@@ -45,6 +45,19 @@ else
 	TOOLCHAIN_TYPE="unknown"
 fi
 
+# Derived from the Buildroot config rather than assumed. /etc/os-release is read
+# at runtime -- `soc -a` reports from it and the web UI displays it -- so this
+# value is user-visible and should describe what was actually built.
+if grep -q "^BR2_arm=y\|^BR2_armeb=y" "$BR2_CONFIG"; then
+	ARCHITECTURE="arm"
+elif grep -q "^BR2_aarch64=y\|^BR2_aarch64_be=y" "$BR2_CONFIG"; then
+	ARCHITECTURE="aarch64"
+elif grep -q "^BR2_mips=y\|^BR2_mipsel=y\|^BR2_mips64=y\|^BR2_mips64el=y" "$BR2_CONFIG"; then
+	ARCHITECTURE="mips"
+else
+	ARCHITECTURE="unknown"
+fi
+
 TOOLCHAIN_GCC=$(sed -rn 's/^BR2_GCC_VERSION="([^"]+)"/\1/p' "$BR2_CONFIG" | tail -n1)
 if [ -z "$TOOLCHAIN_GCC" ]; then
 	TOOLCHAIN_GCC=$(sed -rn 's/^BR2_TOOLCHAIN_(EXTERNAL|BUILDROOT)_GCC_([0-9]+)=y$/\2/p' "$BR2_CONFIG" | tail -n1)
@@ -81,7 +94,7 @@ CPE_NAME=\"cpe:/o:thinginoproject:thingino:1\"
 LOGO=thingino-logo-icon
 ANSI_COLOR=\"1;34\"
 HOME_URL=\"https://thingino.com/\"
-ARCHITECTURE=mips
+ARCHITECTURE=${ARCHITECTURE}
 LIBC=${LIBC}
 TOOLCHAIN=${LIBC}
 TOOLCHAIN_TYPE=${TOOLCHAIN_TYPE}


### PR DESCRIPTION
`ARCHITECTURE` was the literal `mips`, which is correct for every target thingino currently builds. **This is groundwork, not a bug fix** — nothing is wrong today.

`/etc/os-release` is read at runtime rather than only at build time: `soc -a` reports from it and the web UI displays it. On a MIPS build the derived value is byte-identical, so this changes nothing for existing targets. It only stops the field being wrong if the tree ever builds for another architecture.

Happy to drop this if you would rather not carry it until there is a target that needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)