### PR TITLE
mbedtls/timps: shrink TLS I/O buffer, fix certgen invocation

### DIFF
--- a/package/thingino-mbedtls/mbedtls-override.mk
+++ b/package/thingino-mbedtls/mbedtls-override.mk
@@ -137,6 +137,24 @@ override MBEDTLS_CONF_OPTS += -DUSE_SHARED_MBEDTLS_LIBRARY=ON -DUSE_STATIC_MBEDT
 # Add the HTTP/2 configuration hook to mbedtls
 MBEDTLS_PRE_CONFIGURE_HOOKS += MBEDTLS_ENABLE_HTTP2_FEATURES
 
+# Shrink the per-connection TLS OUTPUT buffer from the 16 KB default to 4 KB
+# (timps optimization review 2026-07-31, S4). mbedTLS allocates one IN and one
+# OUT I/O buffer per TLS connection; the IN buffer must stay at 16 KB because
+# a peer may legally send full 16 KB records (shrinking it needs the
+# Max-Fragment-Length extension, which common clients do not negotiate), but
+# the OUT buffer only bounds the records WE send. mbedtls_ssl_write() returns
+# partial writes when handed more than one record's worth, and every consumer
+# in the image (timps, libcurl, libwebsockets, ustream-ssl, libmosquitto,
+# wpa_supplicant) loops on short writes. The only hard floor is that our own
+# outgoing handshake messages (certificate chain) must fit in one buffer -
+# the self-signed device certs used here are well under 4 KB. Saves ~12 KB of
+# heap per concurrent TLS connection in every mbedTLS user on the target.
+define MBEDTLS_REDUCE_OUT_CONTENT_LEN
+	$(SED) "s:^//#define MBEDTLS_SSL_OUT_CONTENT_LEN.*:#define MBEDTLS_SSL_OUT_CONTENT_LEN 4096:" \
+		$(@D)/include/mbedtls/mbedtls_config.h
+endef
+MBEDTLS_PRE_CONFIGURE_HOOKS += MBEDTLS_REDUCE_OUT_CONTENT_LEN
+
 # mbedTLS 3.6.6 defaults MBEDTLS_PLATFORM_DEV_RANDOM to /dev/random.
 # On low-entropy systems this can block indefinitely in libcurl/uhttpd.
 define MBEDTLS_USE_URANDOM

--- a/package/timps/files/generate-tls-certs.sh
+++ b/package/timps/files/generate-tls-certs.sh
@@ -23,15 +23,26 @@ if command -v openssl >/dev/null 2>&1; then
 		-days 3650 -nodes \
 		-subj "/C=US/ST=State/L=City/O=Thingino/CN=camera.local" \
 		2>/dev/null
-	chmod 600 "$KEY"
-	chmod 644 "$CERT"
+	ret=$?
+	chmod 600 "$KEY" 2>/dev/null
+	chmod 644 "$CERT" 2>/dev/null
 elif command -v mbedtls-certgen >/dev/null 2>&1; then
 	echo "Generating self-signed certificate with mbedtls-certgen..."
-	mbedtls-certgen server "$CERT" "$KEY" \
-		--cn camera.local --days 3650
+	# mbedtls-certgen's flags, not openssl's: -h hostname -c cert -k key
+	# (no positional "server" arg, no --cn/--days long options).
+	mbedtls-certgen -h camera.local -c "$CERT" -k "$KEY" -d 3650
+	ret=$?
 	chmod 600 "$KEY" 2>/dev/null
 else
 	echo "WARNING: No TLS tool found, skipping certificate generation."
+	exit 1
+fi
+
+# Neither branch above may have written both files (wrong flags, disk full,
+# etc.) - checking $ret alone isn't enough since a tool can exit 0 without
+# producing a usable pair, so also verify the outputs are actually there.
+if [ "$ret" -ne 0 ] || [ ! -s "$CERT" ] || [ ! -s "$KEY" ]; then
+	echo "ERROR: certificate generation failed (exit $ret)"
 	exit 1
 fi
 


### PR DESCRIPTION
## Summary
- Shrinks the mbedTLS TLS OUT I/O buffer from 16KB to 4KB per connection, reducing per-connection RAM footprint on flash/RAM-constrained boards.
- Fixes an incorrect mbedtls-certgen invocation in timps' TLS certificate generation script (`generate-tls-certs.sh`).

Split out of un-upstreamed work accumulated on our timps-package fork branch — unrelated to the ONVIF fix in a separate PR.

## Test plan
- [x] Deployed on cameras running `BR2_PACKAGE_TIMPS_TLS=y`, HTTPS/RTSPS confirmed working with the smaller buffer