### PR TITLE
thingino-agent: harden omnibus /config and /state capture

### DIFF
--- a/docs/thingino/next/camera-agent-implementation.md
+++ b/docs/thingino/next/camera-agent-implementation.md
@@ -292,6 +292,7 @@ Current lifecycle shape:
 - `thingino-agentd` enforces loopback-only non-TLS binds and requires `agent.token` before allowing non-loopback TLS exposure
 - the managed listeners expose `/api/v1/*`, with the native listener handling request routing directly instead of via web-root CGI assets
 - default config keeps the listener disabled until explicitly enabled in `thingino.json`
+- omnibus `GET /config` and `GET /state` (`runtime all`) may take several seconds on Raptor; the native listener allows up to 30s of overall agentctl capture time and no longer kills on short stdout idle gaps. Failure returns HTTP 503 with an error JSON body instead of HTTP 200 with an empty body. The Raptor adapter batches section reads for those omnibus paths; narrow `/settings/*` and `/runtime/<resource>` routes stay single-key and unchanged.
 
 ## Risks
 
@@ -300,6 +301,7 @@ Current lifecycle shape:
 - serving the API from a streamer would lock the northbound contract to one backend boundary
 - keeping stale CGI compatibility assets around after the transport migrated would obscure which layer owns the live API path
 - remote exposure before auth is solid creates avoidable risk
+- hubs that treated empty HTTP 200 on `/config` or `/state` as "empty config" must treat 503 as a soft failure and retry instead
 
 ## Acceptance checklist for the first package
 

--- a/package/thingino-agent/files/thingino-agent-adapter-raptor
+++ b/package/thingino-agent/files/thingino-agent-adapter-raptor
@@ -46,9 +46,74 @@ agent_json_bool_field() {
 	esac
 }
 
+# Omnibus GET /config and GET /state prefetch sections via
+# `raptorctl config get <section>` (one IPC call per section) into a PID-scoped
+# cache. Narrow /settings and /runtime paths leave the cache unset and keep
+# single-key raptorctl gets.
+agent_config_cache_begin() {
+	AGENT_CFG_CACHE="/tmp/thingino-agent-raptor-cfg.$$"
+	_raptor_osd_shared_ready=
+	: >"$AGENT_CFG_CACHE"
+	command -v raptorctl >/dev/null 2>&1 || return 0
+	for section in sensor image motion recording audio stream0 stream1 rtsp osd \
+		osd.timestamp osd.uptime osd.camera osd.logo osd.privacy; do
+		raptorctl config get "$section" 2>/dev/null | awk -v s="$section" '
+			/^\[/ { next }
+			/^[[:space:]]*$/ { next }
+			{
+				eq = index($0, "=")
+				if (eq < 1) next
+				key = substr($0, 1, eq - 1)
+				val = substr($0, eq + 1)
+				gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+				gsub(/^[[:space:]]+/, "", val)
+				gsub(/[[:space:]]+$/, "", val)
+				if (key == "") next
+				printf "%s\t%s\t%s\n", s, key, val
+			}
+		' >>"$AGENT_CFG_CACHE"
+	done
+}
+
+agent_config_cache_end() {
+	rm -f "$AGENT_CFG_CACHE" \
+		"/tmp/thingino-agent-raptor-isp.$$" \
+		"/tmp/thingino-agent-raptor-wb.$$"
+	AGENT_CFG_CACHE=
+	_raptor_osd_shared_ready=
+	_raptor_osd_font=
+	_raptor_osd_font_size=
+	_raptor_osd_stroke_size=
+	_raptor_osd_time_format=
+	_raptor_osd_fill_ui=
+	_raptor_osd_stroke_ui=
+	_raptor_osd_logo_enabled=
+	_raptor_osd_logo_position=
+	_raptor_osd_logo_path=
+	_raptor_osd_logo_width=
+	_raptor_osd_logo_height=
+	_raptor_osd_time_enabled=
+	_raptor_osd_time_position=
+	_raptor_osd_uptime_enabled=
+	_raptor_osd_uptime_format=
+	_raptor_osd_uptime_position=
+	_raptor_osd_usertext_enabled=
+	_raptor_osd_usertext_format=
+	_raptor_osd_usertext_position=
+}
+
 agent_config_get() {
 	section=$1
 	key=$2
+	if [ -n "$AGENT_CFG_CACHE" ] && [ -f "$AGENT_CFG_CACHE" ]; then
+		awk -F '\t' -v s="$section" -v k="$key" '
+			$1 == s && $2 == k {
+				print $3
+				exit
+			}
+		' "$AGENT_CFG_CACHE" | tr -d '\r\n"'
+		return 0
+	fi
 	command -v raptorctl >/dev/null 2>&1 || return 0
 	raptorctl config get "$section" "$key" 2>/dev/null | tr -d '\r\n"'
 }
@@ -878,44 +943,72 @@ agent_print_stream_config() {
 	printf '}'
 }
 
+agent_osd_shared_prepare() {
+	# Global OSD keys are identical for both streams; load once per omnibus call.
+	[ "$_raptor_osd_shared_ready" = 1 ] && return 0
+	_raptor_osd_font=$(agent_config_get osd font)
+	_raptor_osd_font_size=$(agent_config_get osd font_size)
+	_raptor_osd_stroke_size=$(agent_config_get osd font_stroke)
+	_raptor_osd_time_format=$(agent_config_get osd time_format)
+	_fill=$(agent_config_get osd font_color)
+	_stroke=$(agent_config_get osd stroke_color)
+	_raptor_osd_fill_ui=
+	_raptor_osd_stroke_ui=
+	[ -n "$_fill" ] && _raptor_osd_fill_ui=$(agent_osd_color_to_ui "$_fill")
+	[ -n "$_stroke" ] && _raptor_osd_stroke_ui=$(agent_osd_color_to_ui "$_stroke")
+	_raptor_osd_logo_enabled=$(agent_config_bool osd.logo visible false)
+	_raptor_osd_logo_position=$(agent_config_get osd.logo position)
+	_raptor_osd_logo_path=$(agent_config_get osd.logo path)
+	_raptor_osd_logo_width=$(agent_config_get osd.logo width)
+	_raptor_osd_logo_height=$(agent_config_get osd.logo height)
+	_raptor_osd_time_enabled=$(agent_config_bool osd.timestamp visible false)
+	_raptor_osd_time_position=$(agent_config_get osd.timestamp position)
+	_raptor_osd_uptime_enabled=$(agent_config_bool osd.uptime visible false)
+	_raptor_osd_uptime_format=$(agent_config_get osd.uptime template)
+	_raptor_osd_uptime_position=$(agent_config_get osd.uptime position)
+	_raptor_osd_usertext_enabled=$(agent_config_bool osd.camera visible false)
+	_raptor_osd_usertext_format=$(agent_config_get osd.camera template)
+	_raptor_osd_usertext_position=$(agent_config_get osd.camera position)
+	_raptor_osd_shared_ready=1
+}
+
 agent_print_stream_osd() {
 	# Raptor ROD is mostly global; streamN only owns osd_enabled. Both streams
 	# still expose the same element tree so OSD pages can hydrate via GET /config.
 	stream_id=$1
+	agent_osd_shared_prepare
 	printf '{'
 	printf '"enabled":%s,' "$(agent_config_bool "$(agent_stream_section "$stream_id")" osd_enabled true)"
-	printf '"font_path":%s,' "$(thingino_agent_json_string_or_null "$(agent_config_get osd font)")"
-	printf '"font_size":%s,' "$(thingino_agent_json_value_or "$(agent_config_get osd font_size)" null)"
-	printf '"stroke_size":%s,' "$(thingino_agent_json_value_or "$(agent_config_get osd font_stroke)" null)"
+	printf '"font_path":%s,' "$(thingino_agent_json_string_or_null "$_raptor_osd_font")"
+	printf '"font_size":%s,' "$(thingino_agent_json_value_or "$_raptor_osd_font_size" null)"
+	printf '"stroke_size":%s,' "$(thingino_agent_json_value_or "$_raptor_osd_stroke_size" null)"
 	printf '"logo":{'
-	printf '"enabled":%s,' "$(agent_config_bool osd.logo visible false)"
-	printf '"position":%s,' "$(thingino_agent_json_string_or_null "$(agent_config_get osd.logo position)")"
-	printf '"path":%s,' "$(thingino_agent_json_string_or_null "$(agent_config_get osd.logo path)")"
-	printf '"width":%s,' "$(thingino_agent_json_value_or "$(agent_config_get osd.logo width)" null)"
-	printf '"height":%s' "$(thingino_agent_json_value_or "$(agent_config_get osd.logo height)" null)"
+	printf '"enabled":%s,' "$_raptor_osd_logo_enabled"
+	printf '"position":%s,' "$(thingino_agent_json_string_or_null "$_raptor_osd_logo_position")"
+	printf '"path":%s,' "$(thingino_agent_json_string_or_null "$_raptor_osd_logo_path")"
+	printf '"width":%s,' "$(thingino_agent_json_value_or "$_raptor_osd_logo_width" null)"
+	printf '"height":%s' "$(thingino_agent_json_value_or "$_raptor_osd_logo_height" null)"
 	printf '},'
 	printf '"time":{'
-	printf '"enabled":%s,' "$(agent_config_bool osd.timestamp visible false)"
-	printf '"format":%s,' "$(thingino_agent_json_string_or_null "$(agent_config_get osd time_format)")"
-	printf '"position":%s,' "$(thingino_agent_json_string_or_null "$(agent_config_get osd.timestamp position)")"
-	_fill=$(agent_config_get osd font_color)
-	_stroke=$(agent_config_get osd stroke_color)
-	printf '"fill_color":%s,' "$(thingino_agent_json_string_or_null "$([ -n "$_fill" ] && agent_osd_color_to_ui "$_fill")")"
-	printf '"stroke_color":%s' "$(thingino_agent_json_string_or_null "$([ -n "$_stroke" ] && agent_osd_color_to_ui "$_stroke")")"
+	printf '"enabled":%s,' "$_raptor_osd_time_enabled"
+	printf '"format":%s,' "$(thingino_agent_json_string_or_null "$_raptor_osd_time_format")"
+	printf '"position":%s,' "$(thingino_agent_json_string_or_null "$_raptor_osd_time_position")"
+	printf '"fill_color":%s,' "$(thingino_agent_json_string_or_null "$_raptor_osd_fill_ui")"
+	printf '"stroke_color":%s' "$(thingino_agent_json_string_or_null "$_raptor_osd_stroke_ui")"
 	printf '},'
 	printf '"uptime":{'
-	printf '"enabled":%s,' "$(agent_config_bool osd.uptime visible false)"
-	printf '"format":%s,' "$(thingino_agent_json_string_or_null "$(agent_config_get osd.uptime template)")"
-	printf '"position":%s,' "$(thingino_agent_json_string_or_null "$(agent_config_get osd.uptime position)")"
-	printf '"fill_color":%s,' "$(thingino_agent_json_string_or_null "$([ -n "$_fill" ] && agent_osd_color_to_ui "$_fill")")"
-	printf '"stroke_color":%s' "$(thingino_agent_json_string_or_null "$([ -n "$_stroke" ] && agent_osd_color_to_ui "$_stroke")")"
+	printf '"enabled":%s,' "$_raptor_osd_uptime_enabled"
+	printf '"format":%s,' "$(thingino_agent_json_string_or_null "$_raptor_osd_uptime_format")"
+	printf '"position":%s,' "$(thingino_agent_json_string_or_null "$_raptor_osd_uptime_position")"
+	printf '"fill_color":%s,' "$(thingino_agent_json_string_or_null "$_raptor_osd_fill_ui")"
+	printf '"stroke_color":%s' "$(thingino_agent_json_string_or_null "$_raptor_osd_stroke_ui")"
 	printf '},'
 	printf '"usertext":{'
-	printf '"enabled":%s,' "$(agent_config_bool osd.camera visible false)"
-	printf '"format":%s,' "$(thingino_agent_json_string_or_null "$(agent_config_get osd.camera template)")"
-	printf '"position":%s,' "$(thingino_agent_json_string_or_null "$(agent_config_get osd.camera position)")"
-	printf '"fill_color":%s,' "$(thingino_agent_json_string_or_null "$([ -n "$_fill" ] && agent_osd_color_to_ui "$_fill")")"
-	printf '"stroke_color":%s' "$(thingino_agent_json_string_or_null "$([ -n "$_stroke" ] && agent_osd_color_to_ui "$_stroke")")"
+	printf '"enabled":%s,' "$_raptor_osd_usertext_enabled"
+	printf '"format":%s,' "$(thingino_agent_json_string_or_null "$_raptor_osd_usertext_format")"
+	printf '"position":%s,' "$(thingino_agent_json_string_or_null "$_raptor_osd_usertext_position")"
+	printf '"fill_color":%s,' "$(thingino_agent_json_string_or_null "$_raptor_osd_fill_ui")"
+	printf '"stroke_color":%s' "$(thingino_agent_json_string_or_null "$_raptor_osd_stroke_ui")"
 	printf '}'
 	printf '}'
 }
@@ -1232,6 +1325,7 @@ thingino_agent_adapter_raptor_get_runtime() {
 	resource=${1:-all}
 	case "$resource" in
 		all)
+			agent_config_cache_begin
 			printf '{'
 			printf '"system":%s,' "$(agent_print_runtime_system)"
 			printf '"network":%s,' "$(agent_print_runtime_network)"
@@ -1252,6 +1346,7 @@ thingino_agent_adapter_raptor_get_runtime() {
 			agent_print_stream_runtime 1
 			printf ']'
 			printf '}\n'
+			agent_config_cache_end
 			;;
 		system)
 			agent_print_runtime_system
@@ -1348,6 +1443,7 @@ thingino_agent_adapter_raptor_get_runtime() {
 }
 
 thingino_agent_adapter_raptor_get_config() {
+	agent_config_cache_begin
 	printf '{'
 	printf '"image":{'
 	printf '"brightness":%s,' "$(thingino_agent_json_value_or "$(agent_image_raw brightness)" null)"
@@ -1383,6 +1479,7 @@ thingino_agent_adapter_raptor_get_config() {
 	printf '"config_path":%s' "$(thingino_agent_json_string "$AGENT_CONFIG")"
 	printf '}}'
 	printf '}\n'
+	agent_config_cache_end
 }
 
 agent_setting_value() {

--- a/package/thingino-agent/files/thingino-agentd-native.c
+++ b/package/thingino-agent/files/thingino-agentd-native.c
@@ -12,6 +12,7 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
 #define AGENT_CONFIG "/etc/thingino.json"
@@ -20,6 +21,10 @@
 #define AGENTCTL_PATH "/usr/sbin/thingino-agentctl"
 #define REQUEST_BUFFER_SIZE 32768
 #define BODY_LIMIT 65536
+/* select() poll slice; idle gaps alone must not kill long agentctl work */
+#define CAPTURE_SELECT_SLICE_SEC 1
+/* hard ceiling for one agentctl capture (omnibus /config and /state) */
+#define CAPTURE_OVERALL_TIMEOUT_SEC 30
 
 struct http_request {
     int client_fd;
@@ -182,6 +187,7 @@ static int capture_command(char *const argv[], const char *stdin_path, char **ou
     size_t used = 0;
     size_t capacity = 0;
     int status = 0;
+    time_t started;
 
     if (pipe(pipe_fd) != 0) {
         return -1;
@@ -210,15 +216,37 @@ static int capture_command(char *const argv[], const char *stdin_path, char **ou
         _exit(127);
     }
     close(pipe_fd[1]);
+    started = time(NULL);
     for (;;) {
         char chunk[4096];
         ssize_t bytes_read;
         fd_set fds;
         struct timeval tv;
+        time_t now;
+        time_t remaining;
+
+        now = time(NULL);
+        if (now < started) {
+            started = now;
+        }
+        if ((now - started) >= CAPTURE_OVERALL_TIMEOUT_SEC) {
+            kill(pid, SIGKILL);
+            waitpid(pid, &status, 0);
+            free(buffer);
+            close(pipe_fd[0]);
+            return -1;
+        }
+        remaining = CAPTURE_OVERALL_TIMEOUT_SEC - (now - started);
+        if (remaining > CAPTURE_SELECT_SLICE_SEC) {
+            remaining = CAPTURE_SELECT_SLICE_SEC;
+        }
+        if (remaining < 1) {
+            remaining = 1;
+        }
 
         FD_ZERO(&fds);
         FD_SET(pipe_fd[0], &fds);
-        tv.tv_sec = 1;
+        tv.tv_sec = (long)remaining;
         tv.tv_usec = 0;
         if (select(pipe_fd[0] + 1, &fds, NULL, NULL, &tv) < 0) {
             if (errno == EINTR) {
@@ -227,12 +255,8 @@ static int capture_command(char *const argv[], const char *stdin_path, char **ou
             break;
         }
         if (!FD_ISSET(pipe_fd[0], &fds)) {
-            /* timeout: kill child, return error */
-            kill(pid, SIGKILL);
-            waitpid(pid, &status, 0);
-            free(buffer);
-            close(pipe_fd[0]);
-            return -1;
+            /* idle slice with overall budget still remaining: keep waiting */
+            continue;
         }
         bytes_read = read(pipe_fd[0], chunk, sizeof(chunk));
 
@@ -497,8 +521,9 @@ static int execute_agentctl_json(int client_fd, char *const argv[], const char *
 
     if (command_status != 0) {
         free(output);
-        /* backend unavailable: return empty payload so caller can fall back */
-        return send_response(client_fd, 200, "OK", "application/json", "", 0);
+        /* Prefer an explicit error over HTTP 200 with an empty body. */
+        return send_json_error(client_fd, 503, "Service Unavailable",
+            "agentctl failed or timed out");
     }
     response_status = send_response(client_fd, 200, "OK", "application/json", output, output_len);
     free(output);


### PR DESCRIPTION
## Summary
- Native listener no longer SIGKILLs `thingino-agentctl` after 1s of stdout idle; uses a 30s overall capture budget so long omnibus `/config` and `/state` work can finish.
- `execute_agentctl_json()` failures now return HTTP 503 with an error JSON body instead of HTTP 200 with an empty body (which misled clients into treating config/state as empty).
- Raptor adapter batches `raptorctl config get <section>` for omnibus `get_config` / `get_runtime all`, and loads shared OSD keys once for both streams. Narrow `/settings/*` and `/runtime/<resource>` paths stay single-key and unchanged.

## Motivation
On Raptor cameras, hub/clients intermittently saw HTTP 200 with 0-byte bodies for `GET /api/v1/config` and `GET /api/v1/state` (~1.7s), while narrow routes stayed healthy. Root cause was the daemon killing agentctl during gaps between many sequential `raptorctl` calls, then returning empty 200.

## Test plan
- [ ] Build/install updated `thingino-agentd` + raptor adapter (or hot-copy scripts and restart `S95thingino-agent`)
- [ ] Repeatedly curl authenticated `GET /api/v1/config` and `GET /api/v1/state`; expect non-empty 200 bodies and stable timing (not 200/0bytes ~1.7s)
- [ ] Confirm narrow `GET /api/v1/device`, `/capabilities`, `/settings/...`, `/runtime/system` still return quickly
- [ ] Confirm agentctl failure/timeout surfaces as 503 JSON, not empty 200


Made with [Cursor](https://cursor.com)