### PR TITLE
thingino-system: retry SD card automount at end of boot

### DIFF
--- a/package/thingino-system/files/S99sdretry
+++ b/package/thingino-system/files/S99sdretry
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# SD cards can enumerate after mdev's one-shot scan at S30. When that
+# happens the mmcblk partition node exists but no hotplug event fires
+# automount, so the card is never mounted and the mount point is never
+# created. Running at the very end of boot guarantees the card had the
+# whole boot to appear; re-fire the uevent to trigger the regular
+# automount path if it is still missing.
+
+start() {
+	for part in /sys/block/mmcblk*/mmcblk*p*; do
+		[ -e "$part" ] || continue
+		grep -qs "^/dev/${part##*/} " /proc/mounts && continue
+		echo add > "$part/uevent" 2>/dev/null
+	done
+}
+
+case "$1" in
+	start)
+		start
+		;;
+	stop)
+		true
+		;;
+	restart)
+		start
+		;;
+	*)
+		echo "Usage: $0 {start|stop|restart}"
+		exit 1
+		;;
+esac
+
+exit $?

--- a/package/thingino-system/thingino-system.mk
+++ b/package/thingino-system/thingino-system.mk
@@ -52,6 +52,8 @@ define THINGINO_SYSTEM_INSTALL_TARGET_CMDS
 			$(TARGET_DIR)/usr/lib/mdev/automount; \
 		$(INSTALL) -D -m 0755 $(THINGINO_SYSTEM_PKGDIR)/files/S30mdev \
 			$(TARGET_DIR)/etc/init.d/S30mdev; \
+		$(INSTALL) -D -m 0755 $(THINGINO_SYSTEM_PKGDIR)/files/S99sdretry \
+			$(TARGET_DIR)/etc/init.d/S99sdretry; \
 		$(INSTALL) -D -m 0755 $(THINGINO_SYSTEM_PKGDIR)/files/formatsd \
 			$(TARGET_DIR)/usr/sbin/formatsd; \
 		$(INSTALL) -D -m 0755 $(THINGINO_SYSTEM_PKGDIR)/files/envfromcard \


### PR DESCRIPTION
## Problem

SD cards that enumerate after `S30mdev`'s one-shot `mdev -s` scan never receive a hotplug event, so `automount` never runs. The result: the `mmcblk0p1` node exists and the Web UI shows the card (capacity, serial) as healthy — but it is not mounted and `/mnt/mmcblk0p1` is never created. A reboot does not reliably fix it.

This bit a user during motion-event recording on stable: after a crash the card would not come back on subsequent boots, which initially looked like card failure or corruption but was purely a missed hotplug event.

## Diagnosis (on device)

```sh
ls /dev/mmcblk0*        # nodes present
mount | grep mmc        # nothing mounted
logread | grep -i mdev  # empty — no event ever fired

# re-fire the event manually → card mounts immediately
echo add > /sys/block/mmcblk0/mmcblk0p1/uevent
```

## Fix

New `S99sdretry` init script: at the very end of boot, re-fire the `add` uevent for every present-but-unmounted `mmcblk*p*` partition. The regular `automount` path (fsck, mount point creation, runonce handling) then runs as if the event had arrived on time.

Why `S99` and not a retry loop inside `S30mdev`: init scripts run serially, so an in-place fix would need sleeps that block boot waiting for a card that may legitimately take seconds to appear — or never exist. Running last guarantees the card had the entire boot to enumerate, so a single non-blocking check suffices: no sleeps, no loops, zero cost when the card is absent, already mounted, or genuinely late.

Gated on `BR2_THINGINO_SDCARD`, installed alongside `S30mdev`/`automount` in `thingino-system`.

## Testing

Tapo C200 (T23N, ciao): card failed to mount on roughly half of reboots without the hook; with `S99sdretry` installed it mounted reliably across 3 consecutive reboots. Manual uevent re-fire also verified as the trigger mechanism.

Reported-by: Discord user (Tapo C200, stable)
Signed-off-by: Gino <gino@wltechblog.com>
