### PR TITLE
prudynt-t: add missing playonspeaker script

### DIFF
--- a/package/prudynt-t/files/playonspeaker
+++ b/package/prudynt-t/files/playonspeaker
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Play an audio file on the camera speaker (triggered by motion script)
+
+. /usr/share/prudynt-helpers
+
+config_file="/etc/send2.json"
+
+file=$(jct "$config_file" get speaker.file 2>/dev/null)
+volume=$(jct "$config_file" get speaker.volume 2>/dev/null)
+gain=$(jct "$config_file" get speaker.gain 2>/dev/null)
+loop=$(jct "$config_file" get speaker.loop 2>/dev/null)
+
+[ -z "$file" ] && echo_error "No speaker file configured" && exit 1
+[ ! -f "$file" ] && echo_error "Speaker file not found: $file" && exit 1
+
+vol_arg=""
+[ -n "$volume" ] && vol_arg="-v $volume"
+gain_arg=""
+[ -n "$gain" ] && gain_arg="-g $gain"
+loop_arg=""
+[ -n "$loop" ] && loop_arg="-l $loop"
+
+echo_info "Playing $file on speaker"
+play $vol_arg $gain_arg $loop_arg "$file"

--- a/package/prudynt-t/prudynt-t.mk
+++ b/package/prudynt-t/prudynt-t.mk
@@ -328,6 +328,8 @@ define PRUDYNT_T_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/usr/sbin/send2telegram
 	$(INSTALL) -D -m 0755 $(PRUDYNT_T_PKGDIR)/files/send2webhook \
 		$(TARGET_DIR)/usr/sbin/send2webhook
+	$(INSTALL) -D -m 0755 $(PRUDYNT_T_PKGDIR)/files/playonspeaker \
+		$(TARGET_DIR)/usr/sbin/playonspeaker
 
 	# scripts (audio)
 	$(INSTALL) -D -m 0755 $(PRUDYNT_T_PKGDIR)/files/microphone \


### PR DESCRIPTION
Adds the missing playonspeaker script that the motion script references. Reads speaker config from send2.json and invokes play command.