### PR TITLE
prudynt-t: patch RTSP audio-only track subscriptions

### DIFF
--- a/package/all-patches/prudynt-t/0001-fix-serve-sessions-that-subscribed-to-the-audio-trac.patch
+++ b/package/all-patches/prudynt-t/0001-fix-serve-sessions-that-subscribed-to-the-audio-trac.patch
@@ -1,0 +1,39 @@
+From 0c91c4494ba30820c715e69ca6d534a23b7d4d07 Mon Sep 17 00:00:00 2001
+From: Viliam Pucik <672009+viliampucik@users.noreply.github.com>
+Date: Wed, 12 Aug 2026 22:17:08 +0200
+Subject: [PATCH 1/2] fix: serve sessions that subscribed to the audio track
+ only
+
+The drain loop skips playing sessions with no video channel unless they are
+the /mic endpoint or a backchannel.  A client that SETUPs only track2 of /ch0
+has videoChn < 0 and audioOnly == false, so the loop skips it and never drains
+its audioTap: PLAY returns 200 OK and RTCP flows, but no audio RTP is ever
+sent.  audioOnly is no substitute -- handleSetup() sets it per endpoint, not
+per requested track.
+
+handlePlay() already accepts these sessions and registers their audio tap, so
+mirror its guard here.  Measured on a Cinnado D1: 0 audio frames in 25 s,
+against 637 in 12 s when both tracks are set up.
+
+Signed-off-by: Viliam Pucik <672009+viliampucik@users.noreply.github.com>
+---
+ src/network/rtsp/RtspServer.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/network/rtsp/RtspServer.cpp b/src/network/rtsp/RtspServer.cpp
+index f5d62c4..4dad3f3 100644
+--- a/src/network/rtsp/RtspServer.cpp
++++ b/src/network/rtsp/RtspServer.cpp
+@@ -226,7 +226,8 @@ void RtspServer::eventLoop() {
+         // -- Drain taps for playing sessions -----------------------------
+         for (auto &s : sessions_) {
+             if (!s || !s->playing) continue;
+-            if (s->videoChn < 0 && !s->audioOnly && !s->backchannel) continue;
++            if (s->videoChn < 0 && !s->hasAudio && !s->audioOnly &&
++                !s->backchannel && !s->hasSubtitles) continue;
+ 
+             bool backpressure = false;
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/package/all-patches/prudynt-t/0002-fix-don-t-send-a-video-Sender-Report-on-audio-only-s.patch
+++ b/package/all-patches/prudynt-t/0002-fix-don-t-send-a-video-Sender-Report-on-audio-only-s.patch
@@ -1,0 +1,54 @@
+From c3849353b75d8844f5bbe4f08ed9f944220c67c9 Mon Sep 17 00:00:00 2001
+From: Viliam Pucik <672009+viliampucik@users.noreply.github.com>
+Date: Wed, 12 Aug 2026 22:17:08 +0200
+Subject: [PATCH 2/2] fix: don't send a video Sender Report on audio-only
+ sessions
+
+sendRtcpSr() always emits an SR for the video stream.  A session with only the
+audio track set up has no video stream, yet videoInterleavedRtcp still holds
+its default of 1 -- the channel such a client maps to audio RTCP.  The client
+then sees SRs from two SSRCs on one channel, one carrying an unset video RTP
+timestamp.
+
+Guard on videoSetupUrl, written only in handleSetup()'s isVideo branch;
+videoChn is unreliable here because handleSubtitleSetup() also derives it from
+the URI.  Receivers ignore unknown SSRCs, so this is correctness rather than a
+fix for a measured symptom.
+
+Signed-off-by: Viliam Pucik <672009+viliampucik@users.noreply.github.com>
+---
+ src/network/rtsp/RtspServer.cpp | 11 +++++++----
+ 1 file changed, 7 insertions(+), 4 deletions(-)
+
+diff --git a/src/network/rtsp/RtspServer.cpp b/src/network/rtsp/RtspServer.cpp
+index 4dad3f3..6bf80ab 100644
+--- a/src/network/rtsp/RtspServer.cpp
++++ b/src/network/rtsp/RtspServer.cpp
+@@ -2427,9 +2427,11 @@ void RtspServer::sendRtcpSr(Session &s) {
+     if (!s.tcpInterleaved) {
+         // UDP: send via UDP sockets
+         sockaddr_in target = s.clientAddr;
+-        target.sin_port = htons(s.videoClientRtcpPort);
+-        sendto(s.videoRtcpSock, rtcp, sizeof(rtcp), MSG_DONTWAIT,
+-               (sockaddr *)&target, sizeof(target));
++        if (s.videoSetupUrl[0] != '\0') {
++            target.sin_port = htons(s.videoClientRtcpPort);
++            sendto(s.videoRtcpSock, rtcp, sizeof(rtcp), MSG_DONTWAIT,
++                   (sockaddr *)&target, sizeof(target));
++        }
+         if (s.hasAudio) {
+             uint32_t asrc = htonl(s.audioRtp.ssrc);
+             memcpy(rtcp + 4, &asrc, 4);
+@@ -2465,7 +2467,8 @@ void RtspServer::sendRtcpSr(Session &s) {
+             s.sendQueue.push_back(std::move(pkt));
+             s.sendQueueBytes += remain;
+         };
+-        queueTc(s.videoInterleavedRtcp, rtcp, 28);
++        if (s.videoSetupUrl[0] != '\0')
++            queueTc(s.videoInterleavedRtcp, rtcp, 28);
+         if (s.hasAudio) {
+             uint32_t asrc = htonl(s.audioRtp.ssrc);
+             memcpy(rtcp + 4, &asrc, 4);
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
An RTSP client that subscribes to **only the audio track** of `/chN` gets no audio
at all — prudynt's drain loop skips the session and never drains its `audioTap`,
so `PLAY` returns `200 OK`, RTCP flows, and the stream stays silent forever.

Adds the two fixes as numbered patches under `package/all-patches/prudynt-t/`,
so they apply on build without waiting for a `PRUDYNT_T_VERSION` bump. Both are
pending upstream as themactep/prudynt-t#30.

| | |
|---|---|
| `0001` | drain loop skipped sessions with `videoChn < 0 && !audioOnly`; `handlePlay()` already accepts them via `hasAudio` |
| `0002` | `sendRtcpSr()` emitted a *video* SR on the audio RTCP channel (wrong SSRC, unset RTP timestamp) |

### Verified

- `git apply --check` clean against the currently pinned **`73ae2b8a`** and against `b8d94db`.
- Built via `PRUDYNT_T_OVERRIDE_SRCDIR` for `cinnado_d1_t23n_sc2336_atbm6012bx` and flashed to `mtd4`.
- Audio-only subscription to `/ch0`: **0 → 712** audio RTP frames, first packet 0.03 s after `PLAY`.
- Both-tracks and `/mic` subscriptions re-tested; unchanged.
- Real-world effect with tinyCam Monitor over ONVIF: audio start went from ~40 s
  to a few seconds, and the camera stopped encoding and sending 1080p **twice**
  (measured 375+393 KB/s before, ~377 KB/s total after).

### Two notes

`ciao` is where this matters most — prudynt is the default streamer there and the
released images come from it — so this likely wants applying to `ciao` as well as
`master`. Happy to open that separately if you prefer.

Unrelated, spotted while checking: `master` pins
`PRUDYNT_T_VERSION = d5336b3d77f5c20e2c7add9b5aa2c0c435cd91e0`, which no longer
resolves in `themactep/prudynt-t` (`422 No commit found`). `ciao` pins `73ae2b8a`.
