### PR TITLE
motors: convert invert_x/invert_y booleans to integers for SPI modprobe

### DIFF
--- a/package/thingino-motors/files/S59motor
+++ b/package/thingino-motors/files/S59motor
@@ -103,12 +103,17 @@ start() {
 
 		if [ "true" = "$is_spi" ]; then
 			# invert_x/invert_y are real module params only on the SPI driver.
-			if [ -n "$invert_x" ]; then
-				modprobe_args="$modprobe_args invert_x=$invert_x"
+			# Kernel module expects integers (0/1), not booleans (true/false).
+			if [ "true" = "$invert_x" ]; then
+				modprobe_args="$modprobe_args invert_x=1"
+			elif [ -n "$invert_x" ]; then
+				modprobe_args="$modprobe_args invert_x=0"
 			fi
 
-			if [ -n "$invert_y" ]; then
-				modprobe_args="$modprobe_args invert_y=$invert_y"
+			if [ "true" = "$invert_y" ]; then
+				modprobe_args="$modprobe_args invert_y=1"
+			elif [ -n "$invert_y" ]; then
+				modprobe_args="$modprobe_args invert_y=0"
 			fi
 		else
 			modprobe_args="$modprobe_args tcu_channels=2"


### PR DESCRIPTION
Same fix as #1432 for ciao branch. The SPI motor kernel module expects integer parameters (0/1) for invert_x and invert_y, but jct returns JSON booleans (true/false). Passing false to modprobe causes Invalid argument error and the motor module fails to load. Confirmed on Tapo C200 (SPI motor) on stable. Reported-by: CaptainRon (Discord)