### PR TITLE
soc: declare the sigmastar soc model

### DIFF
--- a/Config.soc.in
+++ b/Config.soc.in
@@ -36,6 +36,18 @@ config BR2_INGENIC_SOC_MODEL
 
 	  Leave empty to use legacy BR2_SOC_INGENIC_* variables (for backward compatibility).
 
+config BR2_SIGMASTAR_SOC_MODEL
+	string "SoC Model"
+	depends on BR2_SOC_VENDOR_SIGMASTAR
+	default ""
+	help
+	  Enter the SigmaStar SoC model name for your device (e.g., ssc30kq).
+	  This value is used to automatically derive the SoC family.
+
+	  Supported models: ssc30kq
+
+	  Note: Model name is case-insensitive.
+
 config BR2_SOC_FAMILY
 	string
 	default "t10" if BR2_INGENIC_SOC_MODEL = "t10l" || BR2_INGENIC_SOC_MODEL = "t10n" || BR2_INGENIC_SOC_MODEL = "t10a"
@@ -49,6 +61,9 @@ config BR2_SOC_FAMILY
 	default "t40" if BR2_INGENIC_SOC_MODEL = "t40n" || BR2_INGENIC_SOC_MODEL = "t40nn" || BR2_INGENIC_SOC_MODEL = "t40xp" || BR2_INGENIC_SOC_MODEL = "t40a"
 	default "t41" if BR2_INGENIC_SOC_MODEL = "t41lq" || BR2_INGENIC_SOC_MODEL = "t41nq" || BR2_INGENIC_SOC_MODEL = "t41zl" || BR2_INGENIC_SOC_MODEL = "t41zn" || BR2_INGENIC_SOC_MODEL = "t41zx" || BR2_INGENIC_SOC_MODEL = "t41a"
 	default "a1" if BR2_INGENIC_SOC_MODEL = "a1n" || BR2_INGENIC_SOC_MODEL = "a1nt" || BR2_INGENIC_SOC_MODEL = "a1x" || BR2_INGENIC_SOC_MODEL = "a1l" || BR2_INGENIC_SOC_MODEL = "a1a"
+	# Only one vendor's model symbol is ever non-empty, so the two halves of
+	# this chain cannot both match and their order does not matter.
+	default "infinity6e" if BR2_SIGMASTAR_SOC_MODEL = "ssc30kq"
 
 config BR2_SOC_RAM_MB
 	int "RAM size in MB"


### PR DESCRIPTION
Follows #1391, which added the SoC vendor choice.

Mirrors `BR2_INGENIC_SOC_MODEL`:  plus a `BR2_SOC_FAMILY` default keyed on it.

Only one vendor's model symbol is ever non-empty — each is `depends on` its own vendor, and the vendor is a `choice` — so the two halves of the chain cannot both match and their relative order does not matter.

## Why no existing board can be affected

`BR2_SIGMASTAR_SOC_MODEL` is invisible without `BR2_SOC_VENDOR_SIGMASTAR` and defaults to `""`, so on every Ingenic board the added `default` line evaluates false and the symbol is not written to `.config` at all.

Verified rather than argued — `.config` regenerated before and after on four boards spanning the families whose behaviour keys on `BR2_SOC_FAMILY`:

| board | SoC | result |
|---|---|---|
| `atom_cam2_t31x_gc2053_atbm6031` | t31 | identical |
| `jooan_w8u_t23n_sc2336_atbm6132u` | t23 | identical |
| `smart_nvr_a1n_eth` | a1 | identical |
| `iget_c5pt_t41lq_gc4023_jl1101` | t41 | identical |

## Scope

Kconfig only. The matching `thingino.mk` change, which derives `SOC_FAMILY` from this symbol for the make side, needs the per-vendor block that arrives with the SigmaStar board support layer, so it is not in this PR.
