### PR TITLE
timps webui: expose adaptive night-recovery and boot-settle daynight tunables

### DIFF
--- a/package/timps/files/www/a/config-photosensing.js
+++ b/package/timps/files/www/a/config-photosensing.js
@@ -7,6 +7,13 @@
  *   #daynight_enabled                     -> daynight.enabled
  *   #daynight_total_gain_night_threshold  -> daynight.total_gain_night_threshold
  *   #daynight_total_gain_day_threshold    -> daynight.total_gain_day_threshold
+ *   #daynight_day_gain_pct                -> daynight.day_gain_pct
+ *   #daynight_baseline_delay_s            -> daynight.baseline_delay_s
+ *   #daynight_night_reconfirm_s           -> daynight.night_reconfirm_s
+ *   #daynight_boot_settle_s/_max_s        -> daynight.boot_settle_s/_max_s
+ *   #daynight_boot_stable_pct             -> daynight.boot_stable_pct
+ *   (read-only: #daynight_night_baseline/#daynight_day_trigger from the
+ *    status fields of the same names - the adaptive trigger in effect)
  *   #daynight_mode                        -> daynight.mode (sensor/time/sun)
  *   #daynight_time_night_start/day_start  -> daynight.time_night_start/day_start
  *   #daynight_sun_latitude/longitude      -> daynight.sun_latitude/longitude
@@ -72,13 +79,25 @@
     var mode = $("daynight_mode");
     if (mode && typeof dn.dn_mode === "string") mode.value = dn.dn_mode;
 
-    // gain thresholds are rounded ints; the rest keep their given value
-    ["total_gain_night_threshold", "total_gain_day_threshold"].forEach(function (k) {
+    // gain thresholds + adaptive/boot tunables are rounded ints; the rest
+    // keep their given value
+    ["total_gain_night_threshold", "total_gain_day_threshold",
+     "day_gain_pct", "baseline_delay_s", "night_reconfirm_s",
+     "boot_settle_s", "boot_settle_max_s", "boot_stable_pct"].forEach(function (k) {
       var el = $("daynight_" + k);
       if (!el) return;
       var v = dn[k];
       el.value = (v === null || typeof v === "undefined") ? "" : Math.round(v);
     });
+
+    // read-only adaptive-baseline feedback (only meaningful in night mode;
+    // timps reports -1 when none is in effect)
+    var nb = $("daynight_night_baseline");
+    var dt = $("daynight_day_trigger");
+    if (nb) nb.textContent = (typeof dn.night_baseline === "number" && dn.night_baseline >= 0)
+      ? Math.round(dn.night_baseline) : "-";
+    if (dt) dt.textContent = (typeof dn.day_trigger === "number" && dn.day_trigger >= 0)
+      ? Math.round(dn.day_trigger) : "-";
     ["sun_latitude", "sun_longitude",
      "sun_sunrise_offset_min", "sun_sunset_offset_min"].forEach(function (k) {
       var el = $("daynight_" + k);
@@ -108,7 +127,9 @@
     var mode = $("daynight_mode");
     if (mode) out.mode = mode.value;
 
-    ["total_gain_night_threshold", "total_gain_day_threshold"].forEach(function (k) {
+    ["total_gain_night_threshold", "total_gain_day_threshold",
+     "day_gain_pct", "baseline_delay_s", "night_reconfirm_s",
+     "boot_settle_s", "boot_settle_max_s", "boot_stable_pct"].forEach(function (k) {
       var el = $("daynight_" + k);
       if (!el) return;
       var v = parseInt(el.value, 10);

--- a/package/timps/files/www/config-photosensing.html
+++ b/package/timps/files/www/config-photosensing.html
@@ -137,6 +137,60 @@
                     day <span id="daynight_sun_computed_sunrise">--:--</span> &rarr; night <span id="daynight_sun_computed_sunset">--:--</span>.</small>
                 </div>
               </div>
+              <div class="col">
+                <h4>Adaptive night recovery</h4>
+                <small>Night&rarr;day triggers relative to a gain baseline sampled in darkness</small>
+                <p class="number-range">
+                  <label for="daynight_day_gain_pct">Day trigger (% of night baseline)</label>
+                  <span class="input-group">
+                    <input type="text" id="daynight_day_gain_pct" name="daynight_day_gain_pct" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="0" data-max="100" data-step="1">
+                    <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
+                  </span>
+                </p>
+                <p class="number-range">
+                  <label for="daynight_baseline_delay_s">Baseline sample delay (s)</label>
+                  <span class="input-group">
+                    <input type="text" id="daynight_baseline_delay_s" name="daynight_baseline_delay_s" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="0" data-max="3600" data-step="1">
+                    <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
+                  </span>
+                </p>
+                <p class="number-range">
+                  <label for="daynight_night_reconfirm_s">Night reconfirm probe every (s, 0 = off)</label>
+                  <span class="input-group">
+                    <input type="text" id="daynight_night_reconfirm_s" name="daynight_night_reconfirm_s" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="0" data-max="86400" data-step="1">
+                    <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
+                  </span>
+                </p>
+                <small class="text-secondary">Live: baseline <span id="daynight_night_baseline">-</span>,
+                  day below <span id="daynight_day_trigger">-</span>.
+                  The baseline self-corrects upward while night lasts, and a sustained
+                  brightening that stays above the strict trigger fires an early day probe.</small>
+              </div>
+              <div class="col">
+                <h4>Boot settle</h4>
+                <small>How long the first decision waits for the AE to converge after start</small>
+                <p class="number-range">
+                  <label for="daynight_boot_settle_s">Minimum settle (s)</label>
+                  <span class="input-group">
+                    <input type="text" id="daynight_boot_settle_s" name="daynight_boot_settle_s" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="0" data-max="600" data-step="1">
+                    <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
+                  </span>
+                </p>
+                <p class="number-range">
+                  <label for="daynight_boot_settle_max_s">Maximum settle wait (s)</label>
+                  <span class="input-group">
+                    <input type="text" id="daynight_boot_settle_max_s" name="daynight_boot_settle_max_s" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="0" data-max="3600" data-step="1">
+                    <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
+                  </span>
+                </p>
+                <p class="number-range">
+                  <label for="daynight_boot_stable_pct">Gain considered stable within (%)</label>
+                  <span class="input-group">
+                    <input type="text" id="daynight_boot_stable_pct" name="daynight_boot_stable_pct" class="form-control text-end" value="" pattern="[0-9]{1,}" title="numeric value" data-min="0" data-max="100" data-step="1">
+                    <button type="button" class="btn btn-outline-secondary dropdown-toggle" aria-label="Open slider"></button>
+                  </span>
+                </p>
+              </div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary

timps's day/night auto-switching gained an adaptive night-baseline-relative trigger (`day_gain_pct`, `baseline_delay_s`), a boot-time AE-settle guard (`boot_settle_s`, `boot_settle_max_s`, `boot_stable_pct`), and a periodic self-healing reconfirm probe (`night_reconfirm_s`) across timps v1.7.1-v1.7.4. All of these are live-settable via `/control` and persist to `/etc/timps.conf`, but the Photosensing config page only ever exposed the two flat gain thresholds (`total_gain_night_threshold`/`total_gain_day_threshold`) - the rest were only reachable by hand-crafting a `POST /control` JSON body.

## Changes

- `config-photosensing.html`: two new form sections -
  - **Adaptive night recovery**: `day_gain_pct`, `baseline_delay_s`, `night_reconfirm_s`, plus a read-only live readout of the currently-effective `night_baseline`/`day_trigger` (so a user can see the actual adaptive bar timps is enforcing right now, not just the config that produced it).
  - **Boot settle**: `boot_settle_s`, `boot_settle_max_s`, `boot_stable_pct`.
  - Slider ranges match the existing `config.c` clamps for each field.
- `a/config-photosensing.js`: wires the new fields into the existing load/save round-trip (same pattern as the pre-existing gain thresholds), and renders the read-only `night_baseline`/`day_trigger` status fields.

No backend/daemon changes - this is UI-only, exposing config surface that already existed and was already fully functional via the API.

## Testing

Verified live against a real T31 camera running timps v1.7.4: page loads existing values correctly, edits round-trip through `/control` and persist across a save, and the live baseline/trigger readout updates to match the daemon's actual computed values (cross-checked against `GET /control`'s `daynight` object and the daemon's own log lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)