### PR TITLE
libhelix-aac: build the portable C path on arm

### DIFF
--- a/package/libhelix-aac/0004-assembly-h-build-on-arm.patch
+++ b/package/libhelix-aac/0004-assembly-h-build-on-arm.patch
@@ -1,0 +1,20 @@
+assembly.h selects a MULSHIFT32/FASTABS/CLZ implementation per platform and
+ends the chain in "#error Unsupported platform in assembly.h". Both ARM
+branches are disabled by misspelt guards -- "defined (XXX__arm)" and
+"defined(XXXX__arm__)" -- so an ARM GCC build matches nothing and hits the
+#error. The portable C branch below covers ARDUINO, mips, powerpc and Solaris
+but not arm.
+
+Add __arm__/__aarch64__ to that branch, which is the path mips already takes.
+
+--- a/src/libhelix-aac/assembly.h
++++ b/src/libhelix-aac/assembly.h
+@@ -533,7 +533,7 @@ static __inline Word64 MADD64(Word64 sum64, int x, int y) {
+     return sum64;
+ }
+ 
+-#elif defined(ARDUINO) || defined(__GNUC__) && (defined(__mips__) || defined(__MIPS__)) || defined(__GNUC__) && (defined(__powerpc__) || defined(__POWERPC__)) || (defined (_SOLARIS) && !defined (__GNUC__) && !defined (_SOLARISX86))
++#elif defined(ARDUINO) || defined(__GNUC__) && (defined(__mips__) || defined(__MIPS__)) || defined(__GNUC__) && (defined(__arm__) || defined(__aarch64__)) || defined(__GNUC__) && (defined(__powerpc__) || defined(__POWERPC__)) || (defined (_SOLARIS) && !defined (__GNUC__) && !defined (_SOLARISX86))
+ 
+ typedef long long Word64;
+ 


### PR DESCRIPTION
## The problem

`assembly.h` selects a `MULSHIFT32`/`FASTABS`/`CLZ` implementation per platform and ends the chain in `#error Unsupported platform in assembly.h` (line 646). Both of its ARM branches are disabled by misspelt guards:

```c
assembly.h:246  #elif defined (XXX__arm) && defined (__ARMCC_VERSION)
assembly.h:368  #elif defined(__GNUC__) && defined(XXXX__arm__)
```

So an ARM GCC build matches nothing and stops at the `#error`, on all 15 sources that include the header. The portable C branch just below covers `ARDUINO`, mips, powerpc and Solaris — but not arm.

## The fix

Add `__arm__`/`__aarch64__` to the portable branch. That is the same path mips already takes, so this is the plain-C implementation thingino ships on Ingenic today — no inline assembly.

Reviving the disabled ARM assembly branch is the other option. I did not, because it is switched off upstream for a reason nobody wrote down, and this decoder feeds the WebRTC audio path.

## Why no existing board can be affected

The change adds one disjunct to an `||` chain, gated on `__arm__`/`__aarch64__`. Evaluating the old and new conditions under the preprocessor:

| target | old | new |
|---|---|---|
| `__mips__` | TAKEN | TAKEN |
| `__powerpc__` | TAKEN | TAKEN |
| `__i386__` | NOT_TAKEN | NOT_TAKEN |
| `__arm__` | NOT_TAKEN | **TAKEN** |
| `__aarch64__` | NOT_TAKEN | **TAKEN** |

No MIPS target can reach the added clause, so every board in the tree compiles the same object it does today.

## Applying

Verified against a pristine checkout of `74fc1f09` with `0001`–`0003` applied first; `0004` then applies cleanly under both `patch -p1` and the stricter `git apply --check`.

The patch header is bare, matching the style of the three patches already in this directory.

## How this surfaced

Worth noting given #1372 just landed here: before that `set -e` fix, this was **not** a build failure. The `$(foreach ...)` loop joined its commands with `;`, so the 15 failing sources were skipped and the final `-shared` link succeeded over the 13 objects that did build, producing a library that loaded and then died on first use:

```
rwd: symbol lookup error: /lib/libhelix-aac.so: undefined symbol: UncoupleSBRNoise
```

With `set -e` in place the ARM build now fails loudly at the `#error` instead, which is how it should have behaved all along.
