### PR TITLE
raptor: add daynight/ircut/light wrapper scripts

### DIFF
--- a/package/thingino-raptor/files/daynight
+++ b/package/thingino-raptor/files/daynight
@@ -1,0 +1,74 @@
+#!/bin/sh
+# Day/night switching script for Raptor
+# Translates daynightd-style commands to raptorctl ric calls
+# Installed by thingino-raptor; called by Web UI (json-imp.cgi)
+
+MODE_FILE="/run/thingino/daynight_mode"
+
+mkdir -p /run/thingino
+[ -f "$MODE_FILE" ] || echo "day" >"$MODE_FILE"
+
+command_present() {
+	command -v "$1" >/dev/null 2>&1
+}
+
+# Read current state from ric if possible, else fall back to mode file
+get_current_state() {
+	if command_present raptorctl; then
+		raptorctl ric status 2>/dev/null | \
+			sed -n 's/.*"state":"\([^"]*\)".*/\1/p'
+	else
+		cat "$MODE_FILE"
+	fi
+}
+
+switch_to_day() {
+	if command_present raptorctl; then
+		raptorctl ric mode day
+	fi
+	echo "day" >"$MODE_FILE"
+}
+
+switch_to_night() {
+	if command_present raptorctl; then
+		raptorctl ric mode night
+	fi
+	echo "night" >"$MODE_FILE"
+}
+
+switch_to_auto() {
+	if command_present raptorctl; then
+		raptorctl ric mode auto
+	fi
+	echo "auto" >"$MODE_FILE"
+}
+
+state=$(cat "$MODE_FILE" 2>/dev/null || echo "day")
+
+case "$1" in
+	night)
+		switch_to_night
+		;;
+	day)
+		switch_to_day
+		;;
+	auto)
+		switch_to_auto
+		;;
+	~ | toggle)
+		if [ "day" = "$state" ]; then
+			switch_to_night
+		else
+			switch_to_day
+		fi
+		;;
+	\? | read | status)
+		echo "$state"
+		;;
+	*)
+		echo "Usage: $0 {day|night|auto|toggle|read}" >&2
+		echo "Current state: $state" >&2
+		;;
+esac
+
+exit 0

--- a/package/thingino-raptor/files/ircut
+++ b/package/thingino-raptor/files/ircut
@@ -1,0 +1,58 @@
+#!/bin/sh
+# IRCUT control wrapper for Raptor
+# Translates ircut commands to raptorctl ric ircut calls
+# Installed by thingino-raptor; called by daynight script and Web UI
+
+command_present() {
+	command -v "$1" >/dev/null 2>&1
+}
+
+if ! command_present raptorctl; then
+	echo "raptorctl not found" >&2
+	exit 1
+fi
+
+case "$1" in
+	0 | off | night)
+		# Remove IR-cut filter (night vision)
+		raptorctl ric ircut night
+		;;
+	1 | on | day)
+		# Set IR-cut filter (day mode)
+		raptorctl ric ircut day
+		;;
+	~ | toggle)
+		# Query current state and toggle
+		state=$(raptorctl ric status 2>/dev/null | \
+			sed -n 's/.*"state":"\([^"]*\)".*/\1/p')
+		if [ "$state" = "night" ]; then
+			raptorctl ric ircut day
+		else
+			raptorctl ric ircut night
+		fi
+		;;
+	status)
+		state=$(raptorctl ric status 2>/dev/null | \
+			sed -n 's/.*"state":"\([^"]*\)".*/\1/p')
+		if [ "$state" = "night" ]; then
+			echo "- IRCUT filter is removed"
+		else
+			echo "- IRCUT filter is set"
+		fi
+		;;
+	\? | read)
+		state=$(raptorctl ric status 2>/dev/null | \
+			sed -n 's/.*"state":"\([^"]*\)".*/\1/p')
+		if [ "$state" = "night" ]; then
+			echo -n "0"
+		else
+			echo -n "1"
+		fi
+		;;
+	*)
+		echo "Usage: $0 [on|off|toggle|status|read]" >&2
+		exit 1
+		;;
+esac
+
+exit 0

--- a/package/thingino-raptor/files/light
+++ b/package/thingino-raptor/files/light
@@ -1,0 +1,81 @@
+#!/bin/sh
+# IR LED / white light control wrapper for Raptor
+# Translates light commands to raptorctl ric ir850/ir940 calls
+# Installed by thingino-raptor; called by daynight script and Web UI
+
+command_present() {
+	command -v "$1" >/dev/null 2>&1
+}
+
+if ! command_present raptorctl; then
+	echo "raptorctl not found" >&2
+	exit 1
+fi
+
+show_help() {
+	echo "Usage: $0 <type> <mode>
+Where:
+	type	ir | ir850 | ir940 | white
+	mode	on | off | toggle | read" >&2
+	exit 1
+}
+
+[ "$#" -lt 1 ] && show_help
+
+type="$1"
+mode="${2:-read}"
+
+case "$type" in
+	ir)
+		# Toggle whichever IR bank ric knows about
+		case "$mode" in
+			0 | off)
+				raptorctl ric ir850 off 2>/dev/null
+				raptorctl ric ir940 off 2>/dev/null
+				;;
+			1 | on)
+				raptorctl ric ir850 on 2>/dev/null
+				raptorctl ric ir940 on 2>/dev/null
+				;;
+			*)
+				show_help
+				;;
+		esac
+		;;
+	ir850)
+		case "$mode" in
+			0 | off) raptorctl ric ir850 off ;;
+			1 | on)  raptorctl ric ir850 on ;;
+			*) show_help ;;
+		esac
+		;;
+	ir940)
+		case "$mode" in
+			0 | off) raptorctl ric ir940 off ;;
+			1 | on)  raptorctl ric ir940 on ;;
+			*) show_help ;;
+		esac
+		;;
+	white | flood)
+		# Raptor has no white light GPIO command via ric.
+		# Fall back to direct GPIO manipulation if configured.
+		gpio_pin=$(jct /etc/thingino.json get "gpio.white" 2>/dev/null || \
+			jct /etc/thingino.json get "gpio.white.pin" 2>/dev/null)
+		if [ -n "$gpio_pin" ]; then
+			case "$mode" in
+				0 | off) gpio set "$gpio_pin" 0 ;;
+				1 | on)  gpio set "$gpio_pin" 1 ;;
+				*) show_help ;;
+			esac
+		else
+			echo "- White light GPIO not configured" >&2
+			exit 1
+		fi
+		;;
+	*)
+		echo "Unknown light type: $type" >&2
+		show_help
+		;;
+esac
+
+exit 0

--- a/package/thingino-raptor/thingino-raptor.mk
+++ b/package/thingino-raptor/thingino-raptor.mk
@@ -181,6 +181,12 @@ define THINGINO_RAPTOR_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/usr/sbin/speaker
 	$(INSTALL) -D -m 0755 $(THINGINO_RAPTOR_PKGDIR)/files/color \
 		$(TARGET_DIR)/usr/sbin/color
+	$(INSTALL) -D -m 0755 $(THINGINO_RAPTOR_PKGDIR)/files/daynight \
+		$(TARGET_DIR)/usr/sbin/daynight
+	$(INSTALL) -D -m 0755 $(THINGINO_RAPTOR_PKGDIR)/files/ircut \
+		$(TARGET_DIR)/usr/sbin/ircut
+	$(INSTALL) -D -m 0755 $(THINGINO_RAPTOR_PKGDIR)/files/light \
+		$(TARGET_DIR)/usr/sbin/light
 	if [ "$(BR2_PACKAGE_THINGINO_RAPTOR_RAC)" = "y" ]; then \
 		$(INSTALL) -D -m 0755 $(THINGINO_RAPTOR_PKGDIR)/files/record \
 			$(TARGET_DIR)/usr/sbin/record; \

--- a/package/thingino-webui/files/www/x/json-imp.cgi
+++ b/package/thingino-webui/files/www/x/json-imp.cgi
@@ -44,9 +44,12 @@ bad_request() {
 }
 
 daynightd_reload() {
+	# Prudynt: signal daynightd daemon
 	if [ -f /run/daynightd.pid ]; then
 		kill -HUP "$(cat /run/daynightd.pid)" 2>/dev/null || true
 	fi
+	# Raptor: ric handles mode changes immediately via raptorctl,
+	# no daemon reload needed
 }
 
 CONFIG="${THINGINO_CONFIG:-/etc/thingino.json}"
@@ -78,8 +81,12 @@ case "$cmd" in
 		esac
 		;;
 	color)
-		# Direct ISP color mode toggle — prudynt still handles this
-		echo "{\"image\":{\"running_mode\": $val}}" | prudyntctl json - >/dev/null 2>&1
+		# Direct ISP color mode toggle
+		if command -v prudyntctl >/dev/null 2>&1; then
+			echo "{\"image\":{\"running_mode\": $val}}" | prudyntctl json - >/dev/null 2>&1
+		elif command -v color >/dev/null 2>&1; then
+			color "$val" >/dev/null 2>&1
+		fi
 		;;
 	daynight)
 		# Direct day/night force — disable photosensing, set mode


### PR DESCRIPTION
## Problem

Raptor uses its own `ric` daemon for day/night detection and GPIO control, but the Web UI (`json-imp.cgi`) and user-facing scripts call daynightd-era commands: `daynight`, `ircut`, `light`, `color`.

The `color` wrapper already existed in the raptor package. The other three were missing, so on Raptor builds:
- Web UI day/night buttons did nothing
- `ircut on/off`, `light ir940 on`, `daynight night` from SSH all failed
- Users had to know to use `raptorctl ric mode night` instead

## Fix

Adds three wrapper scripts to `package/thingino-raptor/files/` that translate daynightd-style commands to `raptorctl ric` calls:

| Script | Translates to |
|--------|---------------|
| `daynight` | `raptorctl ric mode day\|night\|auto` |
| `ircut` | `raptorctl ric ircut day\|night` |
| `light` | `raptorctl ric ir850\|ir940 on\|off` |

Also makes `json-imp.cgi` streamer-agnostic:
- `color` command falls back to the `color` wrapper if `prudyntctl` is absent
- `daynightd_reload()` is a no-op on Raptor (ric handles changes immediately)

This implements the approach described in #1453 — raptor installs its own versions of the control scripts wired to its own daemon, keeping the user-facing interface common.

## Known limitation

Auto day/night on T20/Gen1-2 SoCs has an inverted `ae_luma` issue (EV goes UP in darkness instead of down). This is a separate ric logic fix, not addressed by these wrappers. The wrappers do enable `raptorctl ric mode auto` to be called from the Web UI for SoCs where it works.

Discussed with @themactep in #1453.

Credit: WLTB-Gino (with thanks to Discord user for testing and wrapper prototype)