### PR TITLE
thingino-agent: persist day/night via daynightd when present

### DIFF
--- a/package/thingino-agent/files/thingino-agent-adapter-prudynt
+++ b/package/thingino-agent/files/thingino-agent-adapter-prudynt
@@ -2068,8 +2068,21 @@ thingino_agent_adapter_prudynt_apply_config() {
 	thingino_agent_prudynt_persist_if_present "$source_file" motion.send2storage
 	thingino_agent_prudynt_persist_if_present "$source_file" motion.send2telegram
 	thingino_agent_prudynt_persist_if_present "$source_file" motion.send2webhook
-	thingino_agent_prudynt_persist_if_present "$source_file" daynight.enabled
-	thingino_agent_prudynt_persist_if_present "$source_file" daynight.force_mode
+	if thingino_agent_has_daynightd; then
+		value=$(thingino_agent_json_config_value "$source_file" daynight.enabled)
+		case "$value" in
+			true) thingino_agent_daynightd_set_mode auto || true ;;
+			false)
+				force=$(thingino_agent_json_config_value "$source_file" daynight.force_mode | tr -d '"')
+				case "$force" in
+					day | night) thingino_agent_daynightd_set_mode "$force" || true ;;
+				esac
+				;;
+		esac
+	else
+		thingino_agent_prudynt_persist_if_present "$source_file" daynight.enabled
+		thingino_agent_prudynt_persist_if_present "$source_file" daynight.force_mode
+	fi
 	thingino_agent_prudynt_persist_if_present "$source_file" recorder.autostart
 	thingino_agent_prudynt_persist_if_present "$source_file" recorder.channel
 	thingino_agent_prudynt_persist_if_present "$source_file" recorder.device_path

--- a/package/thingino-agent/files/thingino-agent-adapter-prudynt
+++ b/package/thingino-agent/files/thingino-agent-adapter-prudynt
@@ -67,7 +67,7 @@ thingino_agent_prudynt_has_privacy() {
 }
 
 thingino_agent_prudynt_has_daynight() {
-	if command -v prudyntctl >/dev/null 2>&1 || [ -f /run/prudynt/daynight_mode ] || [ -f "$THINGINO_AGENT_PRUDYNT_CONFIG" ]; then
+	if thingino_agent_has_daynightd || command -v prudyntctl >/dev/null 2>&1 || [ -f /run/prudynt/daynight_mode ] || [ -f "$THINGINO_AGENT_PRUDYNT_CONFIG" ]; then
 		printf 'true'
 	else
 		printf 'false'
@@ -441,14 +441,26 @@ thingino_agent_prudynt_motion_active() {
 }
 
 thingino_agent_prudynt_daynight_enabled() {
+	if thingino_agent_has_daynightd; then
+		thingino_agent_daynightd_enabled
+		return 0
+	fi
 	thingino_agent_json_value_or "$(thingino_agent_prudynt_raw daynight.enabled)" false
 }
 
 thingino_agent_prudynt_daynight_force_mode() {
+	if thingino_agent_has_daynightd; then
+		thingino_agent_daynightd_force_mode
+		return 0
+	fi
 	thingino_agent_json_value_or "$(thingino_agent_prudynt_raw daynight.force_mode)" null
 }
 
 thingino_agent_prudynt_daynight_running_mode() {
+	if thingino_agent_has_daynightd; then
+		thingino_agent_daynightd_running_mode
+		return 0
+	fi
 	if [ -f /run/prudynt/daynight_mode ]; then
 		mode=$(awk 'NR == 1 { print $1 }' /run/prudynt/daynight_mode 2>/dev/null | tr -d '\n')
 		[ -n "$mode" ] && {
@@ -478,6 +490,10 @@ EOF
 }
 
 thingino_agent_prudynt_daynight_target_mode() {
+	if thingino_agent_has_daynightd; then
+		thingino_agent_daynightd_target_mode
+		return 0
+	fi
 	enabled=$(thingino_agent_prudynt_daynight_enabled)
 	if [ "$enabled" = "true" ]; then
 		printf 'auto'
@@ -1370,10 +1386,10 @@ thingino_agent_adapter_prudynt_get_setting() {
 			thingino_agent_print_setting_leaf enabled "$(thingino_agent_prudynt_send2_motion_enabled "$service")"
 			;;
 		daynight/enabled)
-			thingino_agent_print_setting_leaf enabled "$(thingino_agent_prudynt_raw daynight.enabled)"
+			thingino_agent_print_setting_leaf enabled "$(thingino_agent_prudynt_daynight_enabled)"
 			;;
 		daynight/force-mode)
-			printf '{"force_mode":%s}\n' "$(thingino_agent_json_string_or_null "$(thingino_agent_prudynt_text daynight.force_mode)")"
+			printf '{"force_mode":%s}\n' "$(thingino_agent_prudynt_daynight_force_mode)"
 			;;
 		privacy/enabled)
 			thingino_agent_print_setting_leaf enabled "$(thingino_agent_prudynt_privacy_enabled)"
@@ -1704,8 +1720,21 @@ thingino_agent_adapter_prudynt_set_setting() {
 		daynight/enabled)
 			value=$(thingino_agent_prudynt_setting_value "$body_file" enabled) || return 1
 			thingino_agent_prudynt_validate_bool "$value" || return 1
-			thingino_agent_prudynt_apply_payload "{\"daynight\":{\"enabled\":$value}}" || return 1
-			thingino_agent_prudynt_persist_value daynight.enabled "$value"
+			if thingino_agent_has_daynightd; then
+				if [ "$value" = true ]; then
+					thingino_agent_daynightd_set_mode auto || return 1
+				else
+					mode=$(thingino_agent_prudynt_daynight_running_mode)
+					case "$mode" in
+						day | night) ;;
+						*) mode=day ;;
+					esac
+					thingino_agent_daynightd_set_mode "$mode" || return 1
+				fi
+			else
+				thingino_agent_prudynt_apply_payload "{\"daynight\":{\"enabled\":$value}}" || return 1
+				thingino_agent_prudynt_persist_value daynight.enabled "$value"
+			fi
 			thingino_agent_print_setting_update "$path" enabled "$value"
 			;;
 		daynight/force-mode)
@@ -1717,8 +1746,13 @@ thingino_agent_adapter_prudynt_set_setting() {
 					return 1
 					;;
 			esac
-			thingino_agent_prudynt_apply_payload "{\"daynight\":{\"force_mode\":$value}}" || return 1
-			thingino_agent_prudynt_persist_value daynight.force_mode "$value"
+			if thingino_agent_has_daynightd; then
+				mode=$(printf '%s' "$value" | tr -d '"')
+				thingino_agent_daynightd_set_mode "$mode" || return 1
+			else
+				thingino_agent_prudynt_apply_payload "{\"daynight\":{\"force_mode\":$value}}" || return 1
+				thingino_agent_prudynt_persist_value daynight.force_mode "$value"
+			fi
 			thingino_agent_print_setting_update "$path" force_mode "$value"
 			;;
 		privacy/enabled)
@@ -2276,14 +2310,22 @@ thingino_agent_adapter_prudynt_daynight() {
 	}
 	case "$mode" in
 		auto)
-			thingino_agent_prudynt_apply_payload '{"daynight":{"enabled":true}}' || return 1
-			thingino_agent_prudynt_persist_value daynight.enabled true
+			if thingino_agent_has_daynightd; then
+				thingino_agent_daynightd_set_mode auto || return 1
+			else
+				thingino_agent_prudynt_apply_payload '{"daynight":{"enabled":true}}' || return 1
+				thingino_agent_prudynt_persist_value daynight.enabled true
+			fi
 			printf '{"status":"accepted","mode":"auto"}\n'
 			;;
 		day | night)
-			thingino_agent_prudynt_apply_payload "{\"daynight\":{\"enabled\":false,\"force_mode\":\"$mode\"}}" || return 1
-			thingino_agent_prudynt_persist_value daynight.enabled false
-			thingino_agent_prudynt_persist_value daynight.force_mode "\"$mode\""
+			if thingino_agent_has_daynightd; then
+				thingino_agent_daynightd_set_mode "$mode" || return 1
+			else
+				thingino_agent_prudynt_apply_payload "{\"daynight\":{\"enabled\":false,\"force_mode\":\"$mode\"}}" || return 1
+				thingino_agent_prudynt_persist_value daynight.enabled false
+				thingino_agent_prudynt_persist_value daynight.force_mode "\"$mode\""
+			fi
 			printf '{"status":"accepted","mode":%s}\n' "$(thingino_agent_json_string "$mode")"
 			;;
 		*)

--- a/package/thingino-agent/files/thingino-agent-adapter-raptor
+++ b/package/thingino-agent/files/thingino-agent-adapter-raptor
@@ -151,7 +151,7 @@ thingino_agent_raptor_has_privacy() {
 }
 
 thingino_agent_raptor_has_daynight() {
-	if command -v raptorctl >/dev/null 2>&1 || [ -x /usr/bin/ric ]; then
+	if thingino_agent_has_daynightd || command -v raptorctl >/dev/null 2>&1 || [ -x /usr/bin/ric ]; then
 		printf 'true'
 	else
 		printf 'false'
@@ -466,12 +466,20 @@ thingino_agent_raptor_motion_active() {
 }
 
 thingino_agent_raptor_daynight_mode_config() {
+	if thingino_agent_has_daynightd; then
+		thingino_agent_daynightd_target_mode
+		return 0
+	fi
 	mode=$(thingino_agent_raptor_config_get ircut mode | tr 'A-Z' 'a-z')
 	[ -n "$mode" ] || mode=auto
 	printf '%s' "$mode"
 }
 
 thingino_agent_raptor_daynight_enabled() {
+	if thingino_agent_has_daynightd; then
+		thingino_agent_daynightd_enabled
+		return 0
+	fi
 	case "$(thingino_agent_raptor_daynight_mode_config)" in
 		auto) printf 'true' ;;
 		*) printf 'false' ;;
@@ -479,6 +487,10 @@ thingino_agent_raptor_daynight_enabled() {
 }
 
 thingino_agent_raptor_daynight_force_mode() {
+	if thingino_agent_has_daynightd; then
+		thingino_agent_daynightd_force_mode
+		return 0
+	fi
 	case "$(thingino_agent_raptor_daynight_mode_config)" in
 		day | night)
 			thingino_agent_json_string "$(thingino_agent_raptor_daynight_mode_config)"
@@ -490,6 +502,10 @@ thingino_agent_raptor_daynight_force_mode() {
 }
 
 thingino_agent_raptor_daynight_running_mode() {
+	if thingino_agent_has_daynightd; then
+		thingino_agent_daynightd_running_mode
+		return 0
+	fi
 	status=$(thingino_agent_raptor_daemon_status ric)
 	mode=$(thingino_agent_raptor_json_string_field state "$status")
 	case "$mode" in
@@ -522,6 +538,10 @@ thingino_agent_raptor_daynight_running_mode() {
 }
 
 thingino_agent_raptor_daynight_target_mode() {
+	if thingino_agent_has_daynightd; then
+		thingino_agent_daynightd_target_mode
+		return 0
+	fi
 	case "$(thingino_agent_raptor_daynight_mode_config)" in
 		auto) printf 'auto' ;;
 		day) printf 'day' ;;
@@ -2150,9 +2170,21 @@ thingino_agent_adapter_raptor_set_setting() {
 		daynight/enabled)
 			value=$(thingino_agent_raptor_setting_value "$body_file" enabled) || return 1
 			thingino_agent_raptor_validate_bool "$value" || return 1
-			if [ "$value" = true ]; then
+			if thingino_agent_has_daynightd; then
+				if [ "$value" = true ]; then
+					thingino_agent_daynightd_set_mode auto || return 1
+				else
+					mode=$(thingino_agent_raptor_daynight_running_mode)
+					case "$mode" in
+						day | night) ;;
+						*) mode=day ;;
+					esac
+					thingino_agent_daynightd_set_mode "$mode" || return 1
+				fi
+			elif [ "$value" = true ]; then
 				thingino_agent_raptor_ctl ric mode auto >/dev/null 2>&1 || return 1
 				thingino_agent_raptor_config_set ircut mode auto || return 1
+				thingino_agent_raptor_config_save
 			else
 				mode=$(thingino_agent_raptor_daynight_running_mode)
 				case "$mode" in
@@ -2161,8 +2193,8 @@ thingino_agent_adapter_raptor_set_setting() {
 				esac
 				thingino_agent_raptor_ctl ric mode "$mode" >/dev/null 2>&1 || return 1
 				thingino_agent_raptor_config_set ircut mode "$mode" || return 1
+				thingino_agent_raptor_config_save
 			fi
-			thingino_agent_raptor_config_save
 			thingino_agent_print_setting_update "$path" enabled "$value"
 			;;
 		daynight/force-mode)
@@ -2175,9 +2207,13 @@ thingino_agent_adapter_raptor_set_setting() {
 					return 1
 					;;
 			esac
-			thingino_agent_raptor_ctl ric mode "$value" >/dev/null 2>&1 || return 1
-			thingino_agent_raptor_config_set ircut mode "$value" || return 1
-			thingino_agent_raptor_config_save
+			if thingino_agent_has_daynightd; then
+				thingino_agent_daynightd_set_mode "$value" || return 1
+			else
+				thingino_agent_raptor_ctl ric mode "$value" >/dev/null 2>&1 || return 1
+				thingino_agent_raptor_config_set ircut mode "$value" || return 1
+				thingino_agent_raptor_config_save
+			fi
 			thingino_agent_print_setting_update "$path" force_mode "$(thingino_agent_json_string "$value")"
 			;;
 		privacy/enabled)
@@ -2429,11 +2465,23 @@ thingino_agent_adapter_raptor_apply_config() {
 
 	value=$(thingino_agent_json_config_value "$source_file" daynight.enabled)
 	case "$value" in
-		true) thingino_agent_raptor_ctl ric mode auto >/dev/null 2>&1 || true ;;
+		true)
+			if thingino_agent_has_daynightd; then
+				thingino_agent_daynightd_set_mode auto || true
+			else
+				thingino_agent_raptor_ctl ric mode auto >/dev/null 2>&1 || true
+			fi
+			;;
 		false)
 			force=$(thingino_agent_json_config_value "$source_file" daynight.force_mode | tr -d '"')
 			case "$force" in
-				day | night) thingino_agent_raptor_ctl ric mode "$force" >/dev/null 2>&1 || true ;;
+				day | night)
+					if thingino_agent_has_daynightd; then
+						thingino_agent_daynightd_set_mode "$force" || true
+					else
+						thingino_agent_raptor_ctl ric mode "$force" >/dev/null 2>&1 || true
+					fi
+					;;
 			esac
 			;;
 	esac
@@ -2580,9 +2628,13 @@ thingino_agent_adapter_raptor_daynight() {
 	}
 	case "$mode" in
 		auto | day | night)
-			thingino_agent_raptor_ctl ric mode "$mode" >/dev/null 2>&1 || return 1
-			thingino_agent_raptor_config_set ircut mode "$mode" || return 1
-			thingino_agent_raptor_config_save
+			if thingino_agent_has_daynightd; then
+				thingino_agent_daynightd_set_mode "$mode" || return 1
+			else
+				thingino_agent_raptor_ctl ric mode "$mode" >/dev/null 2>&1 || return 1
+				thingino_agent_raptor_config_set ircut mode "$mode" || return 1
+				thingino_agent_raptor_config_save
+			fi
 			printf '{"status":"accepted","mode":%s}\n' "$(thingino_agent_json_string "$mode")"
 			;;
 		*)

--- a/package/thingino-agent/files/thingino-agent-lib
+++ b/package/thingino-agent/files/thingino-agent-lib
@@ -218,3 +218,109 @@ thingino_agent_print_setting_resource_update() {
 	printf '{"status":"accepted","applied":["settings.%s"],"staged":[],"restart_required":[],"resource":%s}\n' \
 		"$(thingino_agent_setting_path_label "$path")" "$(thingino_agent_json_value_or "$resource_json" null)"
 }
+
+# daynightd owns day/night when present (writes /etc/thingino.json + SIGHUP).
+# Matches package/thingino-webui/files/www/x/json-imp.cgi preference order.
+thingino_agent_has_daynightd() {
+	command -v daynightd >/dev/null 2>&1
+}
+
+thingino_agent_daynightd_reload() {
+	if [ -f /run/daynightd.pid ]; then
+		kill -HUP "$(cat /run/daynightd.pid)" 2>/dev/null || true
+	fi
+}
+
+thingino_agent_daynightd_script() {
+	if [ -x /sbin/daynight ]; then
+		printf '/sbin/daynight'
+	elif [ -x /usr/sbin/daynight ]; then
+		printf '/usr/sbin/daynight'
+	fi
+}
+
+thingino_agent_daynightd_config_get() {
+	thingino_agent_json_config_value "$THINGINO_CONFIG_FILE" "$1"
+}
+
+thingino_agent_daynightd_config_set() {
+	path=$1
+	value=$2
+	command -v jct >/dev/null 2>&1 || {
+		echo "jct is not available" >&2
+		return 1
+	}
+	[ -f "$THINGINO_CONFIG_FILE" ] || {
+		echo "missing $THINGINO_CONFIG_FILE" >&2
+		return 1
+	}
+	jct "$THINGINO_CONFIG_FILE" set "$path" "$value" >/dev/null 2>&1 || {
+		echo "failed to set $path" >&2
+		return 1
+	}
+}
+
+thingino_agent_daynightd_enabled() {
+	case "$(thingino_agent_daynightd_config_get daynight.enabled | tr 'A-Z' 'a-z')" in
+		1 | true | yes | on) printf 'true' ;;
+		*) printf 'false' ;;
+	esac
+}
+
+thingino_agent_daynightd_force_mode() {
+	mode=$(thingino_agent_daynightd_config_get daynight.force_mode | tr -d '"' | tr 'A-Z' 'a-z')
+	case "$mode" in
+		day | night) thingino_agent_json_string "$mode" ;;
+		*) printf 'null' ;;
+	esac
+}
+
+thingino_agent_daynightd_running_mode() {
+	if [ -r /run/thingino/daynight_mode ]; then
+		mode=$(sed -n '1p' /run/thingino/daynight_mode 2>/dev/null | tr -d '\r\n ' | tr 'A-Z' 'a-z')
+		case "$mode" in
+			day | night)
+				printf '%s' "$mode"
+				return 0
+				;;
+		esac
+	fi
+	printf 'unknown'
+}
+
+thingino_agent_daynightd_target_mode() {
+	if [ "$(thingino_agent_daynightd_enabled)" = true ]; then
+		printf 'auto'
+		return 0
+	fi
+	mode=$(thingino_agent_daynightd_config_get daynight.force_mode | tr -d '"' | tr 'A-Z' 'a-z')
+	case "$mode" in
+		day | night) printf '%s' "$mode" ;;
+		*) printf 'auto' ;;
+	esac
+}
+
+# Apply auto|day|night the same way json-imp.cgi does for daynightd images.
+thingino_agent_daynightd_set_mode() {
+	mode=$(printf '%s' "$1" | tr 'A-Z' 'a-z')
+	case "$mode" in
+		auto)
+			thingino_agent_daynightd_config_set daynight.enabled true || return 1
+			thingino_agent_daynightd_config_set daynight.force_mode "" || return 1
+			thingino_agent_daynightd_reload
+			;;
+		day | night)
+			thingino_agent_daynightd_config_set daynight.enabled false || return 1
+			thingino_agent_daynightd_config_set daynight.force_mode "$mode" || return 1
+			script=$(thingino_agent_daynightd_script)
+			if [ -n "$script" ]; then
+				"$script" "$mode" >/dev/null 2>&1 || true
+			fi
+			thingino_agent_daynightd_reload
+			;;
+		*)
+			echo "daynight mode must be auto, day, or night" >&2
+			return 1
+			;;
+	esac
+}


### PR DESCRIPTION
## Summary
- After the WebUI control bar started routing day/night through the camera agent (#1356), daynightd-backed images stopped persisting mode because the adapters still drove RIC/`prudynt.json` only.
- Prefer `daynightd` + `/etc/thingino.json` + SIGHUP when `daynightd` is installed (same preference as `json-imp.cgi`); keep RIC/`raptor.conf` and legacy prudynt paths otherwise.

## Test plan
- [ ] On a daynightd image: toggle auto/day/night from the WebUI control bar, reboot, confirm mode persists in `/etc/thingino.json` and UI state.
- [ ] On a RIC raptor image (no daynightd): confirm day/night still applies via `raptorctl ric mode` and `ircut mode` in `raptor.conf`.
- [ ] Confirm photosensing / daynightd WebUI plugin pages still work independently of the control bar.


Made with [Cursor](https://cursor.com)