### PR TITLE
configs: drop removed ssl fragment from WUUK Y0941

### DIFF
--- a/configs/cameras-exp/wuuk_y0941_t41nq_sc4336p_atbm6031/wuuk_y0941_t41nq_sc4336p_atbm6031_defconfig
+++ b/configs/cameras-exp/wuuk_y0941_t41nq_sc4336p_atbm6031/wuuk_y0941_t41nq_sc4336p_atbm6031_defconfig
@@ -1,5 +1,5 @@
 # NAME: WUUK Y0941 (T41NQ, SC4336P, ATBM6031, SPI-NAND)
-# FRAG: soc-xburst2 core ssl flash-nand
+# FRAG: soc-xburst2 core flash-nand
 BR2_AVPU_CLK_550MHZ=y
 BR2_AVPU_SCLKA=y
 BR2_INGENIC_SOC_MODEL="t41nq"


### PR DESCRIPTION
Commit 6fd51348e ("ssl: migrate to virtual-package choice and libopenssl") removed the `ssl` fragment and updated 221 camera defconfigs, but missed `configs/cameras-exp/wuuk_y0941_t41nq_sc4336p_atbm6031` — it was added in 0fcdf6e2c on 2026-08-08, after the config sweep started.

The stale fragment reference makes the Y0941 profile unbuildable on master:

```
ERROR: Missing fragment ssl
```

This one-line change drops `ssl` from the FRAG line, matching every other profile updated by 6fd51348e.

Found while porting the WUUK Y0910 (a hardware clone of the Y0941 — see #1479).
