### PR TITLE
timps: bump TIMPS_VERSION to v1.8.1

### DIFF
--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,7 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.8.0
+TIMPS_VERSION = v1.8.1
 TIMPS_LICENSE = MIT
 # Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
 # once it exists so legal-info can capture it.


### PR DESCRIPTION
## Summary
Bumps timps to v1.8.1. Started from a Discord bug report ("setting rc_mode=fixqp crashes the streamer") and grew into a full audit of every IMP-SDK call site across the encoder, audio, JPEG, and OSD subsystems - 15 fixes total, see the [v1.8.1 release notes](https://github.com/Lu-Fi/timps/releases/tag/v1.8.1) / [CHANGELOG](https://github.com/Lu-Fi/timps/blob/main/CHANGELOG.md) for the full list.

### Highlights
- `rc_mode=fixqp` crashed the encoder on T31/C100/T40/T41 (the reported bug); silently ran as CBR on classic SoCs (T20/T21/T23/T30) instead - both fixed.
- Classic-path H265 CBR/FixQP was writing into the wrong union member on T30.
- `IMP_AI_EnableAec`/`DisableAec` raced the audio capture thread (use-after-free class).
- `min_qp`/`max_qp`, `vbr`/`smart`/`capped_*` rc modes, `jpeg.quality`, `motion.hold_ms`/`skip_frames` all had no effect on various SoC/API combinations - now wired up correctly everywhere or explicitly logged when not applicable.
- `IMP_OSD_CreateRgn`'s return value is now checked before use.

## Test plan
- [x] Fleet-verified: MD5 + version-matched across all 11 cameras (T20/T23/T31 mix)
- [x] 0 FAIL QA on the 3 standard test cameras (Garage/Wyze/Galayou)

🤖 Generated with [Claude Code](https://claude.com/claude-code)