### PR TITLE
webui: add speaker config and playonspeaker toggle to Send to Services page

### DIFF
--- a/package/thingino-webui/files/www/a/tool-send2.js
+++ b/package/thingino-webui/files/www/a/tool-send2.js
@@ -15,11 +15,22 @@
   };
 
   const motionEnabledInput = $("#motion_enabled");
+  const motionPlayOnSpeakerInput = $("#motion_playonspeaker");
   const motionSensitivityInput = $("#motion_sensitivity");
   const motionSensitivityValue = $("#motion_sensitivity_value");
   const motionCooldownInput = $("#motion_cooldown");
   const motionCooldownValue = $("#motion_cooldown_value");
   const saveMotionButton = $("#save_motion");
+
+  // Speaker elements
+  const speakerFileInput = $("#speaker_file");
+  const speakerVolumeInput = $("#speaker_volume");
+  const speakerVolumeValue = $("#speaker_volume_value");
+  const speakerGainInput = $("#speaker_gain");
+  const speakerGainValue = $("#speaker_gain_value");
+  const speakerLoopInput = $("#speaker_loop");
+  const saveSpeakerButton = $("#save_speaker");
+  const testSpeakerButton = $("#test_speaker");
 
   // Update slider value displays
   if (motionSensitivityInput) {
@@ -34,6 +45,22 @@
     motionCooldownInput.addEventListener("input", () => {
       if (motionCooldownValue) {
         motionCooldownValue.textContent = motionCooldownInput.value;
+      }
+    });
+  }
+
+  if (speakerVolumeInput) {
+    speakerVolumeInput.addEventListener("input", () => {
+      if (speakerVolumeValue) {
+        speakerVolumeValue.textContent = speakerVolumeInput.value;
+      }
+    });
+  }
+
+  if (speakerGainInput) {
+    speakerGainInput.addEventListener("input", () => {
+      if (speakerGainValue) {
+        speakerGainValue.textContent = speakerGainInput.value;
       }
     });
   }
@@ -78,6 +105,10 @@
         if (motionEnabledInput)
           motionEnabledInput.checked =
             data.motion.enabled === true || data.motion.enabled === "true";
+        if (motionPlayOnSpeakerInput)
+          motionPlayOnSpeakerInput.checked =
+            data.motion.playonspeaker === true ||
+            data.motion.playonspeaker === "true";
         if (motionSensitivityInput) {
           motionSensitivityInput.value = data.motion.sensitivity || 4;
           if (motionSensitivityValue)
@@ -155,6 +186,24 @@
           setStatus(videoStatus, sendVideo);
         }
       });
+
+      // Apply speaker settings
+      if (data.speaker) {
+        if (speakerFileInput)
+          speakerFileInput.value = data.speaker.file || "";
+        if (speakerVolumeInput) {
+          speakerVolumeInput.value = data.speaker.volume ?? 80;
+          if (speakerVolumeValue)
+            speakerVolumeValue.textContent = speakerVolumeInput.value;
+        }
+        if (speakerGainInput) {
+          speakerGainInput.value = data.speaker.gain ?? 20;
+          if (speakerGainValue)
+            speakerGainValue.textContent = speakerGainInput.value;
+        }
+        if (speakerLoopInput)
+          speakerLoopInput.value = data.speaker.loop ?? 1;
+      }
     } catch (err) {
       console.error("Failed to load config:", err);
       showAlert(
@@ -176,6 +225,7 @@
       const payload = {
         motion: {
           enabled: motionEnabledInput ? motionEnabledInput.checked : false,
+          playonspeaker: motionPlayOnSpeakerInput ? motionPlayOnSpeakerInput.checked : false,
           sensitivity: motionSensitivityInput
             ? Number(motionSensitivityInput.value)
             : 4,
@@ -207,6 +257,68 @@
       hideBusy();
       saveMotionButton.disabled = false;
     }
+  }
+
+  async function saveSpeakerSettings() {
+    if (!saveSpeakerButton) return;
+
+    showBusy("Saving speaker settings...");
+    saveSpeakerButton.disabled = true;
+
+    try {
+      const payload = {
+        speaker: {
+          file: speakerFileInput ? speakerFileInput.value : "",
+          volume: speakerVolumeInput ? Number(speakerVolumeInput.value) : 80,
+          gain: speakerGainInput ? Number(speakerGainInput.value) : 20,
+          loop: speakerLoopInput ? Number(speakerLoopInput.value) : 1,
+        },
+      };
+
+      const response = await fetch(endpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) throw new Error("Failed to save settings");
+
+      const result = await response.json();
+
+      if (result.error) {
+        throw new Error(result.error.message || "Failed to save settings");
+      }
+
+      showAlert("success", "Speaker settings saved successfully.", 3000);
+    } catch (err) {
+      console.error("Failed to save speaker settings:", err);
+      showAlert("danger", `Failed to save settings: ${err.message || err}`);
+    } finally {
+      hideBusy();
+      saveSpeakerButton.disabled = false;
+    }
+  }
+
+  function testSpeaker() {
+    if (!testSpeakerButton) return;
+    testSpeakerButton.disabled = true;
+
+    const params = new URLSearchParams({ to: "speaker" });
+    fetch(`/x/send.cgi?${params.toString()}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.error) {
+          showAlert("danger", `Speaker test failed: ${data.error.message || data.error}`);
+        } else {
+          showAlert("success", "Speaker test played.", 3000);
+        }
+      })
+      .catch((err) => {
+        showAlert("danger", `Speaker test failed: ${err}`);
+      })
+      .finally(() => {
+        testSpeakerButton.disabled = false;
+      });
   }
 
   // Handle motion service toggles
@@ -290,6 +402,14 @@
 
   if (saveMotionButton) {
     saveMotionButton.addEventListener("click", saveMotionSettings);
+  }
+
+  if (saveSpeakerButton) {
+    saveSpeakerButton.addEventListener("click", saveSpeakerSettings);
+  }
+
+  if (testSpeakerButton) {
+    testSpeakerButton.addEventListener("click", testSpeaker);
   }
 
   loadConfig();

--- a/package/thingino-webui/files/www/tool-send2.html
+++ b/package/thingino-webui/files/www/tool-send2.html
@@ -36,21 +36,48 @@
                 <input class="form-check-input me-2" type="checkbox" id="motion_enabled">
                 <label class="form-check-label" for="motion_enabled">Start motion detection on boot</label>
               </p>
+              <p class="row">
+                <label class="col-4" for="motion_sensitivity">Sensitivity: <span id="motion_sensitivity_value"></span></label>
+                <input class="col form-range" type="range" id="motion_sensitivity" min="1" max="8" step="1">
+              </p>
+              <p class="row">
+                <label class="col-4" for="motion_cooldown">Cooldown: <span id="motion_cooldown_value"></span> seconds</label>
+                <input class="col form-range" type="range" id="motion_cooldown" min="1" max="60" step="1">
+              </p>
+
+              <h4 class="mb-3">Speaker</h4>
               <p class="form-switch">
                 <input class="form-check-input me-2" type="checkbox" id="motion_playonspeaker">
                 <label class="form-check-label" for="motion_playonspeaker">Play audio on speaker when motion detected</label>
               </p>
-              <p>
-                <label for="motion_sensitivity">Sensitivity: <span id="motion_sensitivity_value"></span></label>
-                <input type="range" class="form-range" id="motion_sensitivity" min="1" max="8" step="1">
+              <p class="row">
+                <label class="col-4 form-label" for="speaker_file">Audio file path</label>
+                <input class="col form-control" type="text" id="speaker_file" placeholder="/usr/share/sounds/chime_1.opus">
               </p>
-              <p>
-                <label for="motion_cooldown">Cooldown: <span id="motion_cooldown_value"></span> seconds</label>
-                <input type="range" class="form-range" id="motion_cooldown" min="1" max="60" step="1">
+              <p class="row">
+                <label class="col-4 form-label" for="speaker_volume">Volume: <span id="speaker_volume_value"></span></label>
+                <input class="col form-range" type="range" id="speaker_volume" min="0" max="120" step="1">
               </p>
-	      <button type="button" class="btn btn-primary" id="save_motion">
-                <i class="bi bi-check-circle"></i> Save Motion Settings
-              </button>
+              <p class="row">
+                <label class="col-4 form-label" for="speaker_gain">Gain: <span id="speaker_gain_value"></span></label>
+                <input class="col form-range" type="range" id="speaker_gain" min="0" max="31" step="1">
+              </p>
+              <p class="row">
+                <label class="col-4 form-label" for="speaker_loop">Repeat (0 = forever)</label>
+                <input class="col form-control" type="number" id="speaker_loop" min="0" step="1" value="1">
+              </p>
+
+              <div class="d-flex gap-2">
+                <button type="button" class="btn btn-primary" id="save_motion">
+                  <i class="bi bi-check-circle"></i> Save Motion Settings
+                </button>
+                <button type="button" class="btn btn-primary" id="save_speaker">
+                  <i class="bi bi-check-circle"></i> Save Speaker Settings
+                </button>
+                <button type="button" class="btn btn-outline-secondary" id="test_speaker" title="Play the configured audio file now">
+                  <i class="bi bi-volume-up"></i> Test
+                </button>
+              </div>
             </div>
           </div>
         </div>
@@ -173,44 +200,6 @@
                     </tr>
                   </tbody>
                 </table>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <!-- Speaker Card -->
-      <div class="row g-3 mt-0">
-        <div class="col-12 col-lg-6">
-          <div class="card h-100">
-            <div class="card-header">Speaker</div>
-            <div class="card-body">
-              <p class="mb-3 text-secondary small">Audio playback settings for the camera speaker. Used when "Play audio on speaker" is enabled in Motion Detection.</p>
-              <div class="mb-3">
-                <label for="speaker_file" class="form-label">Audio file path</label>
-                <input type="text" class="form-control" id="speaker_file" placeholder="/usr/share/sounds/chime_1.opus">
-                <div class="form-text">Path to an .opus or .mp3 file on the camera.</div>
-              </div>
-              <div class="mb-3">
-                <label for="speaker_volume" class="form-label">Volume: <span id="speaker_volume_value"></span></label>
-                <input type="range" class="form-range" id="speaker_volume" min="0" max="100" step="1">
-              </div>
-              <div class="mb-3">
-                <label for="speaker_gain" class="form-label">Gain: <span id="speaker_gain_value"></span></label>
-                <input type="range" class="form-range" id="speaker_gain" min="0" max="100" step="1">
-              </div>
-              <div class="mb-3">
-                <label for="speaker_loop" class="form-label">Loop</label>
-                <input type="number" class="form-control" id="speaker_loop" min="0" step="1" value="1">
-                <div class="form-text">Number of times to play the file. 0 = unlimited.</div>
-              </div>
-              <div class="d-flex gap-2">
-                <button type="button" class="btn btn-primary" id="save_speaker">
-                  <i class="bi bi-check-circle"></i> Save Speaker Settings
-                </button>
-                <button type="button" class="btn btn-outline-secondary" id="test_speaker" title="Play the configured audio file now">
-                  <i class="bi bi-volume-up"></i> Test
-                </button>
               </div>
             </div>
           </div>

--- a/package/thingino-webui/files/www/tool-send2.html
+++ b/package/thingino-webui/files/www/tool-send2.html
@@ -36,6 +36,10 @@
                 <input class="form-check-input me-2" type="checkbox" id="motion_enabled">
                 <label class="form-check-label" for="motion_enabled">Start motion detection on boot</label>
               </p>
+              <p class="form-switch">
+                <input class="form-check-input me-2" type="checkbox" id="motion_playonspeaker">
+                <label class="form-check-label" for="motion_playonspeaker">Play audio on speaker when motion detected</label>
+              </p>
               <p>
                 <label for="motion_sensitivity">Sensitivity: <span id="motion_sensitivity_value"></span></label>
                 <input type="range" class="form-range" id="motion_sensitivity" min="1" max="8" step="1">
@@ -169,6 +173,44 @@
                     </tr>
                   </tbody>
                 </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Speaker Card -->
+      <div class="row g-3 mt-0">
+        <div class="col-12 col-lg-6">
+          <div class="card h-100">
+            <div class="card-header">Speaker</div>
+            <div class="card-body">
+              <p class="mb-3 text-secondary small">Audio playback settings for the camera speaker. Used when "Play audio on speaker" is enabled in Motion Detection.</p>
+              <div class="mb-3">
+                <label for="speaker_file" class="form-label">Audio file path</label>
+                <input type="text" class="form-control" id="speaker_file" placeholder="/usr/share/sounds/chime_1.opus">
+                <div class="form-text">Path to an .opus or .mp3 file on the camera.</div>
+              </div>
+              <div class="mb-3">
+                <label for="speaker_volume" class="form-label">Volume: <span id="speaker_volume_value"></span></label>
+                <input type="range" class="form-range" id="speaker_volume" min="0" max="100" step="1">
+              </div>
+              <div class="mb-3">
+                <label for="speaker_gain" class="form-label">Gain: <span id="speaker_gain_value"></span></label>
+                <input type="range" class="form-range" id="speaker_gain" min="0" max="100" step="1">
+              </div>
+              <div class="mb-3">
+                <label for="speaker_loop" class="form-label">Loop</label>
+                <input type="number" class="form-control" id="speaker_loop" min="0" step="1" value="1">
+                <div class="form-text">Number of times to play the file. 0 = unlimited.</div>
+              </div>
+              <div class="d-flex gap-2">
+                <button type="button" class="btn btn-primary" id="save_speaker">
+                  <i class="bi bi-check-circle"></i> Save Speaker Settings
+                </button>
+                <button type="button" class="btn btn-outline-secondary" id="test_speaker" title="Play the configured audio file now">
+                  <i class="bi bi-volume-up"></i> Test
+                </button>
               </div>
             </div>
           </div>

--- a/package/thingino-webui/files/www/x/json-send2.cgi
+++ b/package/thingino-webui/files/www/x/json-send2.cgi
@@ -66,7 +66,8 @@ if [ "$REQUEST_METHOD" = "GET" ]; then
   "webhook": $(get_domain_config webhook),
   "storage": $(get_domain_config storage),
   "ntfy": $(get_domain_config ntfy),
-  "gphotos": $(get_domain_config gphotos)
+  "gphotos": $(get_domain_config gphotos),
+  "speaker": $(get_domain_config speaker)
 }
 EOF
 	exit 0
@@ -135,6 +136,9 @@ if [ "$REQUEST_METHOD" = "POST" ]; then
 		jct "$config_file" import "$temp_json"
 
 	elif jct "$temp_json" get gphotos >/dev/null 2>&1; then
+		jct "$config_file" import "$temp_json"
+
+	elif jct "$temp_json" get speaker >/dev/null 2>&1; then
 		jct "$config_file" import "$temp_json"
 
 	else

--- a/package/thingino-webui/files/www/x/send.cgi
+++ b/package/thingino-webui/files/www/x/send.cgi
@@ -233,6 +233,17 @@ case "$target" in
 			json_ok "Sent to $target"
 		fi
 		;;
+	speaker)
+		webui_log "send.cgi: target=speaker, verbose_flag='$verbose_flag'"
+		if [ -n "$verbose_flag" ]; then
+			webui_log "Running: playonspeaker $verbose_flag"
+			run_verbose playonspeaker $verbose_flag
+		else
+			webui_log "Running: playonspeaker"
+			playonspeaker >/dev/null &
+			json_ok "Speaker test sent"
+		fi
+		;;
 	termbin)
 		case ${POST_file:-$GET_file} in
 			weblog)


### PR DESCRIPTION
The Send to Services page had no UI for configuring the speaker section in `/etc/send2.json`, and the `motion.playonspeaker` toggle was only accessible via CLI or manual JSON editing.

## Changes

**Motion Detection card** — added "Play audio on speaker when motion detected" toggle next to the existing motion settings. Saved to `motion.playonspeaker` in `prudynt.json`.

**New Speaker card** — file path, volume (0-100), gain (0-100), and loop count fields, with Save and Test buttons. Reads/writes the `speaker` section of `/etc/send2.json`.

**json-send2.cgi** — added `speaker` to GET response and POST handler.

**send.cgi** — added `speaker` target so the Test button invokes `playonspeaker`.

Depends on the `playonspeaker` script from PR #1447/#1448 being merged first, otherwise the Test button will fail.

Signed-off-by: WLTB-Gino <WLTB-Gino@users.noreply.github.com>