### PR TITLE
soc: read the SoC model from whichever vendor declares it

### DIFF
--- a/thingino.mk
+++ b/thingino.mk
@@ -24,8 +24,15 @@ else
 SOC_TARGET_ARCH := mipsel
 endif
 
-# Get SoC model from BR2_INGENIC_SOC_MODEL (single source of truth)
+# The SoC model, from whichever vendor's symbol carries it. Kconfig keeps them
+# mutually exclusive -- each depends on its vendor and the vendor is a choice --
+# so at most one is ever set and the order below is not a precedence. Testing
+# after qstrip rather than before is what makes an empty BR2_..._SOC_MODEL=""
+# fall through, since "" is two characters to make and not an empty string.
 SOC_MODEL_INPUT := $(call qstrip,$(BR2_INGENIC_SOC_MODEL))
+ifeq ($(SOC_MODEL_INPUT),)
+SOC_MODEL_INPUT := $(call qstrip,$(BR2_SIGMASTAR_SOC_MODEL))
+endif
 ifneq ($(SOC_MODEL_INPUT),)
 	SOC_MODEL := $(shell echo $(SOC_MODEL_INPUT) | tr A-Z a-z)
 


### PR DESCRIPTION
#1404 added `BR2_SIGMASTAR_SOC_MODEL`, but nothing has ever read it. `thingino.mk`
takes the model from `BR2_INGENIC_SOC_MODEL` alone, so a board selecting the
SigmaStar vendor resolves an **empty** `SOC_MODEL`, skips the family lookup and
carries on silently.

Four lines fix it:

```make
SOC_MODEL_INPUT := $(call qstrip,$(BR2_INGENIC_SOC_MODEL))
ifeq ($(SOC_MODEL_INPUT),)
SOC_MODEL_INPUT := $(call qstrip,$(BR2_SIGMASTAR_SOC_MODEL))
endif
```

### Why this and not a second vendor arm

Everything downstream was **already** vendor-neutral — the include is
`soc/$(SOC_VENDOR)/*.mk` and the unknown-model error names `$(SOC_VENDOR)`.
This one read was the only thing keeping the block Ingenic-only. With it
generalised, a second vendor needs no `ifeq` on the vendor here at all, and the
`include` stays exactly where it is.

### Why the symbols stay separate in Kconfig

Unifying them into one `BR2_SOC_MODEL` would touch 250 defconfigs, and it would
lose something: each symbol carries its own help text listing that vendor's
valid models, and `depends on` its vendor so menuconfig shows only the relevant
one. That split is right for Kconfig. It is only make that has no use for the
distinction, holding a string either way — so make is where it gets dropped.

The order is not a precedence. `BR2_SOC_VENDOR` is a `choice` and each model
symbol `depends on` its vendor, so at most one is ever set.

Testing **after** `qstrip` rather than before is deliberate: a defconfig carrying
an explicit `BR2_INGENIC_SOC_MODEL=""` holds two characters, not an empty string,
and would otherwise win the fallback.

### Verification

**`.config` for all 171 camera defconfigs: byte-identical to master**, 0
differing, 0 failures. Both passes on this branch with only `thingino.mk`
swapped, so `OUTPUT_DIR` — which contains the branch name — does not move.

And the behaviour that changes, shown directly. A board selecting the SigmaStar
vendor with `BR2_SIGMASTAR_SOC_MODEL="ssc30kq"`:

| | `SOC_VENDOR` | `SOC_MODEL` | result |
|---|---|---|---|
| master | `sigmastar` | *(empty)* | silently no family lookup |
| this PR | `sigmastar` | `ssc30kq` | `Unknown sigmastar SoC model 'ssc30kq': no soc/sigmastar/*.mk claims it` |

The error is the correct outcome here — no `soc/sigmastar/` exists yet, and
stopping is what #1426's check is for. It stops being reachable when the
platform PR adds that directory.
