### PR TITLE
makefile: dispatch the bootloader targets on the soc vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,12 @@ HOST_DIR = $(OUTPUT_DIR)/host
 # include thingino makefile only when board configuration is available
 ifeq ($(SKIP_CAMERA_SELECTION),)
 include $(BR2_EXTERNAL)/thingino.mk
+# Vendor build rules. Missing means the vendor has no board support layer, which
+# is a packaging bug rather than a configuration the user can reach.
+ifeq ($(wildcard $(SOC_VENDOR_MK)),)
+$(error no vendor build rules for SOC_VENDOR '$(SOC_VENDOR)' (expected $(SOC_VENDOR_MK)))
+endif
+include $(SOC_VENDOR_MK)
 endif
 
 # Capped XBurst1 SoCs (T10/T20/T21/T30) boot a TPL chain with modern u-boot; allow legacy names
@@ -1154,7 +1160,7 @@ endif
 # Rebuild U-Boot with actual partition sizes after rootfs is ready
 $(U_BOOT_BIN): $(U_BOOT_ENV_TXT)
 	$(info -------------------------------- $@ (rebuilding with actual partition sizes))
-	$(call thingino_run_build,$(BR2_MAKE) $(BR2_MAKE_JOBS) host-libyaml host-uboot-tools uboot-dirclean uboot)
+	$(call thingino_run_build,$(BR2_MAKE) $(BR2_MAKE_JOBS) host-libyaml host-uboot-tools $(VENDOR_BOOTLOADER_TARGETS))
 
 $(UB_ENV_BIN): $(U_BOOT_ENV_TXT)
 	@$(TEAL) "$@"

--- a/board/ingenic/vendor.mk
+++ b/board/ingenic/vendor.mk
@@ -1,0 +1,8 @@
+# Ingenic-specific build rules for the top-level Makefile.
+#
+# Included via SOC_VENDOR_MK. A vendor that does not build its bootloader from
+# package/thingino-uboot leaves VENDOR_BOOTLOADER_TARGETS empty.
+
+# Targets that produce $(U_BOOT_BIN). thingino-uboot wraps gtxaspec/u-boot-ingenic,
+# whose defconfig is derived per SoC, so the tree is cleaned before every rebuild.
+VENDOR_BOOTLOADER_TARGETS := uboot-dirclean uboot

--- a/thingino.mk
+++ b/thingino.mk
@@ -7,6 +7,9 @@ qstrip ?= $(strip $(subst ",,$(1)))
 
 SOC_VENDOR := ingenic
 
+# Per-vendor build rules, included by the top-level Makefile.
+SOC_VENDOR_MK := $(BR2_EXTERNAL)/board/$(SOC_VENDOR)/vendor.mk
+
 # Get SoC model from BR2_INGENIC_SOC_MODEL (single source of truth)
 SOC_MODEL_INPUT := $(call qstrip,$(BR2_INGENIC_SOC_MODEL))
 ifneq ($(SOC_MODEL_INPUT),)


### PR DESCRIPTION
Deliberately smaller than the problem — the rest is a design question I'd rather ask than answer for you. Companion to #1391 (SoC vendor choice); they are independent and this one does not need it.

## The failure

`make fast` is the invocation your own CI runs (`firmware-master.yaml:374`):

```yaml
BOARD=${{ matrix.thingino-version }} make fast WORKFLOW=1
```

`fast` → `pack` → `$(FIRMWARE_BIN_FULL)` → `$(U_BOOT_BIN)`, whose recipe was:

```make
$(U_BOOT_BIN): $(U_BOOT_ENV_TXT)
	$(call thingino_run_build,... host-libyaml host-uboot-tools uboot-dirclean uboot)
```

`uboot-dirclean` only exists when `package/thingino-uboot` is enabled. For a board that builds its bootloader from a *different* package, `make fast` dies with:

```
*** No rule to make target 'uboot-dirclean'.  Stop.
```

Every board in the tree today enables `thingino-uboot`, so nothing is broken right now. It matters because the CI matrix is auto-discovered from `configs/cameras/*_defconfig` (`firmware-master.yaml:132-134`) — so the *first* board that builds its bootloader another way turns your CI red on merge, with no matrix entry to opt out of.

## The change

The smallest thing that removes the hardcoded assumption: a per-vendor makefile, and one variable.

```make
# thingino.mk
SOC_VENDOR_MK := $(BR2_EXTERNAL)/board/$(SOC_VENDOR)/vendor.mk

# board/ingenic/vendor.mk
VENDOR_BOOTLOADER_TARGETS := uboot-dirclean uboot

# Makefile
	$(call thingino_run_build,... host-libyaml host-uboot-tools $(VENDOR_BOOTLOADER_TARGETS))
```

18 insertions, 1 deletion. A missing `vendor.mk` is an `$(error)` with the expected path, so a new vendor fails diagnostically instead of with `No rule to make target`.

## Evidence for Ingenic

The variable expands to exactly the two words it replaced:

```
$ make BOARD=jooan_w8u_t23n_sc2336_atbm6132u WORKFLOW=1 \
    --eval='__pv:;@echo "[$(VENDOR_BOOTLOADER_TARGETS)]"' __pv
[uboot-dirclean uboot]
```

so the recipe is textually identical after expansion, and no Kconfig is touched.

- `make fast` exits 0 on `jooan_w8u_t23n_sc2336_atbm6132u` (the only raptor board, and dual-sensor, so it exercises more of the packaging path than most)
- `uenv.txt` byte-identical against `master` — the literal output of the path this touches
- `u-boot-env.bin` identical
- `.config` byte-identical on `jooan_w8u_t23n_sc2336_atbm6132u` (t23n, 3.10.14) and `iget_c5pt_t41lq_gc4023_jl1101` (t41lq, 4.4.94)

See the comment below for why I am *not* offering `uImage`/`rootfs.squashfs` hashes.

## What I did not do, and why I'm asking

Three things sit on this path. I have not touched any of them, because each is a decision about *your* build system rather than a bug:

1. **Where does `vendor.mk` belong?** I put it at `board/<vendor>/vendor.mk` because `board/ingenic/` already exists. `configs/vendor/` or a top-level file are equally defensible.

2. **Should the three flash-media dispatch blocks move into it?** `pack` reporting (`Makefile:739-778`), `$(FIRMWARE_BIN_FULL)` (`:955-1065`) and `$(U_BOOT_ENV_TXT)` (`:1113-1145`) are already 3-way `ifeq` chains on boot media, and boot media is a property of the vendor's bootloader — so one level of indirection above what exists looks more natural than a fourth arm bolted onto each. That is a ~220-line move of working code and I did not want to send it unsolicited.

3. **How should a non-Ingenic SoC supply `UBOOT_BIN_NAME`?** `Makefile:244` derives it from `scripts/get_soc_params.sh $(SOC_MODEL) uboot_image`, which reads `scripts/soc_database.txt` — an Ingenic-only table. A vendor whose bootloader package installs, say, `u-boot-<soc>-nor.bin` has no way to say so except by falling through to the `u-boot-with-spl-lzma.bin` default. Another `vendor.mk` variable is the obvious answer, but where the name comes from is your call.

One thing I'd actively **recommend against**, in case it comes up in review: renaming the Ingenic-named `UBOOT_FLASH_CONTROLLER` / `BR2_PACKAGE_THINGINO_UBOOT_FLASH_CONTROLLER_*` symbols. That would churn all 170 camera defconfigs to no benefit.

## Coverage gap

The NAND arm of these dispatches is not exercised by anything I can build: `BR2_THINGINO_FLASH_NAND=y` appears only in `configs/cameras-exp/` (`wyze_cam3pro_t40xp_gc4653_rtl8192fs`, `360_k7ts_t41nq_gc4023_eth`) and in the fragment/layout files — no board under `configs/cameras/` sets it. This PR does not modify those blocks, but if you take question 2 above, that arm would move untested.

<sub>Context: this comes out of a SigmaStar (ARMv7) port. That board <b>does</b> build a bootloader — a separate package, producing <code>u-boot-&lt;soc&gt;-nor.bin</code> in <code>images/</code> — so its <code>VENDOR_BOOTLOADER_TARGETS</code> is a real target list, not empty. It is the target name and the output filename that are Ingenic-specific here, not the existence of a bootloader.</sub>
