### PR TITLE
usbnet: fix MAC address lookup in CDC NCM scripts

### DIFF
--- a/overlay/etc/init.d/S03mac
+++ b/overlay/etc/init.d/S03mac
@@ -60,3 +60,6 @@ echo -c 240 -e "- Generated WLAN MAC: $wlan_mac"
 # Persist to thingino.json
 jct "$CONFIG_JSON" set eth.mac "$eth_mac"
 jct "$CONFIG_JSON" set wlan.mac "$wlan_mac"
+
+# Persist eth MAC to U-Boot environment for network operations (tftp, etc.)
+fw_setenv ethaddr "$eth_mac" 2>/dev/null

--- a/package/usbnet/files/S36cdcnet
+++ b/package/usbnet/files/S36cdcnet
@@ -24,10 +24,12 @@ start() {
 	echo -c 15 "Starting CDC Ethernet gadget"
 	# Skip gadget load if g_webcam composite already provides NCM
 	if ! lsmod 2>/dev/null | grep -q g_webcam; then
-		ethaddr=$(fw_printenv -n ethaddr)
+		ethaddr=$(fw_printenv -n ethaddr 2>/dev/null || jct /etc/thingino.json get eth.mac 2>/dev/null)
+		[ -z "$ethaddr" ] && { echo "Error: MAC address not found" >&2; exit 1; }
+		host_addr=$ethaddr
 		decrement_mac
 		usb-role -m device
-		modprobe g_ncm iManufacturer=thingino host_addr=$(fw_printenv -n ethaddr) dev_addr=$ethaddr iProduct="NCM CDC Ethernet Gadget"
+		modprobe g_ncm iManufacturer=thingino host_addr=$host_addr dev_addr=$ethaddr iProduct="NCM CDC Ethernet Gadget"
 	fi
 	# Wait for usb0 to appear
 	i=0

--- a/package/usbnet/files/S36cdcnet-client
+++ b/package/usbnet/files/S36cdcnet-client
@@ -19,7 +19,10 @@ decrement_mac() {
 }
 
 start() {
-	usbmac=$(fw_printenv -n usbmac)
+	ethaddr=$(fw_printenv -n ethaddr 2>/dev/null || jct /etc/thingino.json get eth.mac 2>/dev/null)
+	[ -z "$ethaddr" ] && { echo "Error: MAC address not found" >&2; exit 1; }
+	host_addr=$ethaddr
+	usbmac=$(fw_printenv -n usbmac 2>/dev/null)
 	if [ -z "$usbmac" ]; then
 		decrement_mac
 		daddr=$ethaddr
@@ -28,7 +31,7 @@ start() {
 	fi
 
 	echo -c 15 "Starting CDC Ethernet client gadget"
-	modprobe g_ncm iManufacturer=thingino host_addr=$(fw_printenv -n ethaddr) dev_addr=$daddr iProduct="NCM CDC Ethernet Gadget"
+	modprobe g_ncm iManufacturer=thingino host_addr=$host_addr dev_addr=$daddr iProduct="NCM CDC Ethernet Gadget"
 	usb-role -m device
 }
 


### PR DESCRIPTION
## Problem

The `S36cdcnet` and `S36cdcnet-client` scripts read `ethaddr` from the U-Boot environment via `fw_printenv`, but that variable is not always present. Meanwhile `S03mac` generates MAC addresses and stores them in `thingino.json` but never writes `ethaddr` to the U-Boot env.

This causes USB NCM networking to fail on cameras where `ethaddr` is absent from the env.

## Fix

Three changes that complete each other:

1. **`S03mac`** — also writes `ethaddr` to the U-Boot environment so U-Boot can use it for network ops (tftp, etc.) and so downstream scripts can read it.

2. **`S36cdcnet`** — adds `jct get eth.mac` fallback if `fw_printenv -n ethaddr` comes up empty, saves the original MAC before `decrement_mac` modifies it, removes redundant second `fw_printenv` call.

3. **`S36cdcnet-client`** — fixes a pre-existing bug where `ethaddr` was never read before `decrement_mac` was called, adds the same `jct` fallback, removes redundant `fw_printenv`.

## Testing

Reported by @user on Discord. Manual fix (setting `ethaddr`/`usbmac` manually) confirmed working. Awaiting hardware test of this patch.

Signed-off-by: WLTB-Gino <gino@wltechblog.com>