### PR TITLE
sysupgrade: identify a full image by vendor signature, not one magic

### DIFF
--- a/package/thingino-sysupgrade/files/sysupgrade
+++ b/package/thingino-sysupgrade/files/sysupgrade
@@ -9,6 +9,7 @@ RUBICON="1768337345" # 2026-01-13
 KERNEL_MAGIC="27051956"
 U_BOOT_MAGIC="06050403"
 ROOTFS_MAGIC="68737173"
+SSTAR_IPL_MAGIC="49504c5f" # "IPL_", at offset 4 rather than 0
 GITHUB_URL="https://github.com"
 PAD="\n\t\t\t    "
 
@@ -167,8 +168,24 @@ expand_bb() {
 	ln -s "$workdir/busybox" "$workdir/$1"
 }
 
+# A full firmware image begins with the bootloader, but "the bootloader" is not
+# one shape across vendors.
+#
+# Ingenic's starts with a fixed four-byte magic. A SigmaStar mask-ROM container
+# starts with an ARM branch instruction whose encoding varies with the branch
+# offset, so its first four bytes identify nothing; what is stable there is the
+# "IPL_" signature the mask ROM looks for at offset 4.
+#
+# Checking both leaves the first-four-bytes dispatch below unchanged for
+# Ingenic and lets a non-Ingenic image be recognised at all.
+image_starts_with_bootloader() {
+	[ "$U_BOOT_MAGIC" = "$(xxd -l 4 -p "$1")" ] && return 0
+	[ "$SSTAR_IPL_MAGIC" = "$(xxd -s 4 -l 4 -p "$1")" ] && return 0
+	return 1
+}
+
 extract_bootloader() {
-	if [ "$U_BOOT_MAGIC" != "$(xxd -l 4 -p $1)" ]; then
+	if ! image_starts_with_bootloader "$1"; then
 		die "$1 image does not start with a bootloader!"
 	fi
 
@@ -486,7 +503,13 @@ case "$(xxd -l 4 -p "$fw_file")" in
 		die "We cannot flash only rootfs"
 		;;
 	*)
-		die "Unknown file"
+		# Not identifiable by its first four bytes. That is the normal case for
+		# a vendor whose container does not begin with a fixed magic -- see
+		# image_starts_with_bootloader.
+		image_starts_with_bootloader "$fw_file" || die "Unknown file"
+		echo "Bootloader detected"
+		mtd_dev=$(full_upgrade_partition_name)
+		part_size=$(full_upgrade_partition_size)
 		;;
 esac
 


### PR DESCRIPTION
A full image is detected by its first four bytes being Ingenic's U-Boot magic. That is a property of Ingenic's bootloader rather than of bootloaders generally: a SigmaStar mask-ROM container opens with an ARM branch whose encoding moves with the branch offset (`0x060000ea` in one build, `0x020000ea` in the vendor's own IPL blobs), so those bytes carry no signature at all. Its stable marker is `IPL_` at offset 4, which is what the mask ROM itself looks for.

Adds `image_starts_with_bootloader()` checking both, used by `extract_bootloader` and as a fallback in the dispatch.

The Ingenic magic is still tested first and still matches first, so behaviour on existing targets is unchanged. The only new outcome is that an image previously rejected as `Unknown file` can be recognised.

Written vendor-shaped rather than board-shaped — it is not specific to any one camera, only to not being Ingenic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)