### PR TITLE
toolchain: give ext-gcc13-glibc the gcc13 toolchain

### DIFF
--- a/configs/fragments/toolchain/ext-gcc13-glibc.fragment
+++ b/configs/fragments/toolchain/ext-gcc13-glibc.fragment
@@ -1,9 +1,9 @@
 BR2_TOOLCHAIN_EXTERNAL=y
 BR2_TOOLCHAIN_EXTERNAL_CUSTOM=y
 BR2_TOOLCHAIN_EXTERNAL_DOWNLOAD=y
-BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/themactep/thingino-firmware/releases/download/toolchain-$(BR2_HOSTARCH)/thingino-toolchain-$(BR2_HOSTARCH)_$(TOOLCHAIN_SOC_TAG)_glibc_gcc14-linux-mipsel.tar.gz"
+BR2_TOOLCHAIN_EXTERNAL_URL="https://github.com/themactep/thingino-firmware/releases/download/toolchain-$(BR2_HOSTARCH)/thingino-toolchain-$(BR2_HOSTARCH)_$(TOOLCHAIN_SOC_TAG)_glibc_gcc13-linux-mipsel.tar.gz"
 BR2_TOOLCHAIN_EXTERNAL_CUSTOM_GLIBC=y
-BR2_TOOLCHAIN_EXTERNAL_GCC_14=y
+BR2_TOOLCHAIN_EXTERNAL_GCC_13=y
 BR2_TOOLCHAIN_EXTERNAL_CXX=y
 BR2_INSTALL_LIBSTDCPP=y
 BR2_TOOLCHAIN_EXTERNAL_INET_RPC=n


### PR DESCRIPTION
`Makefile:185` selects a toolchain fragment purely by filename:

```make
TOOLCHAIN_FRAGMENT_FILE := configs/fragments/toolchain/$(TOOLCHAIN_TYPE_TAG)-gcc$(TOOLCHAIN_GCC_RAW)-$(TOOLCHAIN_LIBC_TAG).fragment
```

So a board asking for GCC 13 with glibc lands on `ext-gcc13-glibc.fragment` — and gets GCC **14**:

```
BR2_TOOLCHAIN_EXTERNAL_URL="..._glibc_gcc14-linux-mipsel.tar.gz"
BR2_TOOLCHAIN_EXTERNAL_GCC_14=y
```

Its contents are otherwise identical to `ext-gcc14-glibc.fragment`, which is what it looks like — a copy where the version substitutions were never made. The musl sibling `ext-gcc13-musl.fragment` has them right, and this is the only one of the eight `ext-*` fragments whose filename disagrees with its contents.

I've changed the contents to match the filename, on the assumption the filename is the intent. **If it's the other way round the fix is `git mv` to `ext-gcc14-glibc.fragment` and deleting the duplicate** — say which and I'll redo it.
