### PR TITLE
timectl: send confirmation messages to stderr

### DIFF
--- a/overlay/usr/sbin/timectl
+++ b/overlay/usr/sbin/timectl
@@ -134,7 +134,7 @@ cmd_set_timezone() {
 
 	if [ "$name" = "$(cat "$TZNAME_FILE" 2>/dev/null)" ] &&
 		[ "$source" = "$(current_source "$TZ_SOURCE_FILE")" ]; then
-		echo "timectl: timezone already set to '$name' [$source]"
+		echo "timectl: timezone already set to '$name' [$source]" >&2
 		return 0
 	fi
 
@@ -147,7 +147,7 @@ cmd_set_timezone() {
 	echo "$name" >"$TZNAME_FILE"
 	echo "$tz" >"$TZCODE_FILE"
 	echo "$source" >"$TZ_SOURCE_FILE"
-	echo "timectl: timezone set to $name ($tz) [$source]"
+	echo "timectl: timezone set to $name ($tz) [$source]" >&2
 }
 
 cmd_set_ntp() {
@@ -198,7 +198,7 @@ cmd_set_ntp() {
 	cat "$tmp" >"$NTP_WORKING_FILE"
 	rm -f "$tmp"
 	echo "$source" >"$NTP_SOURCE_FILE"
-	echo "timectl: ntp set to:$servers [$source]"
+	echo "timectl: ntp set to:$servers [$source]" >&2
 }
 
 cmd_set_time() {
@@ -225,12 +225,12 @@ cmd_pin_timezone() {
 		echo "$name" >"$TZNAME_FILE"
 	fi
 	echo "user" >"$TZ_SOURCE_FILE"
-	echo "timectl: timezone pinned to $name [user]"
+	echo "timectl: timezone pinned to $name [user]" >&2
 }
 
 cmd_unpin_timezone() {
 	echo "default" >"$TZ_SOURCE_FILE"
-	echo "timectl: timezone unpinned [default]"
+	echo "timectl: timezone unpinned [default]" >&2
 }
 
 cmd_sync() {


### PR DESCRIPTION
## Problem

On the provisioning portal (first boot), clicking Save on the WiFi
setup page fails with a JSON decoding error on
`http://172.16.0.1/x/api.cgi?action=save`, leaving the camera stuck
in provisioning.

## Root cause

The portal CGI (`package/wifi/files/api.cgi`) runs
`timectl set-timezone --source user "$timezone"` inside
`save_config()`, and the dispatcher wraps the function output with
`json_response "$(save_config)"`. `timectl` prints its human-readable
confirmation (`timectl: timezone set to ...`) to **stdout**, so the
response body comes out as:

```
timectl: timezone set to America/New_York (EST5EDT,...) [user]
{"success": true}
```

The portal frontend (`index.html`) parses this with
`response.json()`, which throws.

This is a ciao-only regression: the portal timezone save was routed
through `timectl` in 6a067601, and `timectl` was introduced in
4d44085.

The same latent bug exists in the WebUI time settings page
(`package/thingino-webui/files/www/x/json-config-time.cgi`), where
`write_config()` invokes `timectl set-timezone/pin-timezone/unpin-timezone/set-ntp`
before the CGI emits its `Status:` header — any of those lines would
land in the HTTP response headers/body.

## Fix

Move all `timectl` confirmation messages (set-timezone, set-ntp,
pin-timezone, unpin-timezone, already-set) from stdout to stderr,
matching the error paths which already go to stderr. stdout is now
reserved for machine-readable output only (the `key=value` dump of
`timectl status`), per docs/timezone.md.

This fixes both the portal save and the WebUI time page in one
change, and makes stdout safe for any future script that wants to
capture timectl output.

## Testing

- Not yet tested on hardware (no portal camera at hand). The change
  is mechanical (5 echo lines gain `>&2`).
- Quick manual verification path: flash ciao, connect to portal AP,
  fill the form, Save — response should now parse and the camera
  should proceed to reboot.
- CLI behavior unchanged for humans (stderr still shows on a tty).

Reported by Josh (WLTechBlog).
