### PR TITLE
webui/raptor: fix agent-era streamer page regressions

### DIFF
--- a/package/thingino-raptor/files/microphone
+++ b/package/thingino-raptor/files/microphone
@@ -32,7 +32,9 @@ set_bool() {
 		echo "microphone: raptorctl is not installed" >&2
 		exit 1
 	}
+	# Persist before restart so S31raptor reloads the new value, not the old conf.
 	raptorctl config set audio "$key" "$value" >/dev/null
+	raptorctl config save >/dev/null 2>&1 || true
 	if [ -x "$RAPTOR_INIT" ] && pidof rvd >/dev/null 2>&1; then
 		"$RAPTOR_INIT" restart >/dev/null
 	fi

--- a/package/thingino-raptor/files/raptor.webui.json
+++ b/package/thingino-raptor/files/raptor.webui.json
@@ -79,7 +79,14 @@
   "cgi": [
     "/x/json-config-save.cgi",
     "/x/restart-streamer.cgi",
-    "/x/webrtc-whip.cgi"
+    "/x/webrtc-whip.cgi",
+    "/x/json-sensor-upload.cgi",
+    "/x/dl0.jpg",
+    "/x/dl1.jpg",
+    "/x/ch0.mjpg",
+    "/x/ch1.mjpg",
+    "/x/ch0.jpg",
+    "/x/ch1.jpg"
   ],
   "pages": [
     "/streamer-main.html",

--- a/package/thingino-raptor/files/speaker
+++ b/package/thingino-raptor/files/speaker
@@ -32,7 +32,9 @@ set_bool() {
 		echo "speaker: raptorctl is not installed" >&2
 		exit 1
 	}
+	# Persist before restart so S31raptor reloads the new value, not the old conf.
 	raptorctl config set audio "$key" "$value" >/dev/null
+	raptorctl config save >/dev/null 2>&1 || true
 	if [ -x "$RAPTOR_INIT" ] && pidof rvd >/dev/null 2>&1; then
 		"$RAPTOR_INIT" restart >/dev/null
 	fi

--- a/package/thingino-raptor/files/www/a/streamer-osd.js
+++ b/package/thingino-raptor/files/www/a/streamer-osd.js
@@ -1,0 +1,166 @@
+/**
+ * Agent-backed OSD page for raptor (ROD timestamp burn-in).
+ */
+(function () {
+  "use strict";
+
+  const burninEnabled = document.getElementById("burnin_enabled");
+  const burninFormat = document.getElementById("burnin_format");
+  const burninFontSize = document.getElementById("burnin_font_size");
+  const burninPosition = document.getElementById("burnin_position");
+  const burninFillColor = document.getElementById("burnin_fill_color");
+  const burninOutlineColor = document.getElementById("burnin_outline_color");
+  const swatchFill = document.getElementById("swatch_fill");
+  const swatchOutline = document.getElementById("swatch_outline");
+  const pickerFill = document.getElementById("picker_fill");
+  const pickerOutline = document.getElementById("picker_outline");
+  const alphaFill = document.getElementById("alpha_fill");
+  const alphaOutline = document.getElementById("alpha_outline");
+  const saveBtn = document.getElementById("save-osd-config");
+
+  function updateSwatch(input, swatch) {
+    let v = (input.value || "").trim();
+    if (v && /^#?[0-9a-fA-F]{8}$/.test(v)) {
+      if (v[0] !== "#") v = "#" + v;
+      const r = parseInt(v.substring(1, 3), 16);
+      const g = parseInt(v.substring(3, 5), 16);
+      const b = parseInt(v.substring(5, 7), 16);
+      const a = parseInt(v.substring(7, 9), 16) / 255;
+      swatch.style.backgroundColor =
+        "rgba(" + r + "," + g + "," + b + "," + a + ")";
+    } else {
+      swatch.style.backgroundColor = "";
+    }
+  }
+
+  function wireColor(swatch, picker, input, alphaSlider) {
+    swatch.addEventListener("click", function () {
+      picker.click();
+    });
+    picker.addEventListener("input", function () {
+      let cur = input.value.trim();
+      let alpha = "ff";
+      if (cur && /^#?[0-9a-fA-F]{8}$/.test(cur)) {
+        if (cur[0] !== "#") cur = "#" + cur;
+        alpha = cur.substring(7, 9);
+      }
+      input.value = picker.value + alpha;
+      updateSwatch(input, swatch);
+    });
+    input.addEventListener("input", function () {
+      updateSwatch(input, swatch);
+      let v = input.value.trim();
+      if (v && /^#?[0-9a-fA-F]{8}$/.test(v)) {
+        if (v[0] !== "#") v = "#" + v;
+        alphaSlider.value = parseInt(v.substring(7, 9), 16);
+      }
+    });
+    alphaSlider.addEventListener("input", function () {
+      let v = input.value.trim();
+      if (!v || !/^#?[0-9a-fA-F]{8}$/.test(v)) {
+        v = "#ffffffff";
+      } else if (v[0] !== "#") {
+        v = "#" + v;
+      }
+      const alpha = ("0" + parseInt(alphaSlider.value, 10).toString(16)).slice(
+        -2,
+      );
+      input.value = v.substring(0, 7) + alpha;
+      updateSwatch(input, swatch);
+    });
+  }
+
+  function syncAlphaFromInput(input, alphaSlider) {
+    let v = (input.value || "").trim();
+    if (v && /^#?[0-9a-fA-F]{8}$/.test(v)) {
+      if (v[0] !== "#") v = "#" + v;
+      alphaSlider.value = parseInt(v.substring(7, 9), 16);
+    }
+  }
+
+  function showAlert(type, message, duration) {
+    if (window.showAlert) {
+      window.showAlert(type, message, duration);
+      return;
+    }
+    alert(message);
+  }
+
+  async function loadOsdConfig() {
+    const helper = window.thinginoStreamer;
+    if (!helper || !helper.agentRequest) return;
+    try {
+      const cfg = await helper.agentRequest("/api/v1/config", {
+        cache: "no-store",
+      });
+      const stream0 = (cfg && cfg.streams && cfg.streams[0]) || {};
+      const osd = stream0.osd || {};
+      const time = osd.time || {};
+
+      burninEnabled.checked = time.enabled === true || osd.enabled === true;
+      if (time.format) burninFormat.value = time.format;
+      if (osd.font_size != null) burninFontSize.value = osd.font_size;
+      if (time.position) burninPosition.value = time.position;
+      burninFillColor.value = time.fill_color || "#ffffffff";
+      burninOutlineColor.value = time.stroke_color || "#000000ff";
+      updateSwatch(burninFillColor, swatchFill);
+      updateSwatch(burninOutlineColor, swatchOutline);
+      syncAlphaFromInput(burninFillColor, alphaFill);
+      syncAlphaFromInput(burninOutlineColor, alphaOutline);
+    } catch (err) {
+      console.warn("Failed to load OSD config", err);
+    }
+  }
+
+  async function saveOsdConfig() {
+    const helper = window.thinginoStreamer;
+    if (!helper || !helper.applyPayload) {
+      showAlert("danger", "Streamer agent helper unavailable", 6000);
+      return;
+    }
+    const confirmed = await window.confirm(
+      (helper.saveConfirmMessage && helper.saveConfirmMessage()) ||
+        "Save the current OSD configuration to /etc/raptor.conf?",
+    );
+    if (!confirmed) return;
+
+    saveBtn.disabled = true;
+    try {
+      const time = {
+        enabled: !!burninEnabled.checked,
+      };
+      if (burninFormat.value.trim()) time.format = burninFormat.value.trim();
+      if (burninPosition.value.trim())
+        time.position = burninPosition.value.trim();
+      if (burninFillColor.value.trim())
+        time.fill_color = burninFillColor.value.trim();
+      if (burninOutlineColor.value.trim())
+        time.stroke_color = burninOutlineColor.value.trim();
+
+      const osd = { enabled: !!burninEnabled.checked, time };
+      const fontSize = Number(burninFontSize.value);
+      if (Number.isFinite(fontSize) && fontSize > 0) {
+        osd.font_size = fontSize;
+      }
+
+      await helper.applyPayload({ stream0: { osd } });
+      if (helper.saveConfig) await helper.saveConfig();
+      showAlert(
+        "success",
+        (helper.saveSuccessMessage && helper.saveSuccessMessage()) ||
+          "OSD configuration saved",
+        4000,
+      );
+    } catch (err) {
+      console.error("Failed to save OSD config", err);
+      showAlert("danger", "Failed to save OSD: " + err.message, 6000);
+    } finally {
+      saveBtn.disabled = false;
+    }
+  }
+
+  wireColor(swatchFill, pickerFill, burninFillColor, alphaFill);
+  wireColor(swatchOutline, pickerOutline, burninOutlineColor, alphaOutline);
+  saveBtn.addEventListener("click", saveOsdConfig);
+  loadOsdConfig();
+})();

--- a/package/thingino-raptor/files/www/a/streamer.js
+++ b/package/thingino-raptor/files/www/a/streamer.js
@@ -172,22 +172,33 @@
 
   function hideUnsupportedControls(root) {
     const doc = root || document;
-    const unsupported = ["max_gop"];
+    const unsupportedStream = ["max_gop"];
+    const unsupportedImage = [
+      "max_gop",
+      "backlight",
+      "wide_dynamic_range",
+      "tone",
+      "defog",
+      "noise_reduction",
+    ];
     [0, 1].forEach((id) => {
-      unsupported.forEach((param) => {
+      unsupportedStream.forEach((param) => {
         const el = doc.querySelector("#stream" + id + "_" + param);
         if (!el) return;
         const wrap =
-          el.closest(".mb-3, .col, .form-check, .row > div") || el.parentElement;
+          el.closest(".mb-3, .col, .form-check, .row > div, p") ||
+          el.parentElement;
         if (wrap) wrap.classList.add("d-none");
         el.disabled = true;
       });
     });
-    unsupported.forEach((param) => {
-      const el = doc.querySelector("#image_" + param);
+    unsupportedImage.forEach((param) => {
+      const el =
+        doc.querySelector("#" + param) ||
+        doc.querySelector("#image_" + param);
       if (!el) return;
       const wrap =
-        el.closest(".mb-3, .col, .form-check, .row > div") || el.parentElement;
+        el.closest(".mb-3, .col, .form-check, .row > div, p") || el.parentElement;
       if (wrap) wrap.classList.add("d-none");
       el.disabled = true;
     });

--- a/package/thingino-raptor/files/www/streamer-osd.html
+++ b/package/thingino-raptor/files/www/streamer-osd.html
@@ -13,7 +13,11 @@
     integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
   <link rel="stylesheet" href="/a/main.css">
-  <style>#sei-osd-overlay{display:none}.color-swatch{width:32px;padding:2px;cursor:pointer;border:1px solid var(--bs-border-color)}.color-picker-group{width:150px}.alpha-slider{width:48px;height:24px;cursor:pointer}</style>
+  <style>
+    .color-swatch{width:32px;padding:2px;cursor:pointer;border:1px solid var(--bs-border-color)}
+    .color-picker-group{width:150px}
+    .alpha-slider{width:48px;height:24px;cursor:pointer}
+  </style>
 </head>
 
 <body id="page-streamer-osd">
@@ -24,12 +28,11 @@
     <div data-app-controls></div>
 
     <section>
-      <div class="d-flex justify-content-between align-items-center mb-3">
-        <h3>OSD Elements</h3>
-        <button type="button" id="add-element" class="btn btn-outline-primary btn-sm">
-          <i class="bi bi-plus-lg me-1"></i> Add
-        </button>
-      </div>
+      <h3 class="mb-3">OSD Elements</h3>
+      <p class="text-secondary small mb-3">
+        Raptor uses ROD burn-in overlays. Timestamp settings below map to the
+        global OSD timestamp element via the camera agent.
+      </p>
 
       <div class="row mb-3">
         <div class="col-12 col-xl-4">
@@ -38,35 +41,27 @@
           </div>
         </div>
         <div class="col col-xl-8">
-          <div class="card bg-dark-subtle mb-3 p-2">
-            <h6 class="mb-2">OSD</h6>
+          <div class="card bg-dark-subtle mb-3 p-3">
+            <h6 class="mb-2">Timestamp overlay</h6>
             <p class="form-switch mb-2">
               <input type="checkbox" id="burnin_enabled" role="switch" class="form-check-input">
               <label for="burnin_enabled" class="form-check-label small">Enabled</label>
             </p>
             <div class="row g-2 mb-2">
               <div class="col">
-                <label class="form-label small mb-0">Format</label>
+                <label class="form-label small mb-0" for="burnin_format">Format</label>
                 <input type="text" id="burnin_format" class="form-control form-control-sm" placeholder="%F %T">
               </div>
-              <div class="col-auto" style="min-width:80px">
-                <label class="form-label small mb-0">Scale</label>
-                <select id="burnin_scale" class="form-select form-select-sm">
-                  <option value="0">auto</option>
-                  <option value="1">1</option>
-                  <option value="2">2</option>
-                  <option value="3">3</option>
-                  <option value="4">4</option>
-                  <option value="5">5</option>
-                  <option value="6">6</option>
-                  <option value="7">7</option>
-                  <option value="8">8</option>
-                  <option value="9">9</option>
-                  <option value="10">10</option>
-                </select>
+              <div class="col-auto" style="min-width:90px">
+                <label class="form-label small mb-0" for="burnin_font_size">Font size</label>
+                <input type="number" id="burnin_font_size" class="form-control form-control-sm" min="8" max="96" step="1" placeholder="24">
+              </div>
+              <div class="col-auto" style="min-width:110px">
+                <label class="form-label small mb-0" for="burnin_position">Position</label>
+                <input type="text" id="burnin_position" class="form-control form-control-sm" placeholder="-10,-10">
               </div>
             </div>
-            <div class="d-flex align-items-end gap-2">
+            <div class="d-flex align-items-end gap-2 flex-wrap">
               <div>
                 <label class="form-label small mb-0">Fill</label>
                 <div class="input-group input-group-sm color-picker-group">
@@ -87,25 +82,7 @@
                 </div>
                 <input type="range" id="alpha_outline" class="alpha-slider" min="0" max="255" value="255" title="Alpha">
               </div>
-              <div>
-                <label class="form-label small mb-0">Background</label>
-                <div class="input-group input-group-sm color-picker-group">
-                  <span class="input-group-text color-swatch" id="swatch_bg" title="Pick color">&nbsp;</span>
-                  <input type="color" id="picker_bg" class="d-none">
-                  <input type="text" id="burnin_background_color" class="form-control form-control-sm font-monospace"
-                    placeholder="#00000080" pattern="#?[0-9a-fA-F]{8}" maxlength="9">
-                </div>
-                <input type="range" id="alpha_bg" class="alpha-slider" min="0" max="255" value="128" title="Alpha">
-              </div>
             </div>
-          </div>
-          <div class="card bg-dark-subtle mb-3 p-2">
-            <h6 class="mb-2">SEI OSD</h6>
-            <p class="form-switch mb-0">
-              <input type="checkbox" id="osd_enabled" role="switch" class="form-check-input">
-              <label for="osd_enabled" class="form-check-label small">Enabled</label>
-            </p>
-            <div id="elements-list" class="mt-2"></div>
           </div>
           <button type="button" id="save-osd-config" class="btn btn-primary">
             <i class="bi bi-floppy me-1"></i> Save configuration
@@ -118,41 +95,6 @@
 
 <footer data-app-footer></footer>
 
-<template id="element-row">
-  <div class="element-row mb-2">
-    <div class="row g-2 align-items-end">
-      <div class="col-2">
-        <label class="form-label small mb-0">Name</label>
-        <input type="text" class="form-control form-control-sm elem-name" placeholder="id" required>
-      </div>
-      <div class="col-3">
-        <label class="form-label small mb-0">Type</label>
-        <select class="form-select form-select-sm elem-type">
-          <option value="text">Static text</option>
-          <option value="gain">Gain</option>
-          <option value="hostname">Hostname</option>
-          <option value="ipaddress">IP address</option>
-          <option value="timestamp">Timestamp</option>
-          <option value="uptime">Uptime</option>
-        </select>
-      </div>
-      <div class="col">
-        <label class="form-label small mb-0">Format</label>
-        <input type="text" class="form-control form-control-sm elem-format" placeholder="%F %T">
-      </div>
-      <div class="col-3">
-        <label class="form-label small mb-0">Position (x,y)</label>
-        <input type="text" class="form-control form-control-sm elem-position" placeholder="10,10">
-      </div>
-      <div class="col-auto text-end">
-        <button type="button" class="btn btn-outline-danger btn-sm elem-remove" title="Remove">
-          <i class="bi bi-trash"></i>
-        </button>
-      </div>
-    </div>
-  </div>
-</template>
-
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
   integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
 <script src="/a/main.js"></script>
@@ -162,274 +104,6 @@
 <script src="/a/footer.js"></script>
 <script src="/a/preview.js"></script>
 <script src="/a/streamer.js"></script>
-<script src="/a/streamer-config.js"></script>
-<script src="/a/sei-rotate.js"></script>
+<script src="/a/streamer-osd.js"></script>
 </body>
-<script>
-(function() {
-  var TYPES = ['text','gain','hostname','ipaddress','timestamp','uptime'];
-  var DEFAULTS = {
-    timestamp: {format: '%F %T', position: '-10,-10'},
-    hostname:  {format: '%s', position: '0,10'},
-    ipaddress: {format: '%s', position: '0,30'},
-    uptime:    {format: '%02lu:%02lu:%02lu', position: '-10,10'},
-    gain:      {format: '%s', position: '10,-10'},
-    text:      {format: '', position: '10,10'}
-  };
-
-  var list = document.getElementById('elements-list');
-  var tmpl = document.getElementById('element-row');
-  var saveBtn = document.getElementById('save-osd-config');
-  var enabledChk = document.getElementById('osd_enabled');
-  var burninEnabledChk = document.getElementById('burnin_enabled');
-  var burninBgColor = document.getElementById('burnin_background_color');
-  var swatchBg = document.getElementById('swatch_bg');
-  var pickerBg = document.getElementById('picker_bg');
-  var alphaBg = document.getElementById('alpha_bg');
-  var burninFormat = document.getElementById('burnin_format');
-  var burninScale = document.getElementById('burnin_scale');
-  var burninFillColor = document.getElementById('burnin_fill_color');
-  var burninOutlineColor = document.getElementById('burnin_outline_color');
-  var swatchFill = document.getElementById('swatch_fill');
-  var swatchOutline = document.getElementById('swatch_outline');
-  var pickerFill = document.getElementById('picker_fill');
-  var pickerOutline = document.getElementById('picker_outline');
-  var alphaFill = document.getElementById('alpha_fill');
-  var alphaOutline = document.getElementById('alpha_outline');
-
-  function updateSwatch(input, swatch) {
-    var v = input.value.trim();
-    if (v && /^#?[0-9a-fA-F]{8}$/.test(v)) {
-      if (v[0] !== '#') v = '#' + v;
-      var r = parseInt(v.substring(1, 3), 16);
-      var g = parseInt(v.substring(3, 5), 16);
-      var b = parseInt(v.substring(5, 7), 16);
-      var a = parseInt(v.substring(7, 9), 16) / 255;
-      swatch.style.backgroundColor = 'rgba(' + r + ',' + g + ',' + b + ',' + a + ')';
-      swatch.style.opacity = '';
-    } else {
-      swatch.style.backgroundColor = '';
-      swatch.style.opacity = '';
-    }
-  }
-
-  // Wire each swatch + hidden color picker + text field + alpha slider.
-  function wireColor(swatch, picker, input, alphaSlider) {
-    // Click swatch → open native color picker.
-    swatch.addEventListener('click', function() { picker.click(); });
-
-    // Picker changed → update text field (RGB only, preserve alpha).
-    picker.addEventListener('input', function() {
-      var cur = input.value.trim();
-      var alpha = 'ff';
-      if (cur && /^#?[0-9a-fA-F]{8}$/.test(cur)) {
-        if (cur[0] !== '#') cur = '#' + cur;
-        alpha = cur.substring(7, 9);
-      }
-      input.value = picker.value + alpha;
-      updateSwatch(input, swatch);
-    });
-
-    // Text field changed → update swatch + alpha slider.
-    input.addEventListener('input', function() {
-      updateSwatch(input, swatch);
-      var v = input.value.trim();
-      if (v && /^#?[0-9a-fA-F]{8}$/.test(v)) {
-        if (v[0] !== '#') v = '#' + v;
-        alphaSlider.value = parseInt(v.substring(7, 9), 16);
-      }
-    });
-
-    // Alpha slider → update text field's last 2 hex digits.
-    alphaSlider.addEventListener('input', function() {
-      var v = input.value.trim();
-      if (!v || !/^#?[0-9a-fA-F]{8}$/.test(v)) {
-        if (v && /^#?[0-9a-fA-F]{3,6}$/.test(v)) v = v + 'ff';
-        else v = '#ffffff';
-        if (v[0] !== '#') v = '#' + v;
-      } else {
-        if (v[0] !== '#') v = '#' + v;
-      }
-      var alpha = ('0' + parseInt(alphaSlider.value, 10).toString(16)).slice(-2);
-      input.value = v.substring(0, 7) + alpha;
-      updateSwatch(input, swatch);
-    });
-  }
-
-  wireColor(swatchFill, pickerFill, burninFillColor, alphaFill);
-  wireColor(swatchOutline, pickerOutline, burninOutlineColor, alphaOutline);
-  wireColor(swatchBg, pickerBg, burninBgColor, alphaBg);
-
-  function createRow(name, type, format, position) {
-    var row = tmpl.content.cloneNode(true).querySelector('.element-row');
-    row.querySelector('.elem-name').value = name || '';
-    row.querySelector('.elem-type').value = type || 'timestamp';
-    row.querySelector('.elem-format').value = format || '';
-    row.querySelector('.elem-position').value = position || '';
-
-    // auto-fill defaults when type changes
-    row.querySelector('.elem-type').addEventListener('change', function() {
-      var t = this.value;
-      var d = DEFAULTS[t];
-      row.querySelector('.elem-format').value = d.format;
-      row.querySelector('.elem-position').value = d.position;
-    });
-
-    row.querySelector('.elem-remove').addEventListener('click', function() {
-      row.remove();
-    });
-
-    return row;
-  }
-
-  function collectElements() {
-    var elems = {};
-    list.querySelectorAll('.element-row').forEach(function(row) {
-      var name = row.querySelector('.elem-name').value.trim();
-      if (!name) return;
-      elems[name] = {
-        type: row.querySelector('.elem-type').value,
-        format: row.querySelector('.elem-format').value,
-        position: row.querySelector('.elem-position').value
-      };
-    });
-    return elems;
-  }
-
-  function loadElements(elems) {
-    list.innerHTML = '';
-    if (!elems) return;
-    Object.keys(elems).forEach(function(name) {
-      var el = elems[name];
-      list.appendChild(createRow(name, el.type, el.format, el.position));
-    });
-  }
-
-  var CFG = 'http://' + location.hostname + ':8080/api/v1/config';
-  var API_KEY_PROMISE = fetch('/x/api-key.cgi', {cache: 'no-store'})
-    .then(function(r) { return r.json(); })
-    .then(function(d) { return (d.exists && d.api_key) ? d.api_key : ''; })
-    .catch(function() { return ''; });
-
-  async function osdApiFetch(url, options) {
-    var key = await API_KEY_PROMISE;
-    options = options || {};
-    options.headers = options.headers || {};
-    if (key) options.headers['X-API-Key'] = key;
-    return fetch(url, options);
-  }
-
-  // Load current OSD config via REST GET
-  function loadOsdConfig() {
-    osdApiFetch(CFG + '/osd')
-    .then(function(r) { return r.json(); })
-    .then(function(data) {
-      if (data.sei && data.sei.enabled !== undefined) {
-        enabledChk.checked = data.sei.enabled !== false;
-        loadElements(data.sei.entries);
-      }
-      if (data.burnin) {
-        if (data.burnin.enabled !== undefined)
-          burninEnabledChk.checked = data.burnin.enabled !== false;
-        if (data.burnin.background_color !== undefined && data.burnin.background_color !== null)
-          burninBgColor.value = data.burnin.background_color;
-        else
-          burninBgColor.value = '#00000080';
-        updateSwatch(burninBgColor, swatchBg);
-        if (data.burnin.format !== undefined && data.burnin.format !== null)
-          burninFormat.value = data.burnin.format;
-        if (data.burnin.scale !== undefined && data.burnin.scale !== null)
-          burninScale.value = data.burnin.scale;
-        if (data.burnin.fill_color !== undefined && data.burnin.fill_color !== null)
-          burninFillColor.value = data.burnin.fill_color;
-        else
-          burninFillColor.value = '#ffffffff';
-        if (data.burnin.outline_color !== undefined && data.burnin.outline_color !== null)
-          burninOutlineColor.value = data.burnin.outline_color;
-        else
-          burninOutlineColor.value = '#000000ff';
-        updateSwatch(burninFillColor, swatchFill);
-        updateSwatch(burninOutlineColor, swatchOutline);
-        // Sync alpha sliders from loaded values.
-        var v = burninFillColor.value.trim();
-        if (v && /^#?[0-9a-fA-F]{8}$/.test(v)) { if (v[0] !== '#') v = '#' + v; alphaFill.value = parseInt(v.substring(7, 9), 16); }
-        v = burninOutlineColor.value.trim();
-        if (v && /^#?[0-9a-fA-F]{8}$/.test(v)) { if (v[0] !== '#') v = '#' + v; alphaOutline.value = parseInt(v.substring(7, 9), 16); }
-        v = burninBgColor.value.trim();
-        if (v && /^#?[0-9a-fA-F]{8}$/.test(v)) { if (v[0] !== '#') v = '#' + v; alphaBg.value = parseInt(v.substring(7, 9), 16); }
-      }
-      // Sync SEI overlay visibility with enabled state
-      var overlay = document.getElementById('sei-osd-overlay');
-      if (overlay) overlay.style.display = enabledChk.checked ? '' : 'none';
-    })
-    .catch(function() {});
-  }
-
-  loadOsdConfig();
-
-  // Toggle SEI overlay when enabled checkbox changes
-  enabledChk.addEventListener('change', function() {
-    var overlay = document.getElementById('sei-osd-overlay');
-    if (overlay) overlay.style.display = enabledChk.checked ? '' : 'none';
-  });
-
-  // Add button
-  document.getElementById('add-element').addEventListener('click', function() {
-    list.appendChild(createRow('', 'text', '', ''));
-  });
-
-  // Persist configuration
-  saveBtn.addEventListener('click', async function() {
-    var confirmed = await confirm(
-      'Save the current OSD configuration to /etc/raptor.conf?\n\nThis will overwrite the saved configuration file on the camera and restart the OSD thread.'
-    );
-    if (!confirmed) return;
-
-    saveBtn.disabled = true;
-
-    try {
-      var payload = {
-        osd: {
-          sei: {
-            enabled: enabledChk.checked,
-            entries: collectElements()
-          },
-          burnin: {
-            enabled: burninEnabledChk.checked,
-            background_color: burninBgColor.value.trim() || undefined,
-            format: burninFormat.value,
-            scale: parseInt(burninScale.value, 10),
-            fill_color: burninFillColor.value.trim() || undefined,
-            outline_color: burninOutlineColor.value.trim() || undefined
-          }
-        },
-        action: { save_config: null, restart_thread: 32 }
-      };
-
-      var r = await osdApiFetch(CFG, {
-        method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(payload)
-      });
-      var msg = await r.json();
-
-      if (msg.action && msg.action.save_config === 'ok') {
-        if (typeof showAlert === 'function')
-          showAlert('success', 'OSD configuration saved and applied.', 4000);
-        loadOsdConfig();
-      } else {
-        throw new Error(msg.error || 'Save failed');
-      }
-    } catch (err) {
-      console.error('Save failed:', err);
-      if (typeof showAlert === 'function')
-        showAlert('danger', 'Failed to save: ' + err.message, 6000);
-    } finally {
-      saveBtn.disabled = false;
-    }
-  });
-
-  // Preview rotation from SEI
-})();
-</script>
 </html>

--- a/package/thingino-raptor/files/www/streamer-sensor.html
+++ b/package/thingino-raptor/files/www/streamer-sensor.html
@@ -65,7 +65,7 @@
         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
       </div>
       <div class="modal-body">
-        <form id="sensorUploadForm" class="mb-4" method="post" action="/x/preview.cgi" enctype="multipart/form-data">
+        <form id="sensorUploadForm" class="mb-4" method="post" action="/x/json-sensor-upload.cgi" enctype="multipart/form-data">
           <input type="hidden" name="form" value="sensor">
           <div class="mb-3">
             <label for="sensorfile">Upload a sensor IQ binary file</label>

--- a/package/thingino-raptor/files/www/x/ch0.mjpg
+++ b/package/thingino-raptor/files/www/x/ch0.mjpg
@@ -1,0 +1,50 @@
+#!/bin/sh
+# MJPEG preview for channel 0 — multipart JPEG loop via raptorctl.
+
+. /var/www/x/auth.sh
+require_auth
+
+CHANNEL=0
+BOUNDARY="raptormjpegboundary"
+FPS=5
+
+OLD_IFS=$IFS
+IFS='&'
+for KV in $QUERY_STRING; do
+	case "$KV" in
+		f=*) FPS=${KV#f=} ;;
+	esac
+done
+IFS=$OLD_IFS
+
+case "$FPS" in
+	'' | *[!0-9]*) FPS=5 ;;
+esac
+[ "$FPS" -lt 1 ] && FPS=1
+[ "$FPS" -gt 15 ] && FPS=15
+
+if ! command -v raptorctl >/dev/null 2>&1; then
+	printf 'Status: 503 Service Unavailable\r\n\r\n'
+	exit 0
+fi
+
+tmp=$(mktemp /tmp/raptor-mjpg.XXXXXX.jpg) || exit 1
+trap 'rm -f "$tmp"' EXIT INT TERM HUP PIPE
+
+printf 'Content-Type: multipart/x-mixed-replace; boundary=%s\r\n\r\n' "$BOUNDARY"
+
+# BusyBox sleep may not do fractional seconds; sleep 1 and skip when FPS>1.
+interval=1
+[ "$FPS" -ge 2 ] && interval=1
+
+while true; do
+	if raptorctl rvd save jpeg "$tmp" "$CHANNEL" >/dev/null 2>&1 && [ -s "$tmp" ]; then
+		size=$(wc -c <"$tmp" | tr -d ' ')
+		printf -- '--%s\r\n' "$BOUNDARY"
+		printf 'Content-Type: image/jpeg\r\n'
+		printf 'Content-Length: %s\r\n\r\n' "$size"
+		cat "$tmp"
+		printf '\r\n'
+	fi
+	sleep "$interval" || exit 0
+done

--- a/package/thingino-raptor/files/www/x/ch1.mjpg
+++ b/package/thingino-raptor/files/www/x/ch1.mjpg
@@ -1,0 +1,48 @@
+#!/bin/sh
+# MJPEG preview for channel 1 — multipart JPEG loop via raptorctl.
+
+. /var/www/x/auth.sh
+require_auth
+
+CHANNEL=1
+BOUNDARY="raptormjpegboundary"
+FPS=5
+
+OLD_IFS=$IFS
+IFS='&'
+for KV in $QUERY_STRING; do
+	case "$KV" in
+		f=*) FPS=${KV#f=} ;;
+	esac
+done
+IFS=$OLD_IFS
+
+case "$FPS" in
+	'' | *[!0-9]*) FPS=5 ;;
+esac
+[ "$FPS" -lt 1 ] && FPS=1
+[ "$FPS" -gt 15 ] && FPS=15
+
+if ! command -v raptorctl >/dev/null 2>&1; then
+	printf 'Status: 503 Service Unavailable\r\n\r\n'
+	exit 0
+fi
+
+tmp=$(mktemp /tmp/raptor-mjpg.XXXXXX.jpg) || exit 1
+trap 'rm -f "$tmp"' EXIT INT TERM HUP PIPE
+
+printf 'Content-Type: multipart/x-mixed-replace; boundary=%s\r\n\r\n' "$BOUNDARY"
+
+interval=1
+
+while true; do
+	if raptorctl rvd save jpeg "$tmp" "$CHANNEL" >/dev/null 2>&1 && [ -s "$tmp" ]; then
+		size=$(wc -c <"$tmp" | tr -d ' ')
+		printf -- '--%s\r\n' "$BOUNDARY"
+		printf 'Content-Type: image/jpeg\r\n'
+		printf 'Content-Length: %s\r\n\r\n' "$size"
+		cat "$tmp"
+		printf '\r\n'
+	fi
+	sleep "$interval" || exit 0
+done

--- a/package/thingino-raptor/files/www/x/dl0.jpg
+++ b/package/thingino-raptor/files/www/x/dl0.jpg
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Snapshot download for channel 0 via raptorctl.
+
+. /var/www/x/auth.sh
+require_auth
+
+tmp=$(mktemp /tmp/raptor-snap.XXXXXX.jpg) || exit 1
+trap 'rm -f "$tmp"' EXIT INT TERM
+
+if ! command -v raptorctl >/dev/null 2>&1; then
+	printf 'Status: 503 Service Unavailable\r\n\r\n'
+	exit 0
+fi
+
+if ! raptorctl rvd save jpeg "$tmp" 0 >/dev/null 2>&1 || [ ! -s "$tmp" ]; then
+	printf 'Status: 503 Service Unavailable\r\n\r\n'
+	exit 0
+fi
+
+printf 'Content-Type: image/jpeg\r\n'
+printf 'Content-Disposition: attachment; filename=ch0-%s.jpg\r\n' "$(date +%s)"
+printf 'Cache-Control: no-store\r\n'
+printf 'Connection: close\r\n'
+printf '\r\n'
+cat "$tmp"

--- a/package/thingino-raptor/files/www/x/dl1.jpg
+++ b/package/thingino-raptor/files/www/x/dl1.jpg
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Snapshot download for channel 1 via raptorctl.
+
+. /var/www/x/auth.sh
+require_auth
+
+tmp=$(mktemp /tmp/raptor-snap.XXXXXX.jpg) || exit 1
+trap 'rm -f "$tmp"' EXIT INT TERM
+
+if ! command -v raptorctl >/dev/null 2>&1; then
+	printf 'Status: 503 Service Unavailable\r\n\r\n'
+	exit 0
+fi
+
+if ! raptorctl rvd save jpeg "$tmp" 1 >/dev/null 2>&1 || [ ! -s "$tmp" ]; then
+	printf 'Status: 503 Service Unavailable\r\n\r\n'
+	exit 0
+fi
+
+printf 'Content-Type: image/jpeg\r\n'
+printf 'Content-Disposition: attachment; filename=ch1-%s.jpg\r\n' "$(date +%s)"
+printf 'Cache-Control: no-store\r\n'
+printf 'Connection: close\r\n'
+printf '\r\n'
+cat "$tmp"

--- a/package/thingino-raptor/files/www/x/json-sensor-upload.cgi
+++ b/package/thingino-raptor/files/www/x/json-sensor-upload.cgi
@@ -1,0 +1,110 @@
+#!/bin/sh
+# Sensor IQ binary upload for raptor images (replaces prudynt-only preview.cgi).
+
+. /var/www/x/auth.sh
+require_auth
+
+SENSOR_IQ_PATH="/etc/sensor"
+SENSOR_IQ_UPLOAD_PATH="/opt/sensor"
+SENSOR_MODEL=$(cat /proc/jz/sensor/sensor0/name 2>/dev/null || cat /proc/jz/sensor/name 2>/dev/null)
+SOC_MODEL=$(soc -f 2>/dev/null)
+SENSOR_IQ_FILE="${SENSOR_MODEL}-${SOC_MODEL}.bin"
+UPLOADED_SENSOR_IQ_FILE="${SENSOR_IQ_UPLOAD_PATH}/uploaded.bin"
+
+send_redirect() {
+	printf 'Status: 303 See Other\r\n'
+	printf 'Location: %s\r\n' "$1"
+	printf 'Cache-Control: no-store\r\n'
+	printf 'Connection: close\r\n\r\n'
+	exit 0
+}
+
+send_error() {
+	printf 'Status: %s\r\n' "$1"
+	printf 'Content-Type: text/plain\r\n'
+	printf 'Cache-Control: no-store\r\n'
+	printf 'Connection: close\r\n\r\n'
+	printf '%s\n' "$2"
+	exit 1
+}
+
+extract_part_value() {
+	awk -v RS='\r\n\r\n' -v target="$2" '
+    NR == target {
+      sub(/\r\n--.*/, "", $0)
+      gsub(/[\r\n]/, "", $0)
+      print
+      exit
+    }
+  ' "$1"
+}
+
+extract_upload_payload() {
+	request_file=$1
+	output_file=$2
+	part_index=$3
+	trailer=$(printf '\r\n--%s--\r\n' "$BOUNDARY" | wc -c | tr -d '[:space:]') || return 1
+	start_offset=$(awk -v RS='\r\n\r\n' -v target="$part_index" '
+    { offset += length($0) + 4 }
+    NR == target - 1 { print offset; exit }
+  ' "$request_file") || return 1
+	total_size=$(wc -c <"$request_file" | tr -d '[:space:]') || return 1
+	case "$start_offset" in '' | *[!0-9]*) return 1 ;; esac
+	case "$total_size" in '' | *[!0-9]*) return 1 ;; esac
+	case "$trailer" in '' | *[!0-9]*) return 1 ;; esac
+	payload_size=$((total_size - start_offset - trailer))
+	[ "$payload_size" -gt 0 ] 2>/dev/null || return 1
+	dd if="$request_file" of="$output_file" bs=1 skip="$start_offset" count="$payload_size" 2>/dev/null || return 1
+	[ -s "$output_file" ] || return 1
+}
+
+case "${REQUEST_METHOD:-GET}" in
+	POST) ;;
+	*) send_error '405 Method Not Allowed' 'Method not allowed.' ;;
+esac
+
+case "${CONTENT_TYPE:-}" in
+	multipart/form-data*)
+		BOUNDARY=$(printf '%s' "$CONTENT_TYPE" | sed -n 's/.*boundary=//p')
+		BOUNDARY=${BOUNDARY%%;*}
+		BOUNDARY=${BOUNDARY%\"}
+		BOUNDARY=${BOUNDARY#\"}
+		[ -n "$BOUNDARY" ] || send_error '400 Bad Request' 'Missing multipart boundary.'
+		;;
+	*) send_error '415 Unsupported Media Type' 'Unsupported content type.' ;;
+esac
+
+case "${CONTENT_LENGTH:-}" in
+	'' | *[!0-9]*) send_error '411 Length Required' 'Invalid content length.' ;;
+esac
+[ "$CONTENT_LENGTH" -gt 0 ] 2>/dev/null || send_error '411 Length Required' 'Empty upload payload.'
+
+REQUEST_FILE=$(mktemp /tmp/sensor-upload.XXXXXX) || send_error '500 Internal Server Error' 'Unable to allocate request buffer.'
+UPLOAD_FILE=$(mktemp /tmp/sensor-file.XXXXXX) || {
+	rm -f "$REQUEST_FILE"
+	send_error '500 Internal Server Error' 'Unable to allocate upload buffer.'
+}
+trap 'rm -f "$REQUEST_FILE" "$UPLOAD_FILE"' EXIT INT TERM
+
+dd bs=1 count="$CONTENT_LENGTH" of="$REQUEST_FILE" 2>/dev/null ||
+	send_error '500 Internal Server Error' 'Failed to read upload payload.'
+
+UPLOAD_FORM=$(extract_part_value "$REQUEST_FILE" 2)
+[ "$UPLOAD_FORM" = sensor ] || send_error '400 Bad Request' 'Unsupported upload form.'
+
+extract_upload_payload "$REQUEST_FILE" "$UPLOAD_FILE" 3 ||
+	send_error '400 Bad Request' 'Failed to extract uploaded file.'
+
+mkdir -p "$SENSOR_IQ_UPLOAD_PATH" "$SENSOR_IQ_PATH" ||
+	send_error '500 Internal Server Error' 'Failed to create sensor directories.'
+mv "$UPLOAD_FILE" "$UPLOADED_SENSOR_IQ_FILE" ||
+	send_error '500 Internal Server Error' 'Failed to install sensor IQ file.'
+UPLOAD_FILE=""
+ln -sf "$UPLOADED_SENSOR_IQ_FILE" "$SENSOR_IQ_PATH/$SENSOR_IQ_FILE" ||
+	send_error '500 Internal Server Error' 'Failed to link sensor IQ file.'
+
+if [ -x /etc/init.d/S31raptor ]; then
+	/etc/init.d/S31raptor restart >/dev/null 2>&1 &
+fi
+
+send_redirect '/streamer-sensor.html'

--- a/package/thingino-raptor/thingino-raptor.mk
+++ b/package/thingino-raptor/thingino-raptor.mk
@@ -195,12 +195,27 @@ define THINGINO_RAPTOR_INSTALL_TARGET_CMDS
 		$(TARGET_DIR)/var/www/a/streamer.js
 	$(INSTALL) -D -m 0644 $(THINGINO_RAPTOR_PKGDIR)/files/www/a/streamer-config.js \
 		$(TARGET_DIR)/var/www/a/streamer-config.js
+	$(INSTALL) -D -m 0644 $(THINGINO_RAPTOR_PKGDIR)/files/www/a/streamer-osd.js \
+		$(TARGET_DIR)/var/www/a/streamer-osd.js
 	$(INSTALL) -D -m 0644 $(THINGINO_RAPTOR_PKGDIR)/files/www/a/audio.js \
 		$(TARGET_DIR)/var/www/a/audio.js
 	$(INSTALL) -D -m 0755 $(THINGINO_RAPTOR_PKGDIR)/files/www/x/json-config-save.cgi \
 		$(TARGET_DIR)/var/www/x/json-config-save.cgi
 	$(INSTALL) -D -m 0755 $(THINGINO_RAPTOR_PKGDIR)/files/www/x/restart-streamer.cgi \
 		$(TARGET_DIR)/var/www/x/restart-streamer.cgi
+	$(INSTALL) -D -m 0755 $(THINGINO_RAPTOR_PKGDIR)/files/www/x/json-sensor-upload.cgi \
+		$(TARGET_DIR)/var/www/x/json-sensor-upload.cgi
+	$(INSTALL) -D -m 0755 $(THINGINO_RAPTOR_PKGDIR)/files/www/x/dl0.jpg \
+		$(TARGET_DIR)/var/www/x/dl0.jpg
+	$(INSTALL) -D -m 0755 $(THINGINO_RAPTOR_PKGDIR)/files/www/x/dl1.jpg \
+		$(TARGET_DIR)/var/www/x/dl1.jpg
+	$(INSTALL) -D -m 0755 $(THINGINO_RAPTOR_PKGDIR)/files/www/x/ch0.mjpg \
+		$(TARGET_DIR)/var/www/x/ch0.mjpg
+	$(INSTALL) -D -m 0755 $(THINGINO_RAPTOR_PKGDIR)/files/www/x/ch1.mjpg \
+		$(TARGET_DIR)/var/www/x/ch1.mjpg
+	# Alias snapshot endpoints used by some send/download helpers
+	ln -sf dl0.jpg $(TARGET_DIR)/var/www/x/ch0.jpg
+	ln -sf dl1.jpg $(TARGET_DIR)/var/www/x/ch1.jpg
 
 	# Init script — webcam variant includes USB gadget setup
 	if [ "$(BR2_THINGINO_DEV_WEBCAM)" = "y" ]; then \

--- a/package/thingino-webui/files/www/a/main.js
+++ b/package/thingino-webui/files/www/a/main.js
@@ -866,15 +866,21 @@ async function toggleButton(el) {
   // Auto day/night uses the agent action; other ISP/light cmds stay on json-imp.
   if (el.id === "auto") {
     try {
+      const daynightBtn = $("#daynight");
+      const currentMode =
+        daynightBtn && daynightBtn.classList.contains("is-night")
+          ? "night"
+          : "day";
+      const mode = newState ? "auto" : currentMode;
       await agentJsonRequest("/api/v1/actions/daynight", {
         method: "POST",
-        body: { mode: newState ? "auto" : "day" },
+        body: { mode },
         cache: "no-store",
       });
       const update = {
         daynight_enabled: !!newState,
       };
-      if (!newState) update.daynight_mode = "day";
+      if (!newState) update.daynight_mode = currentMode;
       updateHeartbeatUi(update);
     } catch (err) {
       console.error("toggleButton auto error", err);
@@ -901,8 +907,17 @@ async function toggleButton(el) {
         ir940: { ir940_state: newState },
         white: { white_state: newState },
       };
-      const update = keyMap[el.id];
-      if (update) {
+      const update = keyMap[el.id] ? { ...keyMap[el.id] } : {};
+      // json-imp clears daynight.enabled for ircut/IR on daynightd images.
+      if (
+        el.id === "ircut" ||
+        el.id === "ir850" ||
+        el.id === "ir940" ||
+        el.id === "white"
+      ) {
+        update.daynight_enabled = false;
+      }
+      if (Object.keys(update).length) {
         updateHeartbeatUi(update);
       } else {
         el.classList.remove("pending");

--- a/package/thingino-webui/files/www/a/navigation.js
+++ b/package/thingino-webui/files/www/a/navigation.js
@@ -69,13 +69,20 @@
   function buildDefaultMenu() {
     const flashOperationsEnabled =
       uiConfig.device && uiConfig.device.flashOperations === true;
+    const isRaptor = uiConfig.device && uiConfig.device.raptor === true;
     const settingsItems = [
       { label: "Admin profile", href: "/config-admin.html" },
     ];
 
+    settingsItems.push({ label: "Network", href: "/config-network.html" });
+    // config-rtsp.html talks to prudynt :8080 — hide on raptor builds.
+    if (!isRaptor) {
+      settingsItems.push({
+        label: "RTSP/ONVIF access",
+        href: "/config-rtsp.html",
+      });
+    }
     settingsItems.push(
-      { label: "Network", href: "/config-network.html" },
-      { label: "RTSP/ONVIF access", href: "/config-rtsp.html" },
       { label: "Remote logging", href: "/config-syslog.html" },
       { label: "Time", href: "/config-time.html" },
       { label: "Web Interface", href: "/config-webui.html" },
@@ -146,7 +153,10 @@
         label: "Services",
         items: [
           { label: "Timelapse Recorder", href: "/tool-timelapse.html" },
-          { label: "Video Recorder", href: "/tool-record.html" },
+          // tool-record.cgi is prudynt.json-backed — hide on raptor builds.
+          ...(isRaptor
+            ? []
+            : [{ label: "Video Recorder", href: "/tool-record.html" }]),
           { label: "Home Assistant", href: "/config-ha.html" },
         ],
       },

--- a/package/thingino-webui/files/www/a/preview.js
+++ b/package/thingino-webui/files/www/a/preview.js
@@ -966,9 +966,47 @@ function applyFieldMetadata(field, data) {
   updateImagingLabel(field, data.value);
 }
 
+function preferStreamerAgent() {
+  const helper = window.thinginoStreamer;
+  return !!(helper && helper.preferAgent && helper.preferAgent());
+}
+
+async function fetchImagingStateFromAgent() {
+  const helper = window.thinginoStreamer;
+  const cfg = await helper.agentRequest("/api/v1/config", { cache: "no-store" });
+  const image = (cfg && cfg.image) || {};
+  const mapped = {
+    brightness: image.brightness,
+    contrast: image.contrast,
+    sharpness: image.sharpness,
+    saturation: image.saturation,
+  };
+  imagingFields.forEach((field) => {
+    const value = mapped[field];
+    if (value === undefined || value === null) {
+      applyFieldMetadata(field, { supported: false });
+      return;
+    }
+    const input = $(`#${field}`);
+    const min = input ? Number(input.dataset.min) : 0;
+    const max = input ? Number(input.dataset.max) : 255;
+    applyFieldMetadata(field, {
+      supported: true,
+      min: Number.isFinite(min) ? min : 0,
+      max: Number.isFinite(max) ? max : 255,
+      value: Number(value),
+      default: Number(value),
+    });
+  });
+}
+
 async function fetchImagingState() {
   showBusy("Loading imaging settings...");
   try {
+    if (preferStreamerAgent()) {
+      await fetchImagingStateFromAgent();
+      return;
+    }
     const res = await fetch("/x/json-imaging.cgi", { cache: "no-store" });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const payload = await res.json();
@@ -997,11 +1035,17 @@ async function persistImagingSetting(field, value) {
 }
 
 async function sendImagingUpdate(field, value, element) {
-  const params = new URLSearchParams({ cmd: "set" });
-  params.append(field, value);
   element?.setAttribute("data-busy", "1");
   element?.classList.add("opacity-75");
   try {
+    if (preferStreamerAgent()) {
+      // Agent-backed streamers (raptor) have no json-imaging.cgi — PATCH leaves directly.
+      await persistImagingSetting(field, value);
+      updateImagingLabel(field, value);
+      return;
+    }
+    const params = new URLSearchParams({ cmd: "set" });
+    params.append(field, value);
     const res = await fetch("/x/json-imaging.cgi", {
       method: "POST",
       headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -1330,6 +1374,7 @@ fetchImagingState();
 
 async function loadConfigFps() {
   try {
+    if (preferStreamerAgent()) return;
     const resp = await fetch("/etc/prudynt.json", { cache: "no-store" });
     if (!resp.ok) return;
     const cfg = await resp.json();


### PR DESCRIPTION
## Summary
- Follow-up to #1356 (and day/night #1475): fix raptor WebUI paths that still assumed prudynt CGIs / `:8080`, without touching heartbeat (already fixed upstream in `478c50952`).
- Image Quality uses agent PATCH/GET when `thinginoStreamer` is present (no more hard dependency on `json-imaging.cgi`).
- OSD page rewritten for ROD timestamp via agent; sensor IQ upload uses a raptor CGI; snapshot/MJPEG CGIs (`dl0/1.jpg`, `ch0/1.mjpg`) installed for preview/download.
- Mic/spk wrappers `config save` before restart; control-bar `#auto` off keeps current day/night mode; IR/ircut toggles clear `daynight_enabled` in the UI; hide prudynt-only RTSP/Video Recorder nav on raptor builds; hide unsupported image sliders.

## Test plan
- [ ] Raptor Image Quality: change brightness/contrast; values apply without `json-imaging.cgi` 404; unsupported WDR/etc. fields hidden.
- [ ] Raptor streamer pages: MJPEG preview loads from `/x/ch0.mjpg` / `/x/ch1.mjpg`; snapshot download via `/x/dl0.jpg`.
- [ ] Raptor OSD: load/save timestamp overlay via agent; no `:8080` calls.
- [ ] Sensor IQ upload succeeds and restarts raptor.
- [ ] Mic/spk toggle survives reboot (`raptor.conf` updated before restart).
- [ ] Control bar: disable Auto while in night keeps night; toggling IR updates daynight auto indicator off.
- [ ] On raptor builds, Settings has no RTSP/ONVIF access and Services has no Video Recorder; prudynt builds still show both.


Made with [Cursor](https://cursor.com)