### PR TITLE
ci: quote the telegram arguments so a fork without secrets does not corrupt them

### DIFF
--- a/.github/workflows/buildroot-dl-cache.yaml
+++ b/.github/workflows/buildroot-dl-cache.yaml
@@ -63,13 +63,13 @@ jobs:
           fetch-depth: "1"
 
       - name: Send build start notifcation via Telegram
-        if: env.TG_DISABLED == 'false'
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
             export TG_TOPIC=""
           fi
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC start ${{ github.workflow }} ${{ github.run_id }} ${{ github.repository }}
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" start ${{ github.workflow }} ${{ github.run_id }} ${{ github.repository }}
 
   build-caches:
     name: ${{ matrix.caches-version }}
@@ -201,13 +201,13 @@ jobs:
           done
 
       - name: Send error notification
-        if: ${{ env.TG_DISABLED == 'false' && failure() }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' && failure() }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
             export TG_TOPIC=""
           fi
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC error $TAG_NAME ${{ github.run_id }} buildroot-dl-cache ${{ github.repository }}
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" error $TAG_NAME ${{ github.run_id }} buildroot-dl-cache ${{ github.repository }}
 
   notify-completion:
     needs: [build-caches, notify-begin]
@@ -231,7 +231,7 @@ jobs:
           ref: ${{ github.event.inputs.branch || 'master' }}
 
       - name: Send notify completion summary
-        if: ${{ env.TG_DISABLED == 'false' }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
@@ -242,4 +242,4 @@ jobs:
           ELAPSED=$((END_TIME - START_TIME))
           ELAPSED_MIN=$((ELAPSED / 60))
           ELAPSED_SEC=$((ELAPSED % 60))
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC finish ${{ github.workflow }} "${ELAPSED_MIN}m ${ELAPSED_SEC}s" ${{ github.run_id }} ${{ github.repository }}
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" finish ${{ github.workflow }} "${ELAPSED_MIN}m ${ELAPSED_SEC}s" ${{ github.run_id }} ${{ github.repository }}

--- a/.github/workflows/firmware-builder.yml
+++ b/.github/workflows/firmware-builder.yml
@@ -190,13 +190,13 @@ jobs:
           fetch-depth: "1"
 
       - name: Send build start notification via Telegram
-        if: env.TG_DISABLED == 'false'
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
             export TG_TOPIC=""
           fi
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC start $TAG_NAME ${{ github.run_id }} ${{ github.repository }}
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" start $TAG_NAME ${{ github.run_id }} ${{ github.repository }}
 
   generate-matrix:
     runs-on: ubuntu-26.04
@@ -427,24 +427,24 @@ jobs:
           7z a -t7z -mx=9 -mmt=on /tmp/thingino-${{ matrix.thingino-version }}.7z ${{ env.FULL_FW }} ${{ env.FULL_FW_SHA }}
 
       - name: Send firmware completion notifications with attachment
-        if: ${{ env.TG_DISABLED == 'false' && (env.FULL_FW) }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' && (env.FULL_FW) }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
             export TG_TOPIC=""
           fi
           if [ -n "${{ env.FULL_FW }}" ]; then
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC completed $TAG_NAME ${{ github.run_id }} ${{ github.repository }} ${GIT_HASH} ${GIT_BRANCH} ${TAG_NAME} ${TIME} ${{ matrix.thingino-version }} /tmp/thingino-${{ matrix.thingino-version }}.7z
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" completed $TAG_NAME ${{ github.run_id }} ${{ github.repository }} ${GIT_HASH} ${GIT_BRANCH} ${TAG_NAME} ${TIME} ${{ matrix.thingino-version }} /tmp/thingino-${{ matrix.thingino-version }}.7z
           fi
 
       - name: Send error notification
-        if: ${{ env.TG_DISABLED == 'false' && failure() }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' && failure() }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
             export TG_TOPIC=""
           fi
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC error $TAG_NAME "Github CI build failed!" ${{ github.run_id }} ${{ matrix.thingino-version }} ${{ github.repository }}
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" error $TAG_NAME "Github CI build failed!" ${{ github.run_id }} ${{ matrix.thingino-version }} ${{ github.repository }}
 
   finalize-release:
     needs: [buildroot, prepare-release, check-updates]
@@ -547,7 +547,7 @@ jobs:
           fetch-depth: "1"
 
       - name: Send notify completion summary
-        if: ${{ env.TG_DISABLED == 'false' }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
@@ -558,4 +558,4 @@ jobs:
           ELAPSED=$((END_TIME - START_TIME))
           ELAPSED_MIN=$((ELAPSED / 60))
           ELAPSED_SEC=$((ELAPSED % 60))
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC finish ${{ github.workflow }} "${ELAPSED_MIN}m ${ELAPSED_SEC}s" ${{ github.run_id }} ${{ github.repository }}
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" finish ${{ github.workflow }} "${ELAPSED_MIN}m ${ELAPSED_SEC}s" ${{ github.run_id }} ${{ github.repository }}

--- a/.github/workflows/firmware-master.yaml
+++ b/.github/workflows/firmware-master.yaml
@@ -103,7 +103,7 @@ jobs:
           fi
 
       - name: Send build start notifcation via Telegram
-        if: env.TG_DISABLED == 'false'
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
@@ -112,7 +112,7 @@ jobs:
           # fetch just the notifier script via gh (no curl/wget dependency; works in containers too)
           gh api "repos/${{ github.repository }}/contents/.github/scripts/tg-notify.sh?ref=master" -H "Accept: application/vnd.github.raw" > /tmp/tg-notify.sh
           chmod +x /tmp/tg-notify.sh
-          /tmp/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC start $TAG_NAME ${{ github.run_id }} ${{ github.repository }}
+          /tmp/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" start $TAG_NAME ${{ github.run_id }} ${{ github.repository }}
 
   generate-matrix:
     runs-on: ubuntu-26.04
@@ -480,24 +480,24 @@ jobs:
           7z a -t7z -mx=9 -mmt=on /tmp/thingino-${{ matrix.thingino-version }}.7z ${{ env.FULL_FW }} ${{ env.FULL_FW_SHA }}
 
       - name: Send firmware completion notifications with attachment
-        if: ${{ env.TG_DISABLED == 'false' && (env.FULL_FW) }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' && (env.FULL_FW) }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
             export TG_TOPIC=""
           fi
           if [ -n "${{ env.FULL_FW }}" ]; then
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC completed $TAG_NAME ${{ github.run_id }} ${{ github.repository }} ${GIT_HASH} ${GIT_BRANCH} ${TAG_NAME} ${TIME} ${{ matrix.thingino-version }} /tmp/thingino-${{ matrix.thingino-version }}.7z
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" completed $TAG_NAME ${{ github.run_id }} ${{ github.repository }} ${GIT_HASH} ${GIT_BRANCH} ${TAG_NAME} ${TIME} ${{ matrix.thingino-version }} /tmp/thingino-${{ matrix.thingino-version }}.7z
           fi
 
       - name: Send error notification
-        if: ${{ env.TG_DISABLED == 'false' && failure() }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' && failure() }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
             export TG_TOPIC=""
           fi
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC error $TAG_NAME "Github CI build failed!" ${{ github.run_id }} ${{ matrix.thingino-version }} ${{ github.repository }}
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" error $TAG_NAME "Github CI build failed!" ${{ github.run_id }} ${{ matrix.thingino-version }} ${{ github.repository }}
 
   fleet:
     needs: [buildroot]
@@ -631,7 +631,7 @@ jobs:
           fi
 
       - name: Send notify completion summary
-        if: ${{ env.TG_DISABLED == 'false' }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
@@ -645,4 +645,4 @@ jobs:
           # fetch just the notifier script via gh (no curl/wget dependency; works in containers too)
           gh api "repos/${{ github.repository }}/contents/.github/scripts/tg-notify.sh?ref=master" -H "Accept: application/vnd.github.raw" > /tmp/tg-notify.sh
           chmod +x /tmp/tg-notify.sh
-          /tmp/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC finish ${{ github.workflow }} "${ELAPSED_MIN}m ${ELAPSED_SEC}s" ${{ github.run_id }} ${{ github.repository }}
+          /tmp/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" finish ${{ github.workflow }} "${ELAPSED_MIN}m ${ELAPSED_SEC}s" ${{ github.run_id }} ${{ github.repository }}

--- a/.github/workflows/firmware-stable.yml
+++ b/.github/workflows/firmware-stable.yml
@@ -175,7 +175,7 @@ jobs:
           echo "TAG_NAME=${{ needs.prepare-release.outputs.tag_name }}" >> $GITHUB_ENV
 
       - name: Send build start notification via Telegram
-        if: env.TG_DISABLED == 'false'
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
@@ -184,7 +184,7 @@ jobs:
           # fetch just the notifier script via gh (no curl/wget dependency; works in containers too)
           gh api "repos/${{ github.repository }}/contents/.github/scripts/tg-notify.sh?ref=${{ github.event.inputs.branch || github.ref_name }}" -H "Accept: application/vnd.github.raw" > /tmp/tg-notify.sh
           chmod +x /tmp/tg-notify.sh
-          /tmp/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC start $TAG_NAME ${{ github.run_id }} ${{ github.repository }}
+          /tmp/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" start $TAG_NAME ${{ github.run_id }} ${{ github.repository }}
 
   generate-matrix:
     runs-on: ubuntu-26.04
@@ -548,24 +548,24 @@ jobs:
           7z a -t7z -mx=9 -mmt=on /tmp/thingino-${{ matrix.thingino-version }}.7z ${{ env.FULL_FW }} ${{ env.FULL_FW_SHA }}
 
       - name: Send firmware completion notifications with attachment
-        if: ${{ env.TG_DISABLED == 'false' && (env.FULL_FW) }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' && (env.FULL_FW) }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
             export TG_TOPIC=""
           fi
           if [ -n "${{ env.FULL_FW }}" ]; then
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC completed $TAG_NAME ${{ github.run_id }} ${{ github.repository }} ${GIT_HASH} ${GIT_BRANCH} ${TAG_NAME} ${TIME} ${{ matrix.thingino-version }} /tmp/thingino-${{ matrix.thingino-version }}.7z
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" completed $TAG_NAME ${{ github.run_id }} ${{ github.repository }} ${GIT_HASH} ${GIT_BRANCH} ${TAG_NAME} ${TIME} ${{ matrix.thingino-version }} /tmp/thingino-${{ matrix.thingino-version }}.7z
           fi
 
       - name: Send error notification
-        if: ${{ env.TG_DISABLED == 'false' && failure() }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' && failure() }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
             export TG_TOPIC=""
           fi
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC error $TAG_NAME "Github CI build failed!" ${{ github.run_id }} ${{ matrix.thingino-version }} ${{ github.repository }}
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" error $TAG_NAME "Github CI build failed!" ${{ github.run_id }} ${{ matrix.thingino-version }} ${{ github.repository }}
 
   finalize-release:
     needs: [buildroot, prepare-release, check-updates]
@@ -708,7 +708,7 @@ jobs:
           echo "TG_DISABLED=${{ github.event.inputs.tg_disabled || 'false' }}" >> $GITHUB_ENV
 
       - name: Send notify completion summary
-        if: ${{ env.TG_DISABLED == 'false' }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
@@ -722,4 +722,4 @@ jobs:
           # fetch just the notifier script via gh (no curl/wget dependency; works in containers too)
           gh api "repos/${{ github.repository }}/contents/.github/scripts/tg-notify.sh?ref=${{ github.event.inputs.branch || github.ref_name }}" -H "Accept: application/vnd.github.raw" > /tmp/tg-notify.sh
           chmod +x /tmp/tg-notify.sh
-          /tmp/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC finish ${{ github.workflow }} "${ELAPSED_MIN}m ${ELAPSED_SEC}s" ${{ github.run_id }} ${{ github.repository }}
+          /tmp/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" finish ${{ github.workflow }} "${ELAPSED_MIN}m ${ELAPSED_SEC}s" ${{ github.run_id }} ${{ github.repository }}

--- a/.github/workflows/toolchain-aarch64.yaml
+++ b/.github/workflows/toolchain-aarch64.yaml
@@ -70,13 +70,13 @@ jobs:
           fetch-depth: "1"
 
       - name: Send build start notifcation via Telegram
-        if: env.TG_DISABLED == 'false'
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
             export TG_TOPIC=""
           fi
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC start $TAG_NAME ${{ github.run_id }} ${{ github.repository }}
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" start $TAG_NAME ${{ github.run_id }} ${{ github.repository }}
 
   generate-matrix:
     runs-on: ubuntu-24.04-arm
@@ -403,24 +403,24 @@ jobs:
 
 
       - name: Send firmware completion notifications
-        if: ${{ env.TG_DISABLED == 'false' && (env.INGTC) }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' && (env.INGTC) }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
             export TG_TOPIC=""
           fi
           if [ -n "${{ env.INGTC  }}" ]; then
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC completed $TAG_NAME ${{ github.run_id }} ${{ github.repository }} ${GIT_HASH} ${GIT_BRANCH} ${TAG_NAME} ${TIME} ${{ matrix.toolchain-version }}
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" completed $TAG_NAME ${{ github.run_id }} ${{ github.repository }} ${GIT_HASH} ${GIT_BRANCH} ${TAG_NAME} ${TIME} ${{ matrix.toolchain-version }}
           fi
 
       - name: Send error notification
-        if: ${{ env.TG_DISABLED == 'false' && failure() }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' && failure() }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
             export TG_TOPIC=""
           fi
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC error $TAG_NAME "CI Failed!" ${{ github.run_id }} ${{ matrix.toolchain-version }} ${{ github.repository }}
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" error $TAG_NAME "CI Failed!" ${{ github.run_id }} ${{ matrix.toolchain-version }} ${{ github.repository }}
 
   notify-completion:
     needs: [build-toolchain, notify-begin]
@@ -444,7 +444,7 @@ jobs:
           ref: "master"
 
       - name: Send notify completion summary
-        if: ${{ env.TG_DISABLED == 'false' }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
@@ -455,4 +455,4 @@ jobs:
           ELAPSED=$((END_TIME - START_TIME))
           ELAPSED_MIN=$((ELAPSED / 60))
           ELAPSED_SEC=$((ELAPSED % 60))
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC finish ${{ github.workflow }} "${ELAPSED_MIN}m ${ELAPSED_SEC}s" ${{ github.run_id }} ${{ github.repository }}
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" finish ${{ github.workflow }} "${ELAPSED_MIN}m ${ELAPSED_SEC}s" ${{ github.run_id }} ${{ github.repository }}

--- a/.github/workflows/toolchain-x86_64.yaml
+++ b/.github/workflows/toolchain-x86_64.yaml
@@ -70,13 +70,13 @@ jobs:
           fetch-depth: "1"
 
       - name: Send build start notifcation via Telegram
-        if: env.TG_DISABLED == 'false'
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
             export TG_TOPIC=""
           fi
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC start $TAG_NAME ${{ github.run_id }} ${{ github.repository }}
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" start $TAG_NAME ${{ github.run_id }} ${{ github.repository }}
 
   generate-matrix:
     runs-on: ubuntu-24.04
@@ -403,24 +403,24 @@ jobs:
 
 
       - name: Send firmware completion notifications
-        if: ${{ env.TG_DISABLED == 'false' && (env.INGTC) }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' && (env.INGTC) }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
             export TG_TOPIC=""
           fi
           if [ -n "${{ env.INGTC  }}" ]; then
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC completed $TAG_NAME ${{ github.run_id }} ${{ github.repository }} ${GIT_HASH} ${GIT_BRANCH} ${TAG_NAME} ${TIME} ${{ matrix.toolchain-version }}
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" completed $TAG_NAME ${{ github.run_id }} ${{ github.repository }} ${GIT_HASH} ${GIT_BRANCH} ${TAG_NAME} ${TIME} ${{ matrix.toolchain-version }}
           fi
 
       - name: Send error notification
-        if: ${{ env.TG_DISABLED == 'false' && failure() }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' && failure() }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
             export TG_TOPIC=""
           fi
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC error $TAG_NAME "CI Failed!" ${{ github.run_id }} ${{ matrix.toolchain-version }} ${{ github.repository }}
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" error $TAG_NAME "CI Failed!" ${{ github.run_id }} ${{ matrix.toolchain-version }} ${{ github.repository }}
 
   notify-completion:
     needs: [build-toolchain, notify-begin]
@@ -444,7 +444,7 @@ jobs:
           ref: "master"
 
       - name: Send notify completion summary
-        if: ${{ env.TG_DISABLED == 'false' }}
+        if: ${{ env.TG_DISABLED == 'false' && env.TG_TOKEN != '' }}
         run: |
           if [[ "${{ github.event.inputs.tg_scratch }}" == 'true' ]]; then
             TG_CHANNEL=${{ env.TG_CHANNEL_SCRATCH }}
@@ -455,4 +455,4 @@ jobs:
           ELAPSED=$((END_TIME - START_TIME))
           ELAPSED_MIN=$((ELAPSED / 60))
           ELAPSED_SEC=$((ELAPSED % 60))
-          .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC finish ${{ github.workflow }} "${ELAPSED_MIN}m ${ELAPSED_SEC}s" ${{ github.run_id }} ${{ github.repository }}
+          .github/scripts/tg-notify.sh -s "$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC" finish ${{ github.workflow }} "${ELAPSED_MIN}m ${ELAPSED_SEC}s" ${{ github.run_id }} ${{ github.repository }}


### PR DESCRIPTION
`tg-notify.sh` takes its token, channel and topic as positional arguments. All 23 call sites pass them unquoted, so on a fork — where the three secrets are unset — they expand to nothing and every later argument shifts left three places.

The script cannot detect this. Its heuristic for "was a topic passed" tests whether `$3` looks like a message type; after the shift `$3` is a run id, so it takes the topic branch and reads `MESSAGE_TYPE` from the repository name:

```console
$ .github/scripts/tg-notify.sh -s $TG_TOKEN $TG_CHANNEL $TG_TOPIC start \
    thingino-master 12345 themactep/thingino-firmware
Unknown MESSAGE_TYPE: themactep/thingino-firmware
$ echo $?
1
```

That exit status fails the step, and because the notify jobs are `needs:` dependencies of the real build jobs, **the build never starts**. Every fork hits this on its first run.

## Why this does not change anything for this repository

Quoting only matters when a variable is empty. Replaying the parser against all three secret configurations:

| case | `TG_TOKEN` | `TG_CHANNEL` | `TG_TOPIC` | unquoted (today) | quoted (this PR) |
|---|---|---|---|---|---|
| 1 | set | set | set | `TYPE='start'` ✅ | `TYPE='start'` ✅ |
| 2 | set | set | *empty* | `TYPE='start'` ✅ | `TYPE='start'` ✅ |
| 3 | *empty* | *empty* | *empty* | `TYPE='themactep/thingino-firmware'` ❌ | `TYPE='start'` ✅ |

Cases 1 and 2 are the ones that run here, and they parse **identically** before and after. Case 2 is the `tg_scratch` path, which deliberately does `export TG_TOPIC=""` — the quoted empty argument lands in `$3`, fails the message-type test, and takes the same topic branch it takes today.

## The guard

Quoting alone would turn the crash into a wasted API call against an empty token, so the steps also test that the token is non-empty.

The existing `env.TG_DISABLED == 'false'` guard does not cover this. `TG_DISABLED` is set from `github.event.inputs.tg_disabled || 'false'`, so on schedule and push triggers it is the string `'false'` and the guard always passes — it is never the thing that stops a secretless fork from calling out.

## Changes

- 23 `tg-notify.sh` call sites across 6 workflows: quote `"$TG_TOKEN" "$TG_CHANNEL" "$TG_TOPIC"`
- the 23 matching step guards: add `&& env.TG_TOKEN != ''`

46 insertions, 46 deletions, no other lines touched. All 9 workflow files still parse as YAML.
