### PR TITLE
timps: bump TIMPS_VERSION to v1.7.6

### DIFF
--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,7 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.7.4
+TIMPS_VERSION = v1.7.6
 TIMPS_LICENSE = MIT
 # Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
 # once it exists so legal-info can capture it.


### PR DESCRIPTION
## Summary
Bumps the pinned timps version from v1.7.4 to v1.7.6, picking up two releases:

**v1.7.5** - the day/night detection thread could get permanently stuck at boot with zero self-healing: if the first-ever gain reading after boot landed inside the configured day/night dead-zone, the original design silently stayed in an undecided state forever, and both self-healing probes (periodic reconfirm, sustained brightening) were gated on already being in a specific state that the stuck state never satisfies. Fixed via "dead-zone adoption": once the boot-settle window ends still undecided, the thread adopts the persisted `image.running_mode` and arms a mandatory one-shot early verify probe.

**v1.7.6** - a comprehensive codebase-wide audit for the same bug class (a thread reaching a healthy-looking, silently-stuck state with no reachable recovery path), followed by fixes for every confirmed instance:
- Motion detection (`imp_motion.c`) could silently stall forever with `motion.enabled` still reporting true - added a stall watchdog + new `motion.stalled` status field.
- RTSP sessions could become immortal - the idle-reap exemption was keyed off a transport flag latched at SETUP time instead of real per-sink TCP write activity, so several transport combinations (UDP video + TCP-only backchannel, a transport-switch re-SETUP, etc.) were excluded from both the idle reaper and `SO_SNDTIMEO`.
- HTTP fMP4/MJPEG and SRT streaming loops could spin forever on an encoder stall (disconnect detection was entirely data-driven) - added a 60s idle bound to all three.
- The audio watchdog reset its own miss-streak counter before the call it was meant to guard, so a persistently failing `GetFrame` could never trip it.
- The JPEG (snapshot/MJPEG) encoder thread had no stall watchdog at all, unlike the video encoder thread.
- Framesource `EnableChn` failures were never retried once another holder (e.g. motion detection) kept the refcount above 0.
- Backchannel/speaker ownership had no inactivity release, so a session that talked once and went quiet could block talk/play for every other client indefinitely.
- SRT client threads had zero liveness check when the source stopped publishing.
- Several smaller visibility/config-trap fixes (a `record.post_roll_s=0` config trap, motion-gate status visibility, an OSD updater thread-create failure that logged nothing, a debug-only ISP-unreadable warning).

Full changelog: https://github.com/Lu-Fi/timps/blob/main/CHANGELOG.md

## Test plan
- [x] `make sim` (host simulation backend) builds clean
- [x] Real T31 cross-build (via this firmware tree) builds clean
- [x] Every fix independently reviewed against the actual diff before landing
- [x] Deployed to one camera and passed the standard QA suite (`scripts/timps-qa.sh`) before wider rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)