### PR TITLE
fix: serialize thingino.json assembly via staging directory

### DIFF
--- a/package/thingino-agent/thingino-agent.mk
+++ b/package/thingino-agent/thingino-agent.mk
@@ -2,9 +2,9 @@ THINGINO_AGENT_SITE_METHOD = local
 THINGINO_AGENT_SITE = $(THINGINO_AGENT_PKGDIR)/files
 THINGINO_AGENT_LICENSE = MIT
 ifeq ($(BR2_PACKAGE_MBEDTLS),y)
-THINGINO_AGENT_DEPENDENCIES = thingino-core thingino-jct host-thingino-jct mbedtls mbedtls-certgen
+THINGINO_AGENT_DEPENDENCIES = thingino-core thingino-jct mbedtls mbedtls-certgen
 else ifeq ($(BR2_PACKAGE_THINGINO_MBEDTLS),y)
-THINGINO_AGENT_DEPENDENCIES = thingino-core thingino-jct host-thingino-jct thingino-mbedtls mbedtls-certgen
+THINGINO_AGENT_DEPENDENCIES = thingino-core thingino-jct thingino-mbedtls mbedtls-certgen
 endif
 
 define THINGINO_AGENT_BUILD_CMDS
@@ -16,8 +16,9 @@ define THINGINO_AGENT_BUILD_CMDS
 endef
 
 define THINGINO_AGENT_INSTALL_TARGET_CMDS
-	$(HOST_DIR)/bin/jct $(TARGET_DIR)/etc/thingino.json import \
-		$(THINGINO_AGENT_PKGDIR)/files/thingino-agent.json
+	# Stage defaults for later merge by thingino-core
+	$(INSTALL) -D -m 0644 $(THINGINO_AGENT_PKGDIR)/files/thingino-agent.json \
+		$(TARGET_DIR)/usr/share/thingino-defaults/20-agent.json
 
 	$(INSTALL) -D -m 0755 $(@D)/S95thingino-agent \
 		$(TARGET_DIR)/etc/init.d/S95thingino-agent

--- a/package/thingino-core/thingino-core.mk
+++ b/package/thingino-core/thingino-core.mk
@@ -3,22 +3,41 @@ THINGINO_CORE_SITE = $(BR2_EXTERNAL_THINGINO_PATH)/package/thingino-core
 
 THINGINO_CORE_DEPENDENCIES = host-thingino-jct
 
-THINGINO_CORE_OUTPUT_FILE=$(TARGET_DIR)/etc/thingino.json
+THINGINO_CORE_OUTPUT_FILE = $(TARGET_DIR)/etc/thingino.json
+THINGINO_CORE_STAGING_DIR = $(TARGET_DIR)/usr/share/thingino-defaults
 
 define THINGINO_CORE_INSTALL_TARGET_CMDS
+	# Create the base thingino.json and staging directory
 	$(INSTALL) -D -m 0644 $(BR2_EXTERNAL_THINGINO_PATH)/configs/common.thingino.json \
 		$(THINGINO_CORE_OUTPUT_FILE)
+	$(INSTALL) -d $(THINGINO_CORE_STAGING_DIR)
 
+	# Stage camera-specific overrides for later merge
 	CAMERA_CONFIG=$(BR2_EXTERNAL_THINGINO_PATH)/$(CAMERA_SUBDIR)/$(CAMERA)/thingino.json; \
 	[ -f "$$CAMERA_CONFIG" ] && \
-		$(HOST_DIR)/bin/jct "$(THINGINO_CORE_OUTPUT_FILE)" import "$$CAMERA_CONFIG" || true
+		$(INSTALL) -m 0644 "$$CAMERA_CONFIG" $(THINGINO_CORE_STAGING_DIR)/10-camera.json || true
 
+	printf "thingino-core: staged %s\n" $(THINGINO_CORE_OUTPUT_FILE) 1>&2
+endef
+
+# Merge all staged JSON fragments and user configs during target-finalize.
+# This runs after every package has installed its staging files, so there
+# is no race on thingino.json.
+define THINGINO_CORE_MERGE_THINGINO_JSON
+	# Merge staging files in sorted (priority) order
+	for FRAGMENT in $(THINGINO_CORE_STAGING_DIR)/*.json; do \
+		[ -f "$$FRAGMENT" ] && \
+			$(HOST_DIR)/bin/jct "$(THINGINO_CORE_OUTPUT_FILE)" import "$$FRAGMENT" || true; \
+	done
+
+	# Apply user overrides last (non-empty only, to avoid parse errors)
 	for USER_CONFIG in $(THINGINO_USER_JSON_FILES); do \
-		[ -f "$$USER_CONFIG" ] && \
+		[ -s "$$USER_CONFIG" ] && \
 			$(HOST_DIR)/bin/jct "$(THINGINO_CORE_OUTPUT_FILE)" import "$$USER_CONFIG" || true; \
 	done
 
-	printf "thingino-core: generated %s\n" $(THINGINO_CORE_OUTPUT_FILE) 1>&2
+	printf "thingino-core: finalized %s\n" $(THINGINO_CORE_OUTPUT_FILE) 1>&2
 endef
+THINGINO_CORE_TARGET_FINALIZE_HOOKS += THINGINO_CORE_MERGE_THINGINO_JSON
 
 $(eval $(generic-package))

--- a/package/thingino-ha/thingino-ha.mk
+++ b/package/thingino-ha/thingino-ha.mk
@@ -1,17 +1,12 @@
 THINGINO_HA_SITE_METHOD = local
 THINGINO_HA_SITE = $(THINGINO_HA_PKGDIR)/files
 THINGINO_HA_LICENSE = MIT
-THINGINO_HA_DEPENDENCIES = thingino-core host-thingino-jct
+THINGINO_HA_DEPENDENCIES = thingino-core
 
 define THINGINO_HA_INSTALL_TARGET_CMDS
-	$(HOST_DIR)/bin/jct $(TARGET_DIR)/etc/thingino.json import \
-		$(THINGINO_HA_PKGDIR)/files/thingino-ha.json
-
-	# Preserve user overrides (common/camera/device) after HA defaults import.
-	for USER_CONFIG in $(THINGINO_USER_JSON_FILES); do \
-		[ -f "$$USER_CONFIG" ] && \
-			$(HOST_DIR)/bin/jct $(TARGET_DIR)/etc/thingino.json import "$$USER_CONFIG" || true; \
-	done
+	# Stage defaults for later merge by thingino-core
+	$(INSTALL) -D -m 0644 $(THINGINO_HA_PKGDIR)/files/thingino-ha.json \
+		$(TARGET_DIR)/usr/share/thingino-defaults/50-ha.json
 
 	$(INSTALL) -D -m 0644 $(@D)/ha-common \
 		$(TARGET_DIR)/usr/share/ha-common


### PR DESCRIPTION
Replace per-package jct import on /etc/thingino.json with a staging
directory (/usr/share/thingino-defaults/) where each package drops its
JSON fragment during install. A single TARGET_FINALIZE_HOOK in
thingino-core merges all fragments in sorted priority order after all
packages are installed, then applies user overrides last.

This eliminates the read-modify-write race condition that occurs when
multiple packages (agent, ha) run jct import on the same thingino.json
inode under BR2_PER_PACKAGE_DIRECTORIES=y, causing keys to be silently
lost.

Staging priority order:
  10-camera.json     (per-camera overrides)
  20-agent.json      (thingino-agent)
  50-ha.json         (thingino-ha)
  ... user configs ... (common > camera > device, applied last)

Packages no longer need host-thingino-jct as a dependency; only
thingino-core retains it for the final merge step.

Cherry-picked from ciao branch (d462059b7).

Fixes the same issue as PR #1373, but with a complete architectural
fix that handles all packages uniformly rather than patching one package
with a post-assembly repair hook.