### PR TITLE
timps: bump TIMPS_VERSION to v1.7.8

### DIFF
--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,7 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.7.7
+TIMPS_VERSION = v1.7.8
 TIMPS_LICENSE = MIT
 # Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
 # once it exists so legal-info can capture it.


### PR DESCRIPTION
## Summary

- Bump `TIMPS_VERSION` v1.7.7 -> v1.7.8. `package/timps` here is otherwise
  already fully in sync with the upstream timps repo, so this is a
  version-only bump.

v1.7.8 changes (full changelog:
https://github.com/Lu-Fi/timps/blob/main/CHANGELOG.md):

- C11 data-race hardening on runtime-mutable config read cross-thread
  without synchronization: `audio.mute` (now `_Atomic`), the daynight
  detection thread (whole-struct config snapshot per poll instead of
  per-field lock-free reads), and OSD `.enabled` (checked post-snapshot
  instead of lock-free in the updater loop).
- `osd.vars_file` custom-OSD-placeholder mechanism documented, plus new QA
  coverage (round-trip test, missing `probe_max_skip_s` live-setting
  coverage, a persist-clamp regression test).
- Documented that empty `rtsp.user`/`http.user` (the shipped default) leaves
  the media endpoints open to anyone on the network while `/control`/
  `/events` stay loopback-gated.

## Test plan

- [x] v1.7.8 built and running on the full camera fleet (11 cameras, mixed
  T20/T23/T31 SoCs)
- [x] `scripts/timps-qa.sh` clean run against a live device on this build

🤖 Generated with [Claude Code](https://claude.com/claude-code)