### PR TITLE
thingino-ha: include usb0 in HA_CAMERA_ID interface detection

### DIFF
--- a/package/thingino-ha/files/ha-common
+++ b/package/thingino-ha/files/ha-common
@@ -79,7 +79,7 @@ ha_entity_enabled() {
 # ---------------------------------------------------------------------------
 if [ -z "$HA_CAMERA_ID" ]; then
 	HA_CAMERA_ID=$(
-		for iface in eth0 wlan0 eth1; do
+		for iface in eth0 wlan0 eth1 usb0; do
 			addr=$(cat "/sys/class/net/$iface/address" 2>/dev/null | tr -d ':')
 			[ -n "$addr" ] && { printf '%s' "$addr"; break; }
 		done


### PR DESCRIPTION
`ha-common` derives `HA_CAMERA_ID` from `eth0/wlan0/eth1` only. On
USB-ethernet cameras (`usb0`, no `eth0`/`wlan0`) the ID is empty, so
`ha-daemon` publishes to malformed `cameras//…` topics and exits, and
the camera never registers in HA. Adding `usb0` fixes it; WiFi cameras
still match `wlan0` first.

Fixes #1222