### PR TITLE
portal: working Wi-Fi scan with pre-portal prescan and mobile-friendly list

### DIFF
--- a/package/wifi/files/S38wpa_supplicant.in
+++ b/package/wifi/files/S38wpa_supplicant.in
@@ -11,7 +11,7 @@ iface_exists() {
 		return 1
 	fi
 
-	if ip link show $iface >/dev/null 2>&1; then
+	if ip link show "$iface" >/dev/null 2>&1; then
 		echo "Interface '$iface' exists."
 		return 0
 	else
@@ -71,11 +71,12 @@ case "$WLAN_MODULE_NAME" in
 		DAEMON_ARGS="-D wext $DAEMON_ARGS"
 		;;
 esac
-if [ "true" = "$debug" ]; then
+if [ "true" = "${debug:-}" ]; then
 	DAEMON_ARGS="$DAEMON_ARGS -dd"
 fi
 
 credentials_from_card() {
+	# shellcheck disable=SC3043 # busybox ash supports local
 	local envfile ssid password
 
 	envfile="/mnt/mmcblk0p1/uenv.txt"
@@ -97,6 +98,12 @@ timeout() {
 # connection, and drivers do not need to support survey-while-AP
 # (which most vendor drivers reject or return empty on).
 prescan_for_portal() {
+	# Hard overall deadline so a misbehaving radio cannot stretch portal
+	# boot indefinitely: everything below is capped by PRESCAN_DEADLINE
+	# seconds from now (healthy path finishes in well under 10).
+	PRESCAN_DEADLINE=$(($(date +%s) + 25))
+	time_left() { [ "$(date +%s)" -lt "$PRESCAN_DEADLINE" ]; }
+
 	# ATBM6461 WiFi lives on the MCU; there is no wpa_supplicant to drive
 	case "$WLAN_MODULE_NAME" in
 		atbm6461*) return 0 ;;
@@ -138,11 +145,14 @@ prescan_for_portal() {
 	# more scans avoids queueing phantom scans, and the first sweep only
 	# shows up in scan_results once it has actually completed.
 	scan_once() {
+		# shellcheck disable=SC3043 # busybox ash supports local
 		local i
 
-		# Trigger; retry while the supplicant is still settling
+		# Trigger; retry while the supplicant is still settling.
+		# wpa_cli exits 0 even on a FAIL reply, so this loop is rarely
+		# more than a single iteration - two retries then give up.
 		i=0
-		while [ $i -lt 10 ]; do
+		while [ $i -lt 3 ] && time_left; do
 			wpa_cli -p "$CTRLDIR" -i "$IFACE" scan >/dev/null 2>&1 && break
 			sleep 1
 			i=$((i + 1))
@@ -152,7 +162,7 @@ prescan_for_portal() {
 		# running (or found nothing; the caller retries once, then
 		# gives up and we simply continue without a cached list)
 		i=0
-		while [ $i -lt 15 ]; do
+		while [ $i -lt 15 ] && time_left; do
 			wpa_cli -p "$CTRLDIR" -i "$IFACE" scan_results 2>/dev/null >"$CACHE.tmp"
 			# Count real entry lines (banner + column header stripped)
 			[ "$(grep -v '^Selected interface' "$CACHE.tmp" 2>/dev/null | tail -n +2 | grep -c .)" -gt 0 ] && return 0
@@ -162,10 +172,11 @@ prescan_for_portal() {
 		return 1
 	}
 
-	# Two attempts total; radio right after boot can be flaky
-	if scan_once || scan_once; then
+	# Two attempts total; radio right after boot can be flaky.
+	# The second attempt only runs while the overall deadline allows.
+	if scan_once || { time_left && scan_once; }; then
 		mv "$CACHE.tmp" "$CACHE"
-		echo "Prescan complete: $(($(wc -l <"$CACHE") - 1)) entries"
+		echo "Prescan complete: $(grep -v '^Selected interface' "$CACHE" | tail -n +2 | grep -c .) entries"
 	else
 		rm -f "$CACHE.tmp"
 		echo "Prescan returned no results; continuing without cached list" >&2
@@ -203,7 +214,7 @@ prepare_portal() {
 	# whatever default wpa_supplicant.conf was installed at build time.
 	echo "Update SSID with last two octets of MAC address"
 	mac_address=$(ip link show $IFACE | awk '/ether/ {print $2}')
-	last_two=$(echo $mac_address | awk -F: '{print $(NF-1) $NF}')
+	last_two=$(echo "$mac_address" | awk -F: '{print $(NF-1) $NF}')
 	cat >$CONFIG <<-WPAEOF
 		ctrl_interface=/run/wpa_supplicant
 		ap_scan=2
@@ -217,6 +228,7 @@ prepare_portal() {
 	WPAEOF
 
 	echo "Start wpa_supplicant"
+	# shellcheck disable=SC2086 # DAEMON_ARGS holds flags that must word-split
 	start-stop-daemon -S -x $DAEMON_FULL -- $DAEMON_ARGS 2>&1
 
 	echo "Set $PORTAL_MODE_FLAG"
@@ -291,10 +303,11 @@ start_access_point() {
 	cp /etc/dnsd-ap.conf /tmp/dnsd.conf
 	if ! grep -q "$hostname" /tmp/dnsd.conf; then
 		echo "Add ${hostname}.local to DNS configuration"
-		echo $hostname.local $WLANAP_IP >>/tmp/dnsd.conf
+		echo "${hostname}.local $WLANAP_IP" >>/tmp/dnsd.conf
 	fi
 
 	echo "Start wpa_supplicant"
+	# shellcheck disable=SC2086 # DAEMON_ARGS holds flags that must word-split
 	start-stop-daemon -S -x $DAEMON_FULL -- $DAEMON_ARGS 2>&1
 
 	echo "Start udhcpd"
@@ -331,6 +344,7 @@ stop_access_point() {
 
 start_client() {
 	echo "Start wpa_supplicant"
+	# shellcheck disable=SC2086 # DAEMON_ARGS holds flags that must word-split
 	start-stop-daemon -S -x $DAEMON_FULL -- $DAEMON_ARGS 2>&1
 }
 
@@ -338,7 +352,7 @@ stop_client() {
 	echo "Stop wpa_supplicant"
 	start-stop-daemon -K -q -x $DAEMON_FULL
 	if [ -f /var/run/udhcpc.${IFACE}.pid ]; then
-		kill $(cat /var/run/udhcpc.${IFACE}.pid) 2>/dev/null
+		kill "$(cat /var/run/udhcpc.${IFACE}.pid)" 2>/dev/null
 		sleep 1
 	fi
 	ip addr flush dev $IFACE 2>/dev/null
@@ -396,12 +410,12 @@ start() {
 						i=$((i + 1))
 						sleep 1
 					done
-					if [ -n "$hex_ip" ] && [ "$(echo -n "$hex_ip" | wc -c)" -eq 8 ] && [ "$hex_ip" != "00000000" ]; then
-						ip_addr=$(printf '%d.%d.%d.%d' 0x$(echo "$hex_ip" | cut -c7-8) 0x$(echo "$hex_ip" | cut -c5-6) 0x$(echo "$hex_ip" | cut -c3-4) 0x$(echo "$hex_ip" | cut -c1-2))
+					if [ -n "$hex_ip" ] && [ "${#hex_ip}" -eq 8 ] && [ "$hex_ip" != "00000000" ]; then
+						ip_addr=$(printf '%d.%d.%d.%d' "0x$(echo "$hex_ip" | cut -c7-8)" "0x$(echo "$hex_ip" | cut -c5-6)" "0x$(echo "$hex_ip" | cut -c3-4)" "0x$(echo "$hex_ip" | cut -c1-2)")
 						gateway=$(echo "$ip_addr" | sed 's/\.[0-9]*$/.1/')
 						echo "MCU DHCP IP: $ip_addr"
-						ip addr add ${ip_addr}/24 dev $IFACE 2>/dev/null || true
-						ip route add default via $gateway dev $IFACE 2>/dev/null || true
+						ip addr add "${ip_addr}/24" dev "$IFACE" 2>/dev/null || true
+						ip route add default via "$gateway" dev "$IFACE" 2>/dev/null || true
 						echo "nameserver $gateway" >/tmp/resolv.conf
 						sed -i 's/iface wlan0 inet dhcp/iface wlan0 inet manual/' /etc/network/interfaces.d/wlan0
 					else

--- a/package/wifi/files/S38wpa_supplicant.in
+++ b/package/wifi/files/S38wpa_supplicant.in
@@ -92,6 +92,95 @@ timeout() {
 		$0 stop
 }
 
+# Survey the radio in plain station mode, before the portal AP goes up.
+# The phone is not yet associated, so the sweep cannot drop the client
+# connection, and drivers do not need to support survey-while-AP
+# (which most vendor drivers reject or return empty on).
+prescan_for_portal() {
+	# ATBM6461 WiFi lives on the MCU; there is no wpa_supplicant to drive
+	case "$WLAN_MODULE_NAME" in
+		atbm6461*) return 0 ;;
+	esac
+
+	command -v wpa_supplicant >/dev/null 2>&1 || return 0
+	command -v wpa_cli >/dev/null 2>&1 || return 0
+
+	CACHE="/tmp/wifi_prescan"
+	CTRLDIR="/tmp/wpa_prescan"
+	CONF="/tmp/wpa_prescan.conf"
+
+	echo "Running pre-portal Wi-Fi scan"
+	ip link set $IFACE up
+
+	# Standalone supplicant with a private ctrl socket, so we never
+	# touch the shared /run/wpa_supplicant the portal instance uses.
+	echo "ctrl_interface=$CTRLDIR" >"$CONF"
+	wpa_supplicant -i $IFACE -c "$CONF" -B >/dev/null 2>&1
+
+	# Wait for the ctrl socket to appear (supplicant failed to start -> bail)
+	i=0
+	while [ $i -lt 5 ]; do
+		[ -S "$CTRLDIR/$IFACE" ] && break
+		sleep 1
+		i=$((i + 1))
+	done
+	if [ ! -S "$CTRLDIR/$IFACE" ]; then
+		echo "Prescan supplicant did not start; skipping" >&2
+		rm -f "$CONF"
+		return 0
+	fi
+
+	# Give the radio a moment to settle after module load
+	sleep 2
+
+	# One scan attempt: fire the scan, then poll scan_results (read-only)
+	# until the BSS list has entries. Polling results instead of firing
+	# more scans avoids queueing phantom scans, and the first sweep only
+	# shows up in scan_results once it has actually completed.
+	scan_once() {
+		local i
+
+		# Trigger; retry while the supplicant is still settling
+		i=0
+		while [ $i -lt 10 ]; do
+			wpa_cli -p "$CTRLDIR" -i "$IFACE" scan >/dev/null 2>&1 && break
+			sleep 1
+			i=$((i + 1))
+		done
+
+		# Poll for results: empty BSS list means the sweep is still
+		# running (or found nothing; the caller retries once, then
+		# gives up and we simply continue without a cached list)
+		i=0
+		while [ $i -lt 15 ]; do
+			wpa_cli -p "$CTRLDIR" -i "$IFACE" scan_results 2>/dev/null >"$CACHE.tmp"
+			# Count real entry lines (banner + column header stripped)
+			[ "$(grep -v '^Selected interface' "$CACHE.tmp" 2>/dev/null | tail -n +2 | grep -c .)" -gt 0 ] && return 0
+			sleep 1
+			i=$((i + 1))
+		done
+		return 1
+	}
+
+	# Two attempts total; radio right after boot can be flaky
+	if scan_once || scan_once; then
+		mv "$CACHE.tmp" "$CACHE"
+		echo "Prescan complete: $(($(wc -l <"$CACHE") - 1)) entries"
+	else
+		rm -f "$CACHE.tmp"
+		echo "Prescan returned no results; continuing without cached list" >&2
+	fi
+
+	# Always tear down the scan supplicant before the portal starts
+	wpa_cli -p "$CTRLDIR" terminate >/dev/null 2>&1
+	i=0
+	while [ $i -lt 5 ] && pgrep -f "wpa_supplicant.*$CONF" >/dev/null 2>&1; do
+		sleep 1
+		i=$((i + 1))
+	done
+	rm -rf "$CTRLDIR" "$CONF"
+}
+
 prepare_portal() {
 	# FIXME: should de done at compile time
 	sed -i "s/%dev%/$IFACE/g" /etc/udhcpd-portal.conf
@@ -329,7 +418,10 @@ start() {
 	esac
 
 	case "$mode" in
-		portal) prepare_portal ;;
+		portal)
+			prescan_for_portal
+			prepare_portal
+			;;
 		ap) start_access_point ;;
 		*) start_client ;;
 	esac

--- a/package/wifi/files/api.cgi
+++ b/package/wifi/files/api.cgi
@@ -74,14 +74,17 @@ get_info() {
 wpa_iface() {
 	# Explicit override first, then probe the ctrl socket directory
 	iface="${WPA_IFACE:-}"
-	[ -n "$iface" ] && { echo "$iface"; return; }
+	[ -n "$iface" ] && {
+		echo "$iface"
+		return
+	}
 
 	# One socket = one supplicant instance = the right interface
-	first_socket=$(ls /run/wpa_supplicant 2>/dev/null | head -n 1)
-	if [ -n "$first_socket" ]; then
-		echo "$first_socket"
+	for socket in /run/wpa_supplicant/*; do
+		[ -S "$socket" ] || continue
+		echo "${socket##*/}"
 		return
-	fi
+	done
 
 	echo "wlan0"
 }
@@ -102,9 +105,9 @@ scan_networks() {
 
 	# Wait up to 8 seconds for ongoing scan to complete
 	while [ -f "$SCAN_LOCK" ] && [ $SCAN_WAIT -lt 8 ]; do
-		# Check if lock is stale (older than 15 seconds)
+		# Check if lock is stale (older than 25 seconds)
 		LOCK_AGE=$(($(date +%s) - $(stat -c %Y "$SCAN_LOCK" 2>/dev/null || echo 0)))
-		if [ $LOCK_AGE -gt 15 ]; then
+		if [ $LOCK_AGE -gt 25 ]; then
 			rm -f "$SCAN_LOCK"
 			break
 		fi
@@ -171,16 +174,21 @@ scan_start() {
 
 	IFACE=$(wpa_iface)
 
-	# Ignore stale locks (older than 15 seconds)
+	# Ignore stale locks (older than 25 seconds)
 	SCAN_LOCK="/tmp/wpa_scan.lock"
 	LOCK_AGE=$(($(date +%s) - $(stat -c %Y "$SCAN_LOCK" 2>/dev/null || echo 0)))
-	[ $LOCK_AGE -gt 15 ] && rm -f "$SCAN_LOCK"
+	[ $LOCK_AGE -gt 25 ] && rm -f "$SCAN_LOCK"
 
 	if [ -f "$SCAN_LOCK" ]; then
 		# A scan is already running; poller will pick it up
 		echo '{"scanning": true}'
 		return
 	fi
+
+	# Snapshot the pre-scan BSS list: scan_status() detects completion
+	# by comparing live results against this baseline instead of firing
+	# more scans, which would queue a phantom second sweep.
+	wpa_cli -i "$IFACE" scan_results 2>/dev/null >/tmp/wpa_scan.baseline
 
 	touch "$SCAN_LOCK"
 	wpa_cli -i "$IFACE" scan >/dev/null 2>&1
@@ -195,28 +203,50 @@ scan_status() {
 	fi
 
 	IFACE=$(wpa_iface)
+	SCAN_LOCK="/tmp/wpa_scan.lock"
+	BASELINE="/tmp/wpa_scan.baseline"
 
-	# Poll wpa_supplicant for scan progress: FAIL-BUSY while the radio
-	# sweeps, OK once results are ready to read.
-	if wpa_cli -i "$IFACE" scan 2>/dev/null | grep -q FAIL; then
-		echo '{"scanning": true}'
+	# No lock (or a lock without our baseline) means nothing is in
+	# flight: serve whatever results exist without touching the radio.
+	if [ ! -f "$SCAN_LOCK" ] || [ ! -f "$BASELINE" ]; then
+		scan_networks_cached
 		return
 	fi
 
-	# Scan finished; release the lock and hand over the results
-	rm -f "/tmp/wpa_scan.lock"
+	# Probe without triggering: `scan_results` is read-only, so polling
+	# it never queues a new sweep. During a sweep it keeps returning
+	# the pre-scan BSS list (the baseline); once the sweep completes,
+	# the content changes (at minimum the signal levels move).
+	RESULTS="$(wpa_cli -i "$IFACE" scan_results 2>/dev/null)"
+	if [ "$RESULTS" != "$(cat "$BASELINE" 2>/dev/null)" ]; then
+		# Sweep finished; release the lock and hand over the results
+		rm -f "$SCAN_LOCK" "$BASELINE"
 
-	# Refresh the prescan cache so page reloads after a manual scan
-	# show the freshest list without another radio sweep. Only write
-	# when the live results actually have entries: AP-mode supplicants
-	# return a header-only list when the driver cannot survey while
-	# hosting, and that must not poison the S38 cache.
-	FRESH="$(wpa_cli -i "$IFACE" scan_results 2>/dev/null)"
-	if [ "$(count_networks "$FRESH")" -gt 0 ]; then
-		echo "$FRESH" >/tmp/wifi_prescan
+		# Refresh the prescan cache so page reloads after a manual scan
+		# show the freshest list without another radio sweep. Only write
+		# when the live results actually have entries: AP-mode supplicants
+		# return a header-only list when the driver cannot survey while
+		# hosting, and that must not poison the S38 cache.
+		if [ "$(count_networks "$RESULTS")" -gt 0 ]; then
+			echo "$RESULTS" >/tmp/wifi_prescan
+		fi
+
+		scan_networks_cached
+		return
 	fi
 
-	scan_networks_cached
+	# Backstop: identical content after 20 s means the sweep returned
+	# byte-identical results (possible when signals do not jitter) or
+	# the driver never completed it. Either way, stop polling and serve
+	# whatever we have instead of waiting forever.
+	LOCK_AGE=$(($(date +%s) - $(stat -c %Y "$SCAN_LOCK" 2>/dev/null || echo 0)))
+	if [ $LOCK_AGE -ge 20 ]; then
+		rm -f "$SCAN_LOCK" "$BASELINE"
+		scan_networks_cached
+		return
+	fi
+
+	echo '{"scanning": true}'
 }
 
 # Count real BSS entries in raw wpa_cli output: strip the banner and
@@ -228,6 +258,11 @@ count_networks() {
 
 # Read-only results reader without triggering a new scan
 scan_networks_cached() {
+	if ! command -v wpa_cli >/dev/null 2>&1; then
+		echo '{"error": "wpa_cli not available"}'
+		return
+	fi
+
 	IFACE=$(wpa_iface)
 
 	# Live results when a reachable supplicant has BSS entries. The

--- a/package/wifi/files/api.cgi
+++ b/package/wifi/files/api.cgi
@@ -67,12 +67,33 @@ get_info() {
 	EOF
 }
 
+# The portal starts exactly one wpa_supplicant instance (S38), so the
+# control socket directory tells us which netdev to talk to. The legacy
+# hardcoded `wlan0` breaks on cameras whose AP interface is ap0/wlan1
+# (hi3881, wq9001) and on ATBM6461 which has no ctrl socket at all.
+wpa_iface() {
+	# Explicit override first, then probe the ctrl socket directory
+	iface="${WPA_IFACE:-}"
+	[ -n "$iface" ] && { echo "$iface"; return; }
+
+	# One socket = one supplicant instance = the right interface
+	first_socket=$(ls /run/wpa_supplicant 2>/dev/null | head -n 1)
+	if [ -n "$first_socket" ]; then
+		echo "$first_socket"
+		return
+	fi
+
+	echo "wlan0"
+}
+
 scan_networks() {
 	# Check if wpa_cli is available
 	if ! command -v wpa_cli >/dev/null 2>&1; then
 		echo '{"error": "wpa_cli not available"}'
 		return
 	fi
+
+	IFACE=$(wpa_iface)
 
 	# Check if scan is already in progress
 	SCAN_LOCK="/tmp/wpa_scan.lock"
@@ -97,7 +118,7 @@ scan_networks() {
 	else
 		# Create lock file and trigger new scan
 		touch "$SCAN_LOCK"
-		wpa_cli -i wlan0 scan >/dev/null 2>&1
+		wpa_cli -i "$IFACE" scan >/dev/null 2>&1
 		sleep 2
 	fi
 
@@ -105,7 +126,7 @@ scan_networks() {
 	echo "{\"networks\": ["
 
 	first=1
-	wpa_cli -i wlan0 scan_results 2>/dev/null | tail -n +2 | while IFS="$(printf '\t')" read -r bssid _ signal flags ssid; do
+	wpa_cli -i "$IFACE" scan_results 2>/dev/null | tail -n +2 | while IFS="$(printf '\t')" read -r bssid _ signal flags ssid; do
 		# Skip empty SSIDs and header
 		[ -z "$ssid" ] || [ "$ssid" = "ssid" ] && continue
 
@@ -140,6 +161,127 @@ scan_networks() {
 
 	# Clean up lock if we created it
 	[ $SHOULD_SCAN -eq 1 ] && rm -f "$SCAN_LOCK"
+}
+
+scan_start() {
+	if ! command -v wpa_cli >/dev/null 2>&1; then
+		echo '{"error": "wpa_cli not available", "scanning": false}'
+		return
+	fi
+
+	IFACE=$(wpa_iface)
+
+	# Ignore stale locks (older than 15 seconds)
+	SCAN_LOCK="/tmp/wpa_scan.lock"
+	LOCK_AGE=$(($(date +%s) - $(stat -c %Y "$SCAN_LOCK" 2>/dev/null || echo 0)))
+	[ $LOCK_AGE -gt 15 ] && rm -f "$SCAN_LOCK"
+
+	if [ -f "$SCAN_LOCK" ]; then
+		# A scan is already running; poller will pick it up
+		echo '{"scanning": true}'
+		return
+	fi
+
+	touch "$SCAN_LOCK"
+	wpa_cli -i "$IFACE" scan >/dev/null 2>&1
+	# Reply immediately; scan_status() reports completion
+	echo '{"scanning": true}'
+}
+
+scan_status() {
+	if ! command -v wpa_cli >/dev/null 2>&1; then
+		echo '{"error": "wpa_cli not available", "scanning": false}'
+		return
+	fi
+
+	IFACE=$(wpa_iface)
+
+	# Poll wpa_supplicant for scan progress: FAIL-BUSY while the radio
+	# sweeps, OK once results are ready to read.
+	if wpa_cli -i "$IFACE" scan 2>/dev/null | grep -q FAIL; then
+		echo '{"scanning": true}'
+		return
+	fi
+
+	# Scan finished; release the lock and hand over the results
+	rm -f "/tmp/wpa_scan.lock"
+
+	# Refresh the prescan cache so page reloads after a manual scan
+	# show the freshest list without another radio sweep. Only write
+	# when the live results actually have entries: AP-mode supplicants
+	# return a header-only list when the driver cannot survey while
+	# hosting, and that must not poison the S38 cache.
+	FRESH="$(wpa_cli -i "$IFACE" scan_results 2>/dev/null)"
+	if [ "$(count_networks "$FRESH")" -gt 0 ]; then
+		echo "$FRESH" >/tmp/wifi_prescan
+	fi
+
+	scan_networks_cached
+}
+
+# Count real BSS entries in raw wpa_cli output: strip the banner and
+# the column header, then count what is left. Header-only output from
+# an AP-mode supplicant counts as zero.
+count_networks() {
+	echo "$1" | grep -v '^Selected interface' | tail -n +2 | grep -c .
+}
+
+# Read-only results reader without triggering a new scan
+scan_networks_cached() {
+	IFACE=$(wpa_iface)
+
+	# Live results when a reachable supplicant has BSS entries. The
+	# portal supplicant is always reachable in portal mode, but its BSS
+	# list stays empty unless a manual scan just ran: scan_results then
+	# succeeds with header-only output. That must not shadow the
+	# prescan cache written by S38 before the AP went up.
+	RESULTS="$(wpa_cli -i "$IFACE" scan_results 2>/dev/null)"
+	if [ "$(count_networks "$RESULTS")" -eq 0 ] && [ -f /tmp/wifi_prescan ]; then
+		RESULTS="$(cat /tmp/wifi_prescan)"
+	fi
+
+	format_networks "$RESULTS"
+}
+
+# Format raw `wpa_cli scan_results` output (tab-separated) as JSON
+format_networks() {
+	echo "{\"networks\": ["
+
+	first=1
+	# Strip the "Selected interface" banner wpa_cli prints when run
+	# without -i, then drop the column header line before parsing
+	echo "$1" | grep -v '^Selected interface' | tail -n +2 | while IFS="$(printf '\t')" read -r bssid _ signal flags ssid; do
+		# Skip empty SSIDs and header
+		[ -z "$ssid" ] || [ "$ssid" = "ssid" ] && continue
+
+		# Determine security type
+		if echo "$flags" | grep -q "WPA2-PSK"; then
+			security="WPA2"
+		elif echo "$flags" | grep -q "WPA-PSK"; then
+			security="WPA"
+		elif echo "$flags" | grep -q "WEP"; then
+			security="WEP"
+		else
+			security="Open"
+		fi
+
+		# Output JSON without trailing commas
+		if [ $first -eq 0 ]; then
+			echo ","
+		else
+			first=0
+		fi
+		cat <<-NETWORK
+			{
+				"ssid": "$(json_encode "$ssid")",
+				"bssid": "$(json_encode "$bssid")",
+				"signal": $signal,
+				"security": "$(json_encode "$security")"
+			}
+		NETWORK
+	done
+
+	echo "]}"
 }
 
 parse_post() {
@@ -266,6 +408,15 @@ case "$PARAM_action" in
 		;;
 	scan_networks)
 		json_response "$(scan_networks)"
+		;;
+	scan_cached)
+		json_response "$(scan_networks_cached)"
+		;;
+	scan_start)
+		json_response "$(scan_start)"
+		;;
+	scan_status)
+		json_response "$(scan_status)"
 		;;
 	save)
 		parse_post

--- a/package/wifi/files/index.html
+++ b/package/wifi/files/index.html
@@ -61,7 +61,7 @@
 <label class="form-label">Wi-Fi Network Name/SSID <span class="small text-white">(case-sensitive)</span></label>
 <div style="position:relative;">
 <input class="form-control bg-light text-dark" type="text" id="wlan_ssid" name="wlan_ssid" autocapitalize="none" placeholder="Enter network name or scan for networks" required>
-<datalist id="networks-list"></datalist>
+<div id="networks-panel" class="networks-panel hidden"></div>
 <button class="btn btn-link" type="button" id="scan-btn" title="Scan for networks">
 <span id="scan-spinner" class="hidden"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#495057" class="bi bi-arrow-clockwise" viewBox="0 0 16 16"><path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2z"/><path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466"/></svg></span>
 <span id="scan-text"><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#495057" viewBox="0 0 16 16"><path d="M11.742 10.344a6.5 6.5 0 1 0-1.397 1.398h-.001q.044.06.098.115l3.85 3.85a1 1 0 0 0 1.415-1.414l-3.85-3.85a1 1 0 0 0-.115-.1zM12 6.5a5.5 5.5 0 1 1-11 0 5.5 5.5 0 0 1 11 0"/></svg></span>
@@ -311,21 +311,84 @@ document.querySelectorAll('.tab-btn').forEach(btn => {
 const scanBtn      = document.getElementById('scan-btn');
 const scanSpinner  = document.getElementById('scan-spinner');
 const scanText     = document.getElementById('scan-text');
-const networksList = document.getElementById('networks-list');
+const networksPanel = document.getElementById('networks-panel');
 const ssidInput    = document.getElementById('wlan_ssid');
 
 let scanInProgress = false;
 let networksScanned = false;
 
-// Only show datalist when user types at least 1 character
-ssidInput.addEventListener('input', () => {
-  if (networksScanned && ssidInput.value.length >= 1) {
-    ssidInput.setAttribute('list', 'networks-list');
+// Render the networks list (shared by prescan cache load and live scan)
+const renderNetworks = (networks) => {
+  networksPanel.innerHTML = '';
+  const seen = new Set();
+  let rendered = 0;
+  networks.filter(n => n && n.ssid).forEach(network => {
+    if (!seen.has(network.ssid)) {
+      seen.add(network.ssid);
+      const signalBars = network.signal > -50 ? '▂▄▆█' : network.signal > -60 ? '▂▄▆_' : network.signal > -70 ? '▂▄__' : '▂___';
+      const item = document.createElement('button');
+      item.type = 'button';
+      item.className = 'network-item';
+      item.innerHTML = `<span class="network-name"></span> <span class="network-signal">${signalBars}</span> <span class="network-security">${network.security}</span>`;
+      item.querySelector('.network-name').textContent = network.ssid;
+      item.addEventListener('click', () => {
+        ssidInput.value = network.ssid;
+        hideNetworksPanel();
+      });
+      networksPanel.appendChild(item);
+      rendered++;
+    }
+  });
+  networksScanned = rendered > 0;
+  if (rendered) {
+    networksPanel.classList.remove('hidden');
+    ssidInput.placeholder = 'Pick a network from the list or type your own';
   } else {
-    ssidInput.removeAttribute('list');
+    hideNetworksPanel();
+    ssidInput.placeholder = 'No networks found';
+  }
+};
+
+// Mobile browsers (iOS Safari, many Android keyboards) do not open
+// <datalist> dropdowns reliably. Render scan results into a plain
+// collapsible <div> list instead, which works everywhere.
+function hideNetworksPanel() {
+  // Keep the rendered items; only hide the panel, so focusing the
+  // SSID field can bring the same list back without a rescan.
+  networksPanel.classList.add('hidden');
+}
+
+// Show only items matching what the user typed (autocomplete-ish)
+const filterNetworks = () => {
+  const query = ssidInput.value.trim().toLowerCase();
+  let visible = 0;
+  networksPanel.querySelectorAll('.network-item').forEach(item => {
+    const name = item.querySelector('.network-name').textContent.toLowerCase();
+    const match = !query || name.includes(query);
+    item.style.display = match ? '' : 'none';
+    if (match) visible++;
+  });
+  return visible;
+};
+
+ssidInput.addEventListener('focus', () => {
+  if (networksScanned && networksPanel.children.length) {
+    const visible = filterNetworks();
+    if (visible) networksPanel.classList.remove('hidden');
   }
 });
 
+// Bring the list back (filtered) as the user types
+ssidInput.addEventListener('input', () => {
+  if (networksScanned && networksPanel.children.length) {
+    const visible = filterNetworks();
+    networksPanel.classList.toggle('hidden', visible === 0);
+  }
+});
+
+// Trigger a scan, then poll until wpa_supplicant reports completion.
+// Two-phase, because a full 2.4 GHz sweep takes 3-5s+ on these radios
+// and the old single-shot call returned before results existed.
 scanBtn.addEventListener('click', async () => {
   if (scanInProgress) return;
 
@@ -339,37 +402,36 @@ scanBtn.addEventListener('click', async () => {
   scanText.classList.add('hidden');
 
   try {
-    const response = await fetch(`${API_URL}?action=scan_networks`);
+    const startResponse = await fetch(`${API_URL}?action=scan_start`);
+    const startData = await startResponse.json();
+
+    if (startData.error) {
+      console.warn('Scan error:', startData.error);
+      alert('Failed to scan networks. Please try again.');
+      return;
+    }
+
+    // Poll until the backend says the sweep finished (max ~20s)
+    for (let i = 0; i < 10; i++) {
+      await new Promise(r => setTimeout(r, 2000));
+      const response = await fetch(`${API_URL}?action=scan_status`);
+      const data = await response.json();
+
+      if (data.error) {
+        console.warn('Scan error:', data.error);
+        return; // Silently skip if scan already in progress
+      }
+
+      if (!data.scanning && data.networks) {
+        renderNetworks(data.networks);
+        return;
+      }
+    }
+
+    // Timed out; show whatever the last poll returned, if anything
+    const response = await fetch(`${API_URL}?action=scan_status`);
     const data = await response.json();
-
-    if (data.error) {
-      console.warn('Scan error:', data.error);
-      return; // Silently skip if scan already in progress
-    }
-
-    // Clear existing options
-    networksList.innerHTML = '';
-
-    if (data.networks) {
-      // Filter out the trailing null and duplicates
-      const networks = data.networks.filter(n => n && n.ssid);
-      const seen = new Set();
-
-      networks.forEach(network => {
-        if (!seen.has(network.ssid)) {
-          seen.add(network.ssid);
-          const option = document.createElement('option');
-          const signalBars = network.signal > -50 ? '▂▄▆█' : network.signal > -60 ? '▂▄▆_' : network.signal > -70 ? '▂▄__' : '▂___';
-          option.value = network.ssid;
-          option.textContent = `${network.ssid} ${signalBars} (${network.security})`;
-          networksList.appendChild(option);
-        }
-      });
-
-      // Mark that networks have been scanned and update placeholder
-      networksScanned = true;
-      ssidInput.placeholder = 'Start typing to select a network';
-    }
+    if (!data.scanning && data.networks) renderNetworks(data.networks);
   } catch (error) {
     // Don't show alert for aborted fetches (page refresh/navigation)
     if (error.name !== 'AbortError' && error.message !== 'Failed to fetch') {
@@ -389,8 +451,34 @@ scanBtn.addEventListener('click', async () => {
   }
 });
 
-scheduleTimeoutWarning();
+// Dismiss the networks list when tapping outside of it (mobile UX)
+document.addEventListener('click', (e) => {
+  if (!networksPanel.classList.contains('hidden') &&
+      !networksPanel.contains(e.target) &&
+      e.target !== ssidInput) {
+    hideNetworksPanel();
+  }
+});
 
+// Load the prescan list (S38 scans once in station mode before the
+// portal AP starts, so the sweep never drops the phone's connection).
+// The magnifying glass triggers a live rescan which may briefly
+// interrupt the connection - opt-in for users who need fresher results.
+async function loadCachedNetworks() {
+  try {
+    const response = await fetch(`${API_URL}?action=scan_cached`);
+    const data = await response.json();
+    if (data && data.networks && data.networks.length) {
+      renderNetworks(data.networks);
+    }
+  } catch (e) {
+    // Prescan unavailable (e.g. first boot race); user can still scan
+    console.warn('No prescan cache:', e);
+  }
+}
+loadCachedNetworks();
+
+scheduleTimeoutWarning();
 loadSystemInfo();
 </script>
 

--- a/package/wifi/files/index.html
+++ b/package/wifi/files/index.html
@@ -443,7 +443,10 @@ scanBtn.addEventListener('click', async () => {
     scanBtn.disabled = false;
     ssidInput.disabled = false;
     ssidInput.style.opacity = '1';
-    if (!networksScanned) {
+    // Restore only when rendering never happened (e.g. fetch error);
+    // otherwise renderNetworks already set the right placeholder
+    // ('Pick a network...' or 'No networks found').
+    if (ssidInput.placeholder === 'Scanning for networks...') {
       ssidInput.placeholder = originalPlaceholder;
     }
     scanSpinner.classList.add('hidden');

--- a/package/wifi/files/portal.min.css
+++ b/package/wifi/files/portal.min.css
@@ -89,3 +89,10 @@ dd{margin-bottom:.5rem;margin-left:0}
 #scan-spinner{display:inline-block;animation:spin 1s linear infinite}
 #wlan_ssid{padding-right:2.5rem}
 @keyframes spin{from{transform:rotate(0deg)}to{transform:rotate(360deg)}}
+.networks-panel{max-height:16rem;overflow-y:auto;background:#dee2e6;border-radius:.375rem;margin-top:.5rem;-webkit-overflow-scrolling:touch}
+.network-item{display:block;width:100%;text-align:left;padding:.6rem .75rem;border:none;background:none;color:#212529;font-size:1rem;line-height:1.4;cursor:pointer}
+.network-item+.network-item{border-top:1px solid #adb5bd}
+.network-item:active,.network-item:hover{background:#ced4da}
+.network-name{font-weight:500;word-break:break-all}
+.network-signal{font-family:monospace;color:#495057}
+.network-security{float:right;color:#6c757d;font-size:.875rem}


### PR DESCRIPTION
Ports the portal Wi-Fi scan fix from ciao (PR #1477, merged) to master.

## Summary

Same reworked flow, verified against master's current wifi package:

- **S38 pre-scans** in plain station mode before the portal AP goes up; results cached to `/tmp/wifi_prescan`, never poisoned by header-only output
- **api.cgi**: dynamic wpa_supplicant ctrl-socket interface detection (no more hardcoded `wlan0`), two-phase `scan_start`/`scan_status` polling, `scan_cached` serves the prescan list read-only with cache fallback on empty live results
- **index.html**: `<datalist>` replaced with a tappable list that works on mobile browsers — focus to show, type to filter, tap to fill, dismiss hides instead of destroying
- **portal.min.css**: styling for the new network list panel

## Port notes

Cherry-picked from ciao commits 2be1f07a9 + cdc005b8a (the latter carries Paul's review fixes: no-trigger status polls, capped prescan deadline, shellcheck cleanup). The only master-specific divergence is preserved: master's `get_info` includes the `features` field for pre-derived PSK / root password hash, which the cherry-pick auto-merge retained.

## Testing

- Shell syntax (`sh -n`) and JS brace-balance verified
- Diff against ciao originals: identical except the preserved `features` field
- Hardware-tested on a WUUK camera (master build): prescan list populates on portal load, manual rescan works, mobile browser list interaction (focus / filter / tap-to-fill) all functioning
- Hardware-validated on ciao (PR #1477) on a different camera
