### PR TITLE
timps: bump to v1.7.7, add optional Opus streaming audio codec

### DIFF
--- a/package/timps/Config.in
+++ b/package/timps/Config.in
@@ -29,6 +29,28 @@ config BR2_PACKAGE_TIMPS_FAAC
 	  browser-compatible audio in the fMP4 preview and RTSP streams.
 	  Without this, only G.711 audio is available.
 
+config BR2_PACKAGE_TIMPS_STREAM_OPUS
+	bool "Opus streaming audio codec (libopus)"
+	default n
+	select BR2_PACKAGE_OPUS
+	help
+	  Offer Opus as a selectable audio.codec for the live RTSP/RTP audio
+	  track (RFC 7587), alongside the existing "aac" and "g711" (pcmu/pcma)
+	  options. When enabled, set audio.codec=opus in timps.conf (or via the
+	  /control API) to stream the microphone as Opus; leave it at aac/g711
+	  and nothing changes. The mic is encoded at its capture rate (16 kHz by
+	  default) in VOIP mode and RTP-signaled as opus/48000/2 per the RFC.
+
+	  This is the STREAMING encoder only and links the bare libopus
+	  (~337KB), NOT opusfile: RTP carries raw Opus frames with no Ogg
+	  container, so libogg and opusfile are not pulled in.
+
+	  Independent of BR2_PACKAGE_TIMPS_PLAY_OPUS below, which is the
+	  unrelated DECODE-side feature (playing local .opus sound files through
+	  the speaker via opusfile). The two do not need to agree; a board may
+	  enable either, both, or neither. Default off; when off, no Opus stream
+	  code is compiled in and "opus" is not an accepted audio.codec value.
+
 config BR2_PACKAGE_TIMPS_CONTROL
 	bool "Live control endpoint (/control)"
 	default y

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,7 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.7.6
+TIMPS_VERSION = v1.7.7
 TIMPS_LICENSE = MIT
 # Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
 # once it exists so legal-info can capture it.
@@ -45,6 +45,12 @@ endif
 # Opus playback in the play queue links opusfile (which pulls opus + libogg).
 ifeq ($(BR2_PACKAGE_TIMPS_PLAY_OPUS),y)
 	TIMPS_DEPENDENCIES += opusfile
+endif
+
+# Opus as an RTSP/RTP streaming codec links the bare libopus encoder only (no
+# opusfile / libogg - RTP carries raw Opus frames, no Ogg container).
+ifeq ($(BR2_PACKAGE_TIMPS_STREAM_OPUS),y)
+	TIMPS_DEPENDENCIES += opus
 endif
 
 # CFLAGS inherit TARGET_CFLAGS for arch-specific flags (critical for XBurst CPUs
@@ -92,6 +98,10 @@ ifeq ($(BR2_PACKAGE_TIMPS_PLAY_OPUS),y)
 	TIMPS_LIBS += -lopusfile -lopus -logg
 endif
 
+ifeq ($(BR2_PACKAGE_TIMPS_STREAM_OPUS),y)
+	TIMPS_LIBS += -lopus
+endif
+
 # Ingenic SDK blobs (libimp/libalog/libsysutils) reference libc symbols their
 # original vendor toolchain exported that modern uClibc-ng/musl dropped (e.g.
 # the glibc-2.2-era __ctype_b/__ctype_tolower bare-pointer symbols T10/T20/T21/
@@ -134,6 +144,8 @@ define TIMPS_BUILD_CMDS
 		USE_PLAY_OPUS=$(if $(BR2_PACKAGE_TIMPS_PLAY_OPUS),1,0) \
 		OPUSLIB="-lopusfile -lopus -logg" \
 		OPUS_INC=$(STAGING_DIR)/usr/include \
+		USE_STREAM_OPUS=$(if $(BR2_PACKAGE_TIMPS_STREAM_OPUS),1,0) \
+		OPUS_ENC_LIB="-lopus" \
 		-C $(@D) target
 endef
 


### PR DESCRIPTION
## Summary
- Bumps TIMPS_VERSION to v1.7.7 (daynight probe-economy: exponential backoff on failed reconfirm probes, brightening-arm margin + failure ratchet, passive-evidence probe skip with a configurable `probe_max_skip_s` safety net, and a general oscillation breaker for physical IR-reflection feedback loops; plus a config persist-clamping fix so `/control` writes persist the validated/clamped value instead of the raw pre-clamp POST body)
- Adds `BR2_PACKAGE_TIMPS_STREAM_OPUS`: Opus as a selectable RTSP/RTP streaming audio codec (RFC 7587), independent of the existing `BR2_PACKAGE_TIMPS_PLAY_OPUS` decode-side option (local .opus sound playback). Links the bare libopus encoder only (~337KB) — no opusfile/libogg, since RTP carries raw Opus frames with no Ogg container. Default off, selectable via menuconfig.

(Replaces #1408, which was opened from a branch that had accumulated unrelated un-upstreamed work — this one is rebased clean on current master with just these two files.)

## Test plan
- [x] Sim-verified daynight probe-economy changes (backoff/margin/ratchet/skip/oscillation) in timpsd-sim
- [x] Real-hardware validated over a multi-day window on two cameras (garage + a second test unit), confirmed click-rate reduction
- [x] Opus streaming codec independently reviewed, one sample-rate bug found and fixed (was pinning Opus to 8kHz narrowband instead of 16kHz wideband), verified live via logread showing `opus encoder: 16000Hz ch=1 VOIP`
- [x] Config persist-clamp fix verified via three-way agreement (GET readback, on-disk file bytes, SSE echo) plus full `timps-qa.sh` section-8b regression (PASS=15, WARN=0, FAIL=0)
- [x] Deployed fleet-wide (10 cameras) on v1.7.7, all confirmed via BUILD_ID after reboot