### PR TITLE
raptor: fix dual-GPIO IRCUT pulse duration (100ms -> 10ms)

### DIFF
--- a/package/thingino-raptor/0002-ric-fix-ircut-pulse-duration.patch
+++ b/package/thingino-raptor/0002-ric-fix-ircut-pulse-duration.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: WLTB-Gino <wltb-gino@users.noreply.github.com>
+Date: Sat, 2 Aug 2025 20:00:00 +0000
+Subject: [PATCH] ric: reduce dual-GPIO IRCUT pulse from 100ms to 10ms
+
+The dual-GPIO (motor-driven) IRCUT filter uses a short electrical pulse
+to actuate. The hardcoded 100ms pulse in ric_daynight.c is inconsistent
+with the ircut shell script, which uses 10ms and works reliably across
+all camera models.
+
+The longer pulse can cause unreliable filter movement, resulting in the
+IRCUT filter getting stuck in the wrong position during day/night
+transitions.
+
+Reduce the pulse duration to 10ms in both day and night code paths,
+matching the proven timing of the ircut shell script.
+
+diff --git a/ric/ric_daynight.c b/ric/ric_daynight.c
+--- a/ric/ric_daynight.c
++++ b/ric/ric_daynight.c
+@@ -148,7 +148,7 @@
+ 				gpio_set(c->gpio_ircut, 0);
+ 				gpio_set(c->gpio_ircut2, 1);
+-				usleep(100000);
++				usleep(10000);
+ 				gpio_set(c->gpio_ircut, 0);
+ 				gpio_set(c->gpio_ircut2, 0);
+ 				RSS_INFO("ircut: gpio %d=0, gpio %d=0 (night)", c->gpio_ircut,
+@@ -171,7 +171,7 @@
+ 				gpio_set(c->gpio_ircut, 1);
+ 				gpio_set(c->gpio_ircut2, 0);
+-				usleep(100000);
++				usleep(10000);
+ 				gpio_set(c->gpio_ircut, 0);
+ 				gpio_set(c->gpio_ircut2, 0);
+ 				RSS_INFO("ircut: gpio %d=0, gpio %d=0 (day)", c->gpio_ircut,


### PR DESCRIPTION
## Problem

The hardcoded `usleep(100000)` (100ms) pulse in `ric_daynight.c` for dual-GPIO IRCUT actuation is inconsistent with the `ircut` shell script, which uses 10ms and works reliably across all camera models.

The longer pulse can cause unreliable IRCUT filter movement, resulting in the filter getting stuck in the wrong position during day/night transitions.

## Fix

Reduce the pulse duration from 100ms to 10ms in both the day and night code paths, matching the proven timing of the `ircut` shell script.

## Context

- The `ircut` shell script already uses 10ms successfully on all cameras
- Dual-GPIO IRCUT actuation is used by multiple camera models, not just one
- This is a timing mismatch between two Thingino components doing the same job
- Tested and confirmed working on Wyze V3 (RTL8189FTV)

## Testing

Verified on Wyze V3 RTL8189FTV — IRCUT now switches reliably at both day and night transitions.