### PR TITLE
timps: clarify rotation=180 behavior (real on T40/T41, no-op elsewhere)

### DIFF
--- a/package/timps/Config.in
+++ b/package/timps/Config.in
@@ -86,14 +86,19 @@ config BR2_PACKAGE_TIMPS_SRT
 	  Playback: ffplay srt://<ip>:9000
 
 config BR2_PACKAGE_TIMPS_ROTATE
-	bool "Image rotation (90/180/270)"
+	bool "Image rotation (90/270)"
 	default n
 	help
-	  Enable per-stream image rotation. 180 is available on all SoCs
-	  (realised as a global ISP Hflip+Vflip); hardware 90/270 rotation
-	  is available on T40/T41 (I2D) and T31 (FrameSource rotate).
-	  Rotation is restart-required. Disabled by default: when off, no
-	  rotation code is compiled in (byte-identical build).
+	  Enable per-stream image rotation (real 90/270 transpose only):
+	  hardware 90/270 on T40/T41 (I2D) and T31 (FrameSource rotate), or
+	  the opt-in software path below for T23. On SoCs with no 90/270
+	  path (T10/T20/T21/T30/C100, and T23 without SW_ROTATE) this option
+	  has no usable effect - rotation accepts no non-zero value there.
+	  For a 180 flip use image.hflip=1 + image.vflip=1 (always available,
+	  independent of this option); rotation=180 was removed - it was only
+	  a redundant global ISP Hflip+Vflip. Rotation is restart-required.
+	  Disabled by default: when off, no rotation code is compiled in
+	  (byte-identical build).
 
 config BR2_PACKAGE_TIMPS_SW_ROTATE
 	bool "Software 90/270 on SoCs without hardware rotate (T23)"

--- a/package/timps/Config.in
+++ b/package/timps/Config.in
@@ -86,17 +86,22 @@ config BR2_PACKAGE_TIMPS_SRT
 	  Playback: ffplay srt://<ip>:9000
 
 config BR2_PACKAGE_TIMPS_ROTATE
-	bool "Image rotation (90/270)"
+	bool "Image rotation (90/270, plus 180 on T40/T41)"
 	default n
 	help
-	  Enable per-stream image rotation (real 90/270 transpose only):
-	  hardware 90/270 on T40/T41 (I2D) and T31 (FrameSource rotate), or
-	  the opt-in software path below for T23. On SoCs with no 90/270
-	  path (T10/T20/T21/T30/C100, and T23 without SW_ROTATE) this option
-	  has no usable effect - rotation accepts no non-zero value there.
-	  For a 180 flip use image.hflip=1 + image.vflip=1 (always available,
-	  independent of this option); rotation=180 was removed - it was only
-	  a redundant global ISP Hflip+Vflip. Rotation is restart-required.
+	  Enable per-stream image rotation. Real 90/270 transpose: hardware
+	  90/270 on T40/T41 (I2D) and T31 (FrameSource rotate), or the opt-in
+	  software path below for T23. On SoCs with no 90/270 path
+	  (T10/T20/T21/T30/C100, and T23 without SW_ROTATE) 90/270 has no
+	  usable effect - rotation accepts no non-zero value there.
+	  rotation=180 IS still offered, but only takes effect as a real,
+	  distinct rotation on T40/T41: there it is a per-channel hardware
+	  I2D flip scoped to just that video stream. On every other SoC
+	  requesting rotation=180 has no effect (it coerces to 0) - it was a
+	  redundant GLOBAL ISP Hflip+Vflip that also flipped every sibling
+	  stream, so use image.hflip=1 + image.vflip=1 there instead for the
+	  equivalent (global) flip (always available, independent of this
+	  option). Rotation is restart-required.
 	  Disabled by default: when off, no rotation code is compiled in
 	  (byte-identical build).
 


### PR DESCRIPTION
## Summary
Two-part Config.in help-text correction for \`BR2_PACKAGE_TIMPS_ROTATE\`: rotation=180 is a real, distinct per-channel hardware I2D flip on T40/T41 only; on every other SoC it coerces to 0 (it used to be a redundant global ISP Hflip+Vflip that also flipped sibling streams — \`image.hflip=1\`+\`image.vflip=1\` is the equivalent there). Docs-only, no behavior change.

## Test plan
- [x] No functional change, help-text only