### PR TITLE
timps: bump TIMPS_VERSION to v1.8.4

### DIFF
--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,7 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.8.1
+TIMPS_VERSION = v1.8.4
 TIMPS_LICENSE = MIT
 # Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
 # once it exists so legal-info can capture it.


### PR DESCRIPTION
## Summary
- Bumps `TIMPS_VERSION` to `v1.8.4`, which self-heals ISP `hflip`/`vflip`/`running_mode` reverting mid-run on a framesource chn0 idle->active cycle (no reboot or config change involved).

See [Lu-Fi/timps v1.8.4](https://github.com/Lu-Fi/timps/releases/tag/v1.8.4) for the full changelog.

## Test plan
- [x] Built and full-chip-flashed to 11 cameras across a live fleet with the fix baked in via local source override, before this version pin existed as a tag
- [x] `timps-qa.sh` standard profile: PASS (only pre-existing, unrelated warnings) on all 11
- [x] Live-reproduced the underlying bug on one camera, confirmed the fix resolves it after a clean rebuild+reflash
- [x] Fix independently reviewed (lock-ordering/deadlock analysis, compile-matrix across all SoC/feature combinations, daynight-interaction check) before shipping