### PR TITLE
configs: add open ISP fragment

### DIFF
--- a/configs/fragments/open-isp.fragment
+++ b/configs/fragments/open-isp.fragment
@@ -1,0 +1,2 @@
+# Experimental open ISP/kernel/userspace replacement stack.
+BR2_PACKAGE_THINGINO_ISP_OPEN=y


### PR DESCRIPTION
## Summary

Add a reusable `open-isp` configuration fragment that selects the active ISP provider-choice symbol:

```text
BR2_PACKAGE_THINGINO_ISP_OPEN=y
```

Camera profiles can now opt into the complete open media stack with `open-isp` in their `# FRAG:` list.

## Problem

The earlier aggregate profile used `BR2_PACKAGE_THINGINO_OPEN_ISP`. That symbol no longer exists after the ISP provider choice was introduced. Reusing a fragment with the old spelling is silently normalized away by `olddefconfig`, which then selects the proprietary ISP default and never builds `open-tx-isp`.

## Validation

Temporarily added `open-isp` to the Wyze Cam 4 T41NQ fragment list and ran:

```sh
CAMERA=wyze_cam4_t41nq_os04d10_atbm6062s GROUP=exp WORKFLOW=1 make force-config
```

The resulting Buildroot configuration selected:

- `BR2_PACKAGE_THINGINO_ISP_OPEN=y`
- `BR2_PACKAGE_OPEN_TX_ISP=y`
- `BR2_PACKAGE_OPENIMP=y`
- the neo system/audio libraries
- proprietary ISP provider disabled

The temporary camera-profile change is not part of this PR.