### PR TITLE
scripts: add local site method support to manage-package-overrides

### DIFF
--- a/scripts/manage-package-overrides.sh
+++ b/scripts/manage-package-overrides.sh
@@ -445,7 +445,30 @@ download_package() {
 
         print_success "Cloned $pkg_name to $dest_dir"
     else
-        print_error "Unsupported site method: $method (only 'git' is supported)"
+        if [ "$method" = "local" ]; then
+            # Resolve the local source path (expand $(XXX_PKGDIR) references)
+            local src_dir=""
+            local pkgdir_var="${pkg_upper}_PKGDIR"
+            local expanded_site="${site/\$($pkgdir_var)/$PACKAGE_DIR/$pkg_name}"
+            # Handle BR2_EXTERNAL or other variable prefixes in the path
+            if [ -d "$expanded_site" ]; then
+                src_dir="$expanded_site"
+            elif [ -d "$BASE_DIR/$expanded_site" ]; then
+                src_dir="$BASE_DIR/$expanded_site"
+            fi
+
+            if [ -z "$src_dir" ] || [ ! -d "$src_dir" ]; then
+                print_error "Could not resolve local source path: $site"
+                return 1
+            fi
+
+            print_info "Copying $src_dir to $dest_dir"
+            cp -a "$src_dir" "$dest_dir"
+            print_success "Copied $pkg_name to $dest_dir"
+        else
+            print_error "Unsupported site method: $method (only 'git' and 'local' are supported)"
+            return 1
+        fi
         return 1
     fi
 }


### PR DESCRIPTION
## Problem

`manage-package-overrides.sh` only supports cloning git repos. Packages using `SITE_METHOD = local` (e.g. `usbnet`, where source lives in `package/<pkg>/files/`) fail with:

```
[ERROR] Unsupported site method: local (only 'git' is supported)
```

## Fix

Adds a `local` branch to `download_package()` that resolves the `$(XXX_PKGDIR)/files` path from the package `.mk` file and copies the source into `overrides/<pkg>/` instead of cloning. The override is registered in `local.mk` the same way as git packages.

Usage after patch:
```bash
./scripts/manage-package-overrides.sh usbnet
# Copies package/usbnet/files/ to overrides/usbnet/
```

Reported by @user on Discord.

Signed-off-by: WLTB-Gino <gino@wltechblog.com>