### PR TITLE
timps: v1.8.0 - OSD hinting default-on, real build-version reporting, WebUI polish

### DIFF
--- a/package/thingino-webui/files/www/a/footer.js
+++ b/package/thingino-webui/files/www/a/footer.js
@@ -221,9 +221,13 @@
     powerText.append("Powered by ");
     powerText.appendChild(poweredLink);
 
+    const timpsVersion = createElement("div", "small");
+    timpsVersion.id = "footer-timps-version";
+
     const buildInfo = createElement("div", "small", globalConfig.buildInfo);
 
     rightCol.appendChild(powerText);
+    rightCol.appendChild(timpsVersion);
     rightCol.appendChild(buildInfo);
 
     row.appendChild(leftCol);

--- a/package/timps/Config.in
+++ b/package/timps/Config.in
@@ -68,6 +68,27 @@ config BR2_PACKAGE_TIMPS_DAYNIGHT
 	  filter automatically. Disable if using an external photosensing
 	  solution.
 
+config BR2_PACKAGE_TIMPS_RECORD
+	bool "Local SD recording"
+	default y
+	help
+	  Enable local recording to SD as fragmented-MP4 segments
+	  (continuous or motion-triggered, pre/post-roll), including the
+	  on-demand clip capture used by the send2/Telegram motion videos.
+	  Disable on cameras without an SD slot to save ~11KB of binary
+	  size; /control then reports record.available=0 and the WebUI
+	  hides the record controls.
+
+config BR2_PACKAGE_TIMPS_TIMELAPSE
+	bool "Native timelapse"
+	default y
+	help
+	  Enable the native timelapse: periodic JPEG snapshots to SD,
+	  pruned after timelapse.keep_days. Disable on cameras without an
+	  SD slot to save ~4KB of binary size; /control then reports
+	  timelapse.available=0 and the WebUI hides the timelapse page
+	  controls.
+
 config BR2_PACKAGE_TIMPS_TLS
 	bool "TLS support (HTTPS + RTSPS via mbedTLS)"
 	default y
@@ -84,6 +105,25 @@ config BR2_PACKAGE_TIMPS_SRT
 	  Enable MPEG-TS over SRT output in listener mode. The camera
 	  acts as an SRT listener, serving live video+audio.
 	  Playback: ffplay srt://<ip>:9000
+
+config BR2_PACKAGE_TIMPS_OSD_HINTING
+	bool "OSD text autohinting (geometric stem snapping)"
+	default y
+	help
+	  Enable the opt-in geometric autohinting pass in the TTF rasterizer
+	  (msttf.c), which snaps long, near-vertical/near-horizontal glyph
+	  outline edges (typical letter stems/serifs) to the pixel grid
+	  before rasterizing. This is NOT a TrueType hint-bytecode
+	  interpreter; it is a coarse heuristic that measurably reduces
+	  uneven stroke widths between glyphs in the OSD text at small sizes
+	  (e.g. the substream OSD's default 12px).
+
+	  Controlled at runtime by the osd.hinting config key (timps.conf /
+	  /control), default 0 (off) either way. This option gates whether
+	  the autohinting code is compiled in at all; disabled by default to
+	  save binary size on boards that don't need it (measured ~2.1KB of
+	  .text on T31/GCC 16.1.0/-Os). With this off, setting osd.hinting=1
+	  in timps.conf is accepted but has no effect.
 
 config BR2_PACKAGE_TIMPS_ROTATE
 	bool "Image rotation (90/270, plus 180 on T40/T41)"

--- a/package/timps/files/www/a/footer.js
+++ b/package/timps/files/www/a/footer.js
@@ -221,9 +221,13 @@
     powerText.append("Powered by ");
     powerText.appendChild(poweredLink);
 
+    const timpsVersion = createElement("div", "small");
+    timpsVersion.id = "footer-timps-version";
+
     const buildInfo = createElement("div", "small", globalConfig.buildInfo);
 
     rightCol.appendChild(powerText);
+    rightCol.appendChild(timpsVersion);
     rightCol.appendChild(buildInfo);
 
     row.appendChild(leftCol);

--- a/package/timps/files/www/a/privacy.js
+++ b/package/timps/files/www/a/privacy.js
@@ -268,6 +268,9 @@
 
   /* ---- snapshot ---- */
 
+  var SNAPSHOT_REFRESH_MS = 4000;
+  var isWindowVisible = document.visibilityState !== "hidden";
+
   function setSnapshot() {
     window.timpsApi.token().then(function (tok) {
       var url = window.timpsApi.base() + "/snapshot.jpg?chn=" + streamIdx +
@@ -277,6 +280,21 @@
       img.src = url;
     });
   }
+
+  // Periodic re-fetch so the reference image tracks the scene while the page
+  // is open - snapshot.jpg is otherwise only fetched once (load/stream-switch/
+  // reload button), unlike the streamer pages' /stream.mjpeg which updates
+  // itself. Paused during a drag (would fight the in-progress resize/move) and
+  // while the tab is hidden (each fetch wakes the JPEG encoder - no point
+  // paying that cost for a page nobody is looking at).
+  setInterval(function () {
+    if (!isWindowVisible || dragging || !window.timpsApi) return;
+    setSnapshot();
+  }, SNAPSHOT_REFRESH_MS);
+  document.addEventListener("visibilitychange", function () {
+    isWindowVisible = document.visibilityState !== "hidden";
+    if (isWindowVisible) setSnapshot();
+  });
 
   /* ---- load ---- */
 

--- a/package/timps/files/www/a/timps-version.js
+++ b/package/timps/files/www/a/timps-version.js
@@ -1,0 +1,42 @@
+/* timps-version.js - tiny build-version badge, bottom-right corner, on every
+ * page that includes this script. Reads GET /control's "version" key (the
+ * daemon's compiled-in MS_VERSION, a git-describe string) - added after a
+ * 2026-08 incident where a stale cached build kept getting reflashed
+ * undetected; this makes "which commit is this camera actually running"
+ * visible at a glance from the WebUI, not just via a manual /control fetch.
+ * No-ops silently if timps-api.js isn't loaded or the daemon build predates
+ * the "version" field. */
+(function () {
+  "use strict";
+  if (!window.timpsApi) return;
+
+  function render(v) {
+    var slot = document.getElementById("footer-timps-version");
+    if (slot) {
+      slot.textContent = "timps " + v;
+      slot.title = "timps build version";
+      return;
+    }
+    var el = document.createElement("div");
+    el.textContent = v;
+    el.title = "timps build version";
+    el.style.cssText =
+      "position:fixed;right:6px;bottom:3px;font-size:.7rem;opacity:.35;" +
+      "font-family:monospace;pointer-events:none;z-index:1;user-select:none;";
+    document.body.appendChild(el);
+  }
+
+  function tryRender() {
+    window.timpsApi.get().then(function (j) {
+      var v = j && j.version;
+      if (!v) return;
+      render(v);
+    }).catch(function () {});
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", tryRender, { once: true });
+  } else {
+    tryRender();
+  }
+})();

--- a/package/timps/files/www/preview-timps.html
+++ b/package/timps/files/www/preview-timps.html
@@ -87,6 +87,20 @@
       font-size: 0.875rem;
       color: var(--bs-secondary-color);
     }
+    /* Statistics card: bitrate trend sparkline (per stream, drawn by the
+       inline script below from the timps /events?stream=stats feed) and the
+       small key/value blocks for the read-only camera state (day/night,
+       motion) that sit below the table. */
+    .stats-spark {
+      display: block;
+      width: 100%;
+      min-width: 100px;
+      max-width: 160px;
+      height: 32px;
+    }
+    .stats-kv-label {
+      color: var(--bs-secondary-color);
+    }
   </style>
 </head>
 
@@ -155,10 +169,54 @@
             </div>
           </div>
           <div class="ms-hint mt-2" id="ms-status"></div>
-          <!-- optional live stats (fps/subscribers/adaptive-drop counters),
-               toggled via ms-stats-toggle; fed by timps's /events?stream=stats
-               SSE (src/mp4/httpd.c stats_json) -->
-          <div class="ms-hint mt-1 font-monospace" id="ms-stats-panel" style="display:none"></div>
+        </div>
+      </div>
+    </section>
+
+    <!-- Statistics: table of live encoder/camera values + a per-stream
+         bitrate trend sparkline. Shown/hidden together with the Live View
+         card's "Stream stats" button (#ms-stats-toggle) and fed by the same
+         timps /events?stream=stats SSE (fast, ~2s, per-frame fps/kbps) plus a
+         slow GET /control poll (5s, matches the control-bar heartbeat
+         cadence) for the config-level fields SSE doesn't carry (gop/profile/
+         rc_mode, ave_bitrate, day/night, motion). See the inline script below. -->
+    <section>
+      <div class="card mb-3" id="stats-card" style="display:none">
+        <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
+          <div>
+            <h2 class="card-title mb-0">Statistics</h2>
+            <small>Live encoder &amp; camera status, from timps <code>/control</code></small>
+          </div>
+        </div>
+        <div class="card-body">
+          <div class="table-responsive">
+            <table class="table table-sm align-middle mb-3">
+              <thead>
+                <tr>
+                  <th scope="col">Stream</th>
+                  <th scope="col">Resolution</th>
+                  <th scope="col">Codec</th>
+                  <th scope="col" class="text-end">FPS</th>
+                  <th scope="col" class="text-end">Bitrate</th>
+                  <th scope="col" class="text-end" title="Measured average bitrate on T31; encoder queue backlog (frames not yet claimed) on every other platform">Avg / queue</th>
+                  <th scope="col" class="text-end">GOP</th>
+                  <th scope="col">Profile</th>
+                  <th scope="col">RC mode</th>
+                  <th scope="col" class="text-end">Subs</th>
+                  <th scope="col">Bitrate trend</th>
+                </tr>
+              </thead>
+              <tbody id="stats-table-body">
+                <tr data-placeholder><td colspan="11" class="text-secondary">Waiting for stats…</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="row row-cols-2 row-cols-md-4 g-2 small">
+            <div class="col"><span class="stats-kv-label">Day/Night</span><br><span id="stats-daynight">–</span></div>
+            <div class="col"><span class="stats-kv-label">Motion</span><br><span id="stats-motion">–</span></div>
+            <div class="col"><span class="stats-kv-label">Uptime</span><br><span id="stats-uptime">–</span></div>
+            <div class="col"><span class="stats-kv-label">Clients</span><br><span id="stats-clients">–</span></div>
+          </div>
         </div>
       </div>
     </section>
@@ -172,6 +230,8 @@
 <script src="/a/control-bar.js"></script>
 <script src="/a/navigation.js"></script>
 <script src="/a/footer.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/timps-version.js"></script>
 <script>
   (function () {
     // timps's HTTP server port (http.port in /etc/timps.conf)
@@ -184,7 +244,12 @@
     const status = document.getElementById("ms-status");
     const overlay = document.getElementById("ms-connecting-overlay");
     const statsToggle = document.getElementById("ms-stats-toggle");
-    const statsPanel = document.getElementById("ms-stats-panel");
+    const statsCard = document.getElementById("stats-card");
+    const statsBody = document.getElementById("stats-table-body");
+    const statsDaynight = document.getElementById("stats-daynight");
+    const statsMotion = document.getElementById("stats-motion");
+    const statsUptime = document.getElementById("stats-uptime");
+    const statsClients = document.getElementById("stats-clients");
     if (!video || !connectButton || !streamSelect || !status) return;
 
     let host = location.hostname || "127.0.0.1";
@@ -218,32 +283,188 @@
       });
     }
 
-    // Optional stats panel (fps/subscribers/adaptive-drop counters) via
-    // timps's /events?stream=stats SSE - same token + EventSource pattern as
+    // Statistics card (table + per-stream bitrate sparkline) via timps's
+    // /events?stream=stats SSE - same token + EventSource pattern as
     // /a/preview-motion.js. Independent of the video player's own
     // connect/disconnect lifecycle: it keeps ticking even while disconnected,
     // so it also shows other clients' activity on this channel.
+    //
+    // The SSE "stats" frame (src/mp4/httpd.c stats_json, ~every 2s by
+    // default) carries the fast-moving per-frame numbers: fps/kbps/subs/drop
+    // per enabled stream, plus uptime_s/clients. It does NOT carry the
+    // config-level encoder fields (gop/profile/rc_mode) or the ave_bitrate/
+    // day-night/motion status blocks - those only exist in GET /control, so a
+    // slow poll of /control (5s, the same cadence as the control-bar
+    // heartbeat elsewhere in this webui) fills in the rest via timps-api.js
+    // (loaded on demand by main.js's timpsApiReady(), already used by the
+    // control bar on every page). Both loops only run while the Statistics
+    // card is visible (toggled by #ms-stats-toggle).
     let statsEs = null;
+    let statsControlTimer = null;
+    const MAX_HISTORY = 40; // ~80s of samples at the default 2s stats interval
+    const streamRows = {};  // chn -> {cells:{...}, history:[kbps,...]}
+
     function formatBytes(n) {
       if (n < 1024) return n + " B";
       if (n < 1024 * 1024) return (n / 1024).toFixed(1) + " KB";
       return (n / (1024 * 1024)).toFixed(1) + " MB";
     }
-    function renderStats(j) {
-      if (!statsPanel) return;
-      const v = (j.video || []).map((s) => {
-        const drop = s.drop_frames
-          ? ` · dropped ${s.drop_frames}f/${formatBytes(s.drop_bytes)}`
-          : "";
-        return `chn${s.chn}: ${s.width}x${s.height} ${s.codec}, ${s.fps.toFixed(1)}fps, ` +
-          `${s.kbps >= 1000 ? (s.kbps / 1000).toFixed(1) + "Mbit/s" : s.kbps.toFixed(0) + "kbit/s"}, ` +
-          `${s.subs} sub${s.subs === 1 ? "" : "s"}${drop}`;
-      }).join("  |  ");
-      statsPanel.textContent = `uptime ${j.uptime_s}s · ${j.clients} client${j.clients === 1 ? "" : "s"}  |  ${v}`;
+    function formatKbps(kbps) {
+      return kbps >= 1000 ? (kbps / 1000).toFixed(2) + " Mb/s" : kbps.toFixed(0) + " kb/s";
     }
+    function streamLabel(chn) {
+      return chn === 0 ? "Main (chn0)" : chn === 1 ? "Sub (chn1)" : "chn" + chn;
+    }
+    function profileLabel(p) {
+      // config.h: 0 baseline, 1 main, 2 high (encoder profile index, not a
+      // resolution/quality "profile" in the marketing sense)
+      return p === 0 ? "0 (baseline)" : p === 1 ? "1 (main)" : p === 2 ? "2 (high)" : String(p);
+    }
+
+    // tiny hand-rolled sparkline: no charting dependency exists anywhere in
+    // this webui tree (checked a/vendor/ and package/thingino-webui/files/www
+    // - only bootstrap is vendored), and pulling one in for 1-2 mini trend
+    // lines would be disproportionate on a flash-constrained device.
+    function drawSparkline(canvas, values) {
+      if (!canvas) return;
+      const w = canvas.clientWidth || 140, h = 32;
+      canvas.width = w; canvas.height = h;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+      ctx.clearRect(0, 0, w, h);
+      if (values.length < 2) return;
+      const max = Math.max.apply(null, values), min = Math.min.apply(null, values);
+      const range = (max - min) || 1;
+      const color = getComputedStyle(document.documentElement).getPropertyValue("--bs-primary").trim() || "#0d6efd";
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      values.forEach((v, i) => {
+        const x = (i / (values.length - 1)) * (w - 2) + 1;
+        const y = h - 1 - ((v - min) / range) * (h - 2);
+        if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+      });
+      ctx.stroke();
+    }
+
+    // builds the <tr> for a stream the first time the stats SSE reports it
+    // (lazily, so the table only ever lists streams that are actually
+    // enabled/running - matches what stats_json itself reports)
+    function ensureStatsRow(chn) {
+      if (streamRows[chn]) return streamRows[chn];
+      if (!statsBody) return null;
+      const placeholder = statsBody.querySelector("tr[data-placeholder]");
+      if (placeholder) placeholder.remove();
+      const tr = document.createElement("tr");
+      const cells = {};
+      ["stream", "res", "codec", "fps", "bitrate", "avgBitrate", "gop", "profile", "rc", "subs", "trend"]
+        .forEach((c) => {
+          const td = document.createElement("td");
+          if (c === "fps" || c === "bitrate" || c === "avgBitrate" || c === "gop" || c === "subs") {
+            td.className = "text-end";
+          }
+          if (c === "trend") {
+            const canvas = document.createElement("canvas");
+            canvas.className = "stats-spark";
+            canvas.setAttribute("aria-label", "bitrate trend");
+            td.appendChild(canvas);
+            cells.canvas = canvas;
+          } else {
+            cells[c] = td;
+          }
+          tr.appendChild(td);
+        });
+      cells.stream.textContent = streamLabel(chn);
+      cells.gop.textContent = "—";
+      cells.profile.textContent = "—";
+      cells.rc.textContent = "—";
+      cells.avgBitrate.textContent = "";
+      statsBody.appendChild(tr);
+      const row = { cells, history: [] };
+      streamRows[chn] = row;
+      return row;
+    }
+
+    // fast path: fed by every "stats" SSE frame (~2s) - live fps/bitrate/subs
+    // and the bitrate trend sparkline
+    function renderStats(j) {
+      if (statsUptime) statsUptime.textContent = j.uptime_s + "s";
+      if (statsClients) statsClients.textContent = String(j.clients);
+      (j.video || []).forEach((s) => {
+        const row = ensureStatsRow(s.chn);
+        if (!row) return;
+        row.cells.res.textContent = s.width + "x" + s.height;
+        row.cells.codec.textContent = s.codec.toUpperCase();
+        row.cells.fps.textContent = s.fps.toFixed(1);
+        row.cells.bitrate.textContent = formatKbps(s.kbps);
+        row.cells.subs.textContent = s.subs + (s.subs === 1 ? " sub" : " subs");
+        row.cells.subs.title = s.drop_frames
+          ? "dropped " + s.drop_frames + " frames / " + formatBytes(s.drop_bytes)
+          : "";
+        row.history.push(s.kbps);
+        if (row.history.length > MAX_HISTORY) row.history.shift();
+        drawSparkline(row.cells.canvas, row.history);
+      });
+    }
+
+    // slow path: one GET /control every 5s while the card is visible - fills
+    // in the fields the stats SSE doesn't carry (config-level gop/profile/
+    // rc_mode, the encoder telemetry below, and day/night + motion status).
+    // Only updates rows the fast path already created; a stream absent from
+    // stats_json (disabled) never gets a control-only row.
+    function applyControlSnapshot(j) {
+      if (!j) return;
+      const video = j.video || {}, enc = j.encoder || {};
+      Object.keys(video).forEach((k) => {
+        const row = streamRows[parseInt(k, 10)];
+        if (!row) return;
+        const vcfg = video[k];
+        row.cells.gop.textContent = String(vcfg.gop);
+        row.cells.profile.textContent = profileLabel(vcfg.profile);
+        row.cells.rc.textContent = String(vcfg.rc_mode || "").toUpperCase();
+        // ave_bitrate (IMP_Encoder_GetChnAveBitrate) only exists on T31; every
+        // other platform - and a T31 stream before its first frame - reports
+        // -1 and control.c omits the field entirely. IMP_Encoder_Query's
+        // queue-backlog counters (left_pics/left_stream_bytes/left_stream_frames)
+        // ARE available on all 9 platforms, so use them as an always-present
+        // encoder-health stand-in instead of leaving the cell as a permanent
+        // "-" placeholder: a healthy encoder keeps this at/near 0, a rising
+        // value means it isn't keeping up with the source.
+        const es = enc[k];
+        if (es && typeof es.ave_bitrate === "number") {
+          row.cells.avgBitrate.textContent = formatKbps(es.ave_bitrate);
+          row.cells.avgBitrate.title = "";
+        } else if (es) {
+          row.cells.avgBitrate.textContent = es.left_pics + " q";
+          row.cells.avgBitrate.title = "encoder backlog: " + es.left_pics +
+            " frame(s) queued, " + formatBytes(es.left_stream_bytes) +
+            " / " + es.left_stream_frames + " stream frame(s) unclaimed";
+        } else {
+          row.cells.avgBitrate.textContent = "";
+          row.cells.avgBitrate.title = "";
+        }
+      });
+      const dn = j.daynight || {};
+      if (statsDaynight) {
+        const modeTxt = dn.mode === 1 ? "Night" : dn.mode === 0 ? "Day" : "Unknown";
+        const gain = (typeof dn.total_gain === "number" && dn.total_gain >= 0)
+          ? " · gain " + dn.total_gain.toFixed(0) : "";
+        statsDaynight.textContent = modeTxt + (dn.enabled ? " (auto)" : " (manual)") + gain;
+      }
+      const mo = j.motion || {};
+      if (statsMotion) {
+        statsMotion.textContent = !mo.available ? "Unavailable" : (mo.enabled ? "Enabled" : "Disabled");
+      }
+    }
+    function fetchControlSnapshot() {
+      timpsApiReady().then((api) => api.get()).then(applyControlSnapshot)
+        .catch(() => { /* offline poll tick - table just keeps its last values */ });
+    }
+
     async function startStats() {
       if (statsEs || !window.EventSource) return;
       const info = await window.timpsTokenInfo;
+      if (statsCard.style.display === "none") return; // toggled off while awaiting the token
       const b = info ? (info.tls ? "https" : "http") + "://" + host + ":" + (info.port || MS_PORT) : base;
       const tok = info && info.token ? "&token=" + encodeURIComponent(info.token) : "";
       statsEs = new EventSource(b + "/events?stream=stats" + tok);
@@ -251,20 +472,28 @@
         try { renderStats(JSON.parse(ev.data)); } catch (e) { /* ignore malformed frame */ }
       });
       statsEs.onerror = () => { /* EventSource auto-reconnects (server retry: 3000) */ };
+      fetchControlSnapshot();
+      if (!statsControlTimer) statsControlTimer = setInterval(fetchControlSnapshot, 5000);
     }
     function stopStats() {
       if (statsEs) { statsEs.close(); statsEs = null; }
-      if (statsPanel) statsPanel.textContent = "";
+      if (statsControlTimer) { clearInterval(statsControlTimer); statsControlTimer = null; }
+      Object.keys(streamRows).forEach((k) => delete streamRows[k]);
+      if (statsBody) statsBody.innerHTML = '<tr data-placeholder><td colspan="11" class="text-secondary">Waiting for stats…</td></tr>';
+      if (statsDaynight) statsDaynight.textContent = "–";
+      if (statsMotion) statsMotion.textContent = "–";
+      if (statsUptime) statsUptime.textContent = "–";
+      if (statsClients) statsClients.textContent = "–";
     }
-    if (statsToggle && statsPanel) {
+    if (statsToggle && statsCard) {
       const statsWanted = sessionStorage.getItem("ms.stats") === "1";
       const applyStatsUi = (on) => {
-        statsPanel.style.display = on ? "" : "none";
+        statsCard.style.display = on ? "" : "none";
         statsToggle.classList.toggle("active", on);
         if (on) startStats(); else stopStats();
       };
       statsToggle.addEventListener("click", () => {
-        const on = statsPanel.style.display === "none";
+        const on = statsCard.style.display === "none";
         sessionStorage.setItem("ms.stats", on ? "1" : "0");
         applyStatsUi(on);
       });

--- a/package/timps/files/www/streamer-config.html
+++ b/package/timps/files/www/streamer-config.html
@@ -54,6 +54,8 @@
 <script src="/a/control-bar.js"></script>
 <script src="/a/navigation.js"></script>
 <script src="/a/footer.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/timps-version.js"></script>
 <script>
 /* Read-only viewer of /etc/timps.conf via the stock texteditor.cgi (auth'd by
  * the WebUI session; no timps token / port needed, so it works over http or

--- a/package/timps/files/www/streamer-image.html
+++ b/package/timps/files/www/streamer-image.html
@@ -134,6 +134,7 @@
 <script src="/a/footer.js"></script>
 <script src="/a/preview.js"></script>
 <script src="/a/timps-api.js"></script>
+<script src="/a/timps-version.js"></script>
 <script src="/a/streamer-image.js"></script>
 </body>
 </html>

--- a/package/timps/files/www/streamer-main.html
+++ b/package/timps/files/www/streamer-main.html
@@ -119,6 +119,7 @@
 <script src="/a/footer.js"></script>
 <script src="/a/preview.js"></script>
 <script src="/a/timps-api.js"></script>
+<script src="/a/timps-version.js"></script>
 <script src="/a/streamer-encoder.js"></script>
 </body>
 </html>

--- a/package/timps/files/www/streamer-osd0.html
+++ b/package/timps/files/www/streamer-osd0.html
@@ -100,6 +100,7 @@
 <script src="/a/footer.js"></script>
 <script src="/a/preview.js"></script>
 <script src="/a/timps-api.js"></script>
+<script src="/a/timps-version.js"></script>
 <script src="/a/streamer-osd.js"></script>
 </body>
 </html>

--- a/package/timps/files/www/streamer-osd1.html
+++ b/package/timps/files/www/streamer-osd1.html
@@ -100,6 +100,7 @@
 <script src="/a/footer.js"></script>
 <script src="/a/preview.js"></script>
 <script src="/a/timps-api.js"></script>
+<script src="/a/timps-version.js"></script>
 <script src="/a/streamer-osd.js"></script>
 </body>
 </html>

--- a/package/timps/files/www/streamer-sensor.html
+++ b/package/timps/files/www/streamer-sensor.html
@@ -85,6 +85,7 @@
 <script src="/a/navigation.js"></script>
 <script src="/a/footer.js"></script>
 <script src="/a/timps-api.js"></script>
+<script src="/a/timps-version.js"></script>
 <script src="/a/preview.js"></script>
 <script src="/a/streamer-sensor.js"></script>
 </body>

--- a/package/timps/files/www/streamer-substream.html
+++ b/package/timps/files/www/streamer-substream.html
@@ -119,6 +119,7 @@
 <script src="/a/footer.js"></script>
 <script src="/a/preview.js"></script>
 <script src="/a/timps-api.js"></script>
+<script src="/a/timps-version.js"></script>
 <script src="/a/streamer-encoder.js"></script>
 </body>
 </html>

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,11 +6,50 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.7.7
+TIMPS_VERSION = v1.8.0
 TIMPS_LICENSE = MIT
 # Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
 # once it exists so legal-info can capture it.
 
+# Build-time VERSION (2026-08 stale-build incident): fw_ota.sh reported
+# "flashed successfully" on cameras whose /usr/bin/timpsd binary had
+# demonstrably NOT changed post-reboot - a stale cached image kept getting
+# reused undetected for hours. GET /control's "version" key (src/control.c's
+# MS_VERSION, -DMS_VERSION on the compile command line) exists precisely to
+# catch that class of drift from the outside. src/Makefile's own default
+# already derives it correctly (`VERSION ?= $(shell git describe --tags
+# --always --dirty ... || echo 0.1.0)`), but TIMPS_BUILD_CMDS below passes
+# VERSION= explicitly, which overrides that `?=` default - so a real,
+# per-commit value has to be computed HERE, not left to src/Makefile.
+#
+# Local dev loop (local.mk: TIMPS_OVERRIDE_SRCDIR = /path/to/timps checkout):
+# Buildroot rsyncs the override dir into $(TIMPS_DIR) using the SAME
+# RSYNC_VCS_EXCLUSIONS every package fetch uses (--exclude .git, see
+# buildroot/Makefile) - so $(TIMPS_DIR)/.git never exists and a `git
+# describe` run from there always fails silently. Verified empirically
+# against a real override-srcdir build: $(TIMPS_DIR) (build/timps-custom/)
+# carries .gitmodules but no .git. The real .git only exists in
+# $(TIMPS_OVERRIDE_SRCDIR) itself, before that rsync - so derive the version
+# there instead, at Makefile-parse time (a plain filesystem git-describe on a
+# path, no fetch involved, so this is cheap and side-effect-free even when
+# unused).
+#
+# Tag-pinned release path (TIMPS_SITE_METHOD = git fetching TIMPS_VERSION,
+# TIMPS_OVERRIDE_SRCDIR unset): there is no local checkout to describe, and
+# there shouldn't be - the pinned tag IS already a real, stable, meaningful
+# version. Leave it untouched, and also fall back to it whenever the
+# override dir's git-describe genuinely isn't available (not a git checkout,
+# git missing, etc.) - matching src/Makefile's own "|| echo 0.1.0" fallback
+# philosophy: use the real git state when derivable, fall back to the static
+# version otherwise.
+ifneq ($(call qstrip,$(TIMPS_OVERRIDE_SRCDIR)),)
+TIMPS_GIT_DESCRIBE := $(shell git -C $(call qstrip,$(TIMPS_OVERRIDE_SRCDIR)) describe --tags --always --dirty 2>/dev/null)
+endif
+ifneq ($(TIMPS_GIT_DESCRIBE),)
+TIMPS_BUILD_VERSION = $(TIMPS_GIT_DESCRIBE)
+else
+TIMPS_BUILD_VERSION = $(TIMPS_VERSION)
+endif
 
 # Submodule provides the IMP headers (ingenic-headers).
 TIMPS_GIT_SUBMODULES = YES
@@ -122,7 +161,7 @@ define TIMPS_BUILD_CMDS
 	$(MAKE) \
 		CROSS_COMPILE=$(TARGET_CROSS) \
 		PLATFORM=$(shell echo $(SOC_FAMILY) | tr a-z A-Z) \
-		VERSION=$(TIMPS_VERSION) \
+		VERSION=$(TIMPS_BUILD_VERSION) \
 		IMP_LIB=$(STAGING_DIR)/usr/lib \
 		IMPLIBS="$(TIMPS_IMPLIBS)" \
 		FAACLIB="-lfaac" \
@@ -132,10 +171,13 @@ define TIMPS_BUILD_CMDS
 		USE_FAAC=$(if $(BR2_PACKAGE_TIMPS_FAAC),1,0) \
 		USE_CONTROL=$(if $(BR2_PACKAGE_TIMPS_CONTROL),1,0) \
 		USE_DAYNIGHT=$(if $(BR2_PACKAGE_TIMPS_DAYNIGHT),1,0) \
+		USE_RECORD=$(if $(BR2_PACKAGE_TIMPS_RECORD),1,0) \
+		USE_TIMELAPSE=$(if $(BR2_PACKAGE_TIMPS_TIMELAPSE),1,0) \
 		USE_TLS=$(if $(BR2_PACKAGE_TIMPS_TLS),1,0) \
 		USE_SRT=$(if $(BR2_PACKAGE_TIMPS_SRT),1,0) \
 		USE_ROTATE=$(if $(BR2_PACKAGE_TIMPS_ROTATE),1,0) \
 		USE_SW_ROTATE=$(if $(BR2_PACKAGE_TIMPS_SW_ROTATE),1,0) \
+		USE_OSD_HINTING=$(if $(BR2_PACKAGE_TIMPS_OSD_HINTING),1,0) \
 		USE_BACKCHANNEL=$(if $(BR2_PACKAGE_TIMPS_BACKCHANNEL),1,0) \
 		USE_BC_AAC=$(if $(BR2_PACKAGE_TIMPS_BC_AAC),1,0) \
 		HELIXLIB="-lhelix-aac" \


### PR DESCRIPTION
## Summary
- default `BR2_PACKAGE_TIMPS_OSD_HINTING` to `y` (Config.in)
- `timps.mk`: derive `VERSION` from the real timps git state at parse time instead of the static `TIMPS_VERSION` tag, so builds using `TIMPS_OVERRIDE_SRCDIR` report the actual commit (buildroot's rsync strips `.git` before the package build sees the source, so `git describe` has to run before that happens)
- `GET /control` now reports it; small version badge in the footer of every Streamer page and the Preview page
- `preview-timps.html`: live Statistics table + bitrate sparkline
- `config-privacy.html`: auto-refresh the mask-editor snapshot every 4s instead of fetching it once

## Test plan
- [x] MD5-verified build deployed and version-confirmed via `/control` on 3 cameras (all report `v1.8.0-5-g0c6c0fc`)
- [x] OSD hinting default-on confirmed live
- [x] Version badge confirmed rendering in the footer
- [x] Privacy-mask auto-refresh deployed and confirmed

(Replaces #1436, which was branched from our master instead of piuma.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)