### PR TITLE
fix: restart prudynt instead of prudyntctl hot-update on motion save

### DIFF
--- a/package/thingino-webui/files/www/x/json-send2.cgi
+++ b/package/thingino-webui/files/www/x/json-send2.cgi
@@ -92,14 +92,14 @@ if [ "$REQUEST_METHOD" = "POST" ]; then
 
 	# Detect which domain is being updated by checking keys
 	if jct "$temp_json" get motion >/dev/null 2>&1; then
-		# Motion config - import into prudynt.json
+		# Motion config - import into prudynt.json, then restart prudynt
+		# so it picks up the full merged config from disk.
+		# Sending a partial config via prudyntctl corrupts the running
+		# process, breaking the live feed and motion detection.
 		jct "$prudynt_config" import "$temp_json"
 		sync
 
-		# Update running prudynt instance if it's running
-		if pidof prudynt >/dev/null 2>&1; then
-			prudyntctl json - <"$temp_json" >/dev/null 2>&1
-		fi
+		service restart prudynt >/dev/null 2>&1 &
 
 	elif jct "$temp_json" get email >/dev/null 2>&1; then
 		jct "$config_file" import "$temp_json"


### PR DESCRIPTION
## Problem

When saving motion settings via the Web UI (**Save Motion Settings** button), `json-send2.cgi` sends a partial JSON config to the running prudynt process via `prudyntctl json -`. This corrupts the daemon's in-memory state, causing:
- Live feed stops updating
- Motion detection stops working

The config file on disk (`/etc/prudynt.json`) is written correctly via `jct import` (deep merge), but the running process gets a partial config that breaks it.

## Fix

After merging the motion config to `/etc/prudynt.json` on disk, restart the prudynt service so it loads the full merged config cleanly.

**Before:**
```sh
prudyntctl json - <"$temp_json" >/dev/null 2>&1
```

**After:**
```sh
service restart prudynt >/dev/null 2>&1 &
```

## Testing

Confirmed on Cinnado D1 (`cinnado_d1_t23n_sc2331_atbm6012bx`) running `ciao+c334a03`.

Repro steps before fix:
1. Enable motion detection + email notifications -- works fine
2. Click **Save Motion Settings**
3. Live feed stops updating, motion detection stops triggering
4. Requires manual `service restart prudynt` to recover

After fix: settings save correctly, prudynt restarts cleanly, live feed and motion detection continue working.

Reported by a Discord user.