### PR TITLE
timps: bump TIMPS_VERSION to v1.7.4

### DIFF
--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,7 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.6.1
+TIMPS_VERSION = v1.7.4
 TIMPS_LICENSE = MIT
 # Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
 # once it exists so legal-info can capture it.


### PR DESCRIPTION
## Summary

Bumps the pinned `timps` version from v1.6.1 to v1.7.4 — ~80 commits, full details in [CHANGELOG.md](https://github.com/Lu-Fi/timps/blob/main/CHANGELOG.md). Highlights:

**v1.7.0**
- HTTP Digest authentication (RFC 7616 `qop=auth` + legacy RFC 2069) alongside Basic, for both HTTP preview and RTSP.
- Read-only encoder telemetry (`IMP_Encoder_Query`, plus `ave_bitrate` on T31) exposed in `GET /control`.
- Per-client adaptive fMP4 frame-dropping on weak links; live IVS motion sensitivity; opt-in backchannel AEC.
- `rotation=180` removed on classic-API SoCs (mechanically identical to hflip+vflip there), restored specifically for T40/T41 (genuine per-channel I2D 180°).
- **T31 FS-rotate / T23 SW-rotate crash safety**: an out-of-envelope rotation request used to silently fail encoder bring-up and take the *entire* multi-stream pipeline down; now refused per-stream instead.
- A large batch of RTSP/RTP/RTCP/SDP conformance fixes from several review rounds: `SET_PARAMETER` keepalive (200 instead of 405), idle TCP backchannel-only session reaping, `Content-Length` body framing, `rtsps://` scheme handling, `Require:` tag rejection (551), Digest `uri=` verification, orphaned UDP session reaping, `HEAD` semantics (RFC 7231 §4.3.2), plus `/control` JSON-encoding hardening (control-char/UTF-8, `\uXXXX`, fail-closed instead of truncated).
- Motion-detection grid/rotation-orientation fixes, day/night latch and hysteresis fixes, recording/timelapse fixes, and several buffer-sizing/performance changes (`sendmmsg` RTP batching, table-driven `/control` lookup, per-thread stack sizing).

**v1.7.1 → v1.7.4 — day/night hardening**, driven by real stuck-in-night incidents on live cameras:
- Adaptive boot-settle (waits for AE to actually stabilize after a reflash instead of a fixed 5s window) + a periodic self-healing day-pipeline reconfirm probe (v1.7.1), and exposing the new fields in `GET /control` (v1.7.2, they were settable but not readable back).
- Threshold hardening for two real incidents where a legitimately-lit room's gain never crossed the adaptive threshold (v1.7.3) — then a fix for a regression that hardening pass introduced: an upward-only baseline drift could ratchet against noisy night-mode AGC and flap night/day every few minutes to every hour, worse than before. Replaced with a noise-resistant smoothed-gain-driven symmetric drift plus a post-probe AE-stability gate (v1.7.4). Verified by replaying the exact logged flap pattern in the host simulator (zero flaps over 3 minutes where the prior version flapped every 1-2 minutes) and against the two original incidents (still resolve correctly).

Full changelog: https://github.com/Lu-Fi/timps/blob/main/CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)