### PR TITLE
wyze-accessory: add floodlight_ctl for Floodlight v1 light control

### DIFF
--- a/package/wyze-accessory/files/floodlight_ctl
+++ b/package/wyze-accessory/files/floodlight_ctl
@@ -1,0 +1,95 @@
+#!/bin/sh
+# Control the light on the Wyze Cam Floodlight v1 accessory board.
+#
+# The light board is attached over an internal USB serial link (ch341)
+# and speaks a simple framed protocol:
+#
+#   <0xAA 0x55> <0x43> <len> <0x46> <payload> <checksum>
+#
+# Usage:
+#   floodlight_ctl on <1-100>   set brightness percentage
+#   floodlight_ctl off          turn the light off
+#
+# Protocol and original script by gponick:
+# https://github.com/gtxaspec/wz_mini_hacks/discussions/771#discussioncomment-11737172
+
+get_floodlight_command_string() {
+	initial_total=405
+	brightness_pct=$1
+	brightness_hex=$(printf "%02x" $((255 * brightness_pct / 100)))
+	#echo "brightness_hex: ${brightness_hex}"
+	brightness_dec=$((255 * brightness_pct / 100))
+	sequence_start="\xaa\x55\x43\x06\x46"
+	brightness_sequence="\x${brightness_hex}\x00\x07"
+	combined_sequence="${sequence_start}${brightness_sequence}"
+	# add brightness_dec and initial_total and print it as a 2 byte hex value in the format \x##\x##
+	check_bytes_raw=$(printf "%.4x" $((brightness_dec + initial_total)))
+	#echo "check_bytes_raw: ${check_bytes_raw}"
+	# get the first 2 bytes of the check_bytes_raw using awk
+	first_two_chars=$(echo "$check_bytes_raw" | awk '{print substr($0, 1, 2)}')
+	# get the last 2 bytes of the check_bytes_raw using awk
+	last_two_chars=$(echo "$check_bytes_raw" | awk '{print substr($0, 3, 2)}')
+	# combine the first and last 2 bytes into a single string
+	check_bytes="\x${first_two_chars}\x${last_two_chars}"
+	# print the literal escape sequences; they are interpreted later,
+	# when the final string is written to the device
+	printf '%s' "${combined_sequence}${check_bytes}"
+}
+
+help() {
+	echo "usage: floodlight_ctl on <% value: 1-100>"
+	echo "usage: floodlight_ctl off"
+}
+
+# if the script is run with no args, display help
+if [ $# -eq 0 ]; then
+	echo "Invalid number of arguments"
+	help
+	exit 1
+fi
+
+# if /dev/ttyUSB0 exists and is a character device, set DEVICE to /dev/ttyUSB0
+if [ -c /dev/ttyUSB0 ]; then
+	DEVICE="/dev/ttyUSB0"
+fi
+
+# if /dev/ttyUSB1 exists and is a character device, set DEVICE to /dev/ttyUSB1
+if [ -c /dev/ttyUSB1 ]; then
+	DEVICE="/dev/ttyUSB1"
+fi
+
+# if DEVICE is not set, print an error message and exit
+if [ -z "$DEVICE" ]; then
+	echo "Could not find a valid device"
+	exit 1
+fi
+
+# if the argument is off, set the brightness to 0 and exit
+if [ "$1" = "off" ] || [ "$1" = "OFF" ]; then
+	echo "OFF" >/var/run/floodlight.status
+	brightness_pct=0
+	echo "Setting brightness to 0"
+	brightness_string=$(get_floodlight_command_string 0)
+	printf '%b' "${brightness_string}" >"$DEVICE"
+fi
+
+# if the argument is on, set the brightness to the value
+if [ "$1" = "on" ] || [ "$1" = "ON" ]; then
+	if [ $# -ne 2 ]; then
+		echo "Invalid number of arguments"
+		help
+		exit 1
+	fi
+	if [ "$2" -lt 1 ] || [ "$2" -gt 100 ]; then
+		echo "Invalid brightness value"
+		help
+		exit 1
+	fi
+	brightness_pct=$2
+	echo "ON" >/var/run/floodlight.status
+	echo "${brightness_pct}" >/var/run/floodlight.brightness
+	echo "Brightness PCT is ${brightness_pct}"
+	brightness_string=$(get_floodlight_command_string "${brightness_pct}")
+	echo "Setting brightness to ${brightness_pct}: [${brightness_string}]"
+	printf '%b' "${brightness_string}" >"$DEVICE"
+fi

--- a/package/wyze-accessory/files/floodlight_ctl
+++ b/package/wyze-accessory/files/floodlight_ctl
@@ -6,90 +6,78 @@
 #
 #   <0xAA 0x55> <0x43> <len> <0x46> <payload> <checksum>
 #
-# Usage:
-#   floodlight_ctl on <1-100>   set brightness percentage
-#   floodlight_ctl off          turn the light off
-#
 # Protocol and original script by gponick:
 # https://github.com/gtxaspec/wz_mini_hacks/discussions/771#discussioncomment-11737172
 
+VERBOSE=0
+
+usage() {
+	echo "usage: $0 [-v] on <1-100> | off" >&2
+}
+
+log() {
+	[ "$VERBOSE" -eq 1 ] && echo "$1"
+}
+
 get_floodlight_command_string() {
-	initial_total=405
 	brightness_pct=$1
-	brightness_hex=$(printf "%02x" $((255 * brightness_pct / 100)))
-	#echo "brightness_hex: ${brightness_hex}"
 	brightness_dec=$((255 * brightness_pct / 100))
-	sequence_start="\xaa\x55\x43\x06\x46"
-	brightness_sequence="\x${brightness_hex}\x00\x07"
-	combined_sequence="${sequence_start}${brightness_sequence}"
-	# add brightness_dec and initial_total and print it as a 2 byte hex value in the format \x##\x##
-	check_bytes_raw=$(printf "%.4x" $((brightness_dec + initial_total)))
-	#echo "check_bytes_raw: ${check_bytes_raw}"
-	# get the first 2 bytes of the check_bytes_raw using awk
-	first_two_chars=$(echo "$check_bytes_raw" | awk '{print substr($0, 1, 2)}')
-	# get the last 2 bytes of the check_bytes_raw using awk
-	last_two_chars=$(echo "$check_bytes_raw" | awk '{print substr($0, 3, 2)}')
-	# combine the first and last 2 bytes into a single string
-	check_bytes="\x${first_two_chars}\x${last_two_chars}"
-	# print the literal escape sequences; they are interpreted later,
-	# when the final string is written to the device
-	printf '%s' "${combined_sequence}${check_bytes}"
+	check_bytes_raw=$(printf "%.4x" $((brightness_dec + 405)))
+	printf '%s%s%s' "\xaa\x55\x43\x06\x46" "\x$(printf "%02x" "$brightness_dec")\x00\x07" "\x${check_bytes_raw%??}\x${check_bytes_raw#??}"
 }
 
-help() {
-	echo "usage: floodlight_ctl on <% value: 1-100>"
-	echo "usage: floodlight_ctl off"
-}
+for DEVICE in /dev/ttyUSB*; do
+	[ -c "$DEVICE" ] && CH341_DEVICE="$DEVICE"
+done
+DEVICE="$CH341_DEVICE"
 
-# if the script is run with no args, display help
-if [ $# -eq 0 ]; then
-	echo "Invalid number of arguments"
-	help
-	exit 1
-fi
-
-# if /dev/ttyUSB0 exists and is a character device, set DEVICE to /dev/ttyUSB0
-if [ -c /dev/ttyUSB0 ]; then
-	DEVICE="/dev/ttyUSB0"
-fi
-
-# if /dev/ttyUSB1 exists and is a character device, set DEVICE to /dev/ttyUSB1
-if [ -c /dev/ttyUSB1 ]; then
-	DEVICE="/dev/ttyUSB1"
-fi
-
-# if DEVICE is not set, print an error message and exit
 if [ -z "$DEVICE" ]; then
-	echo "Could not find a valid device"
+	echo "Could not find a valid device" >&2
 	exit 1
 fi
 
-# if the argument is off, set the brightness to 0 and exit
-if [ "$1" = "off" ] || [ "$1" = "OFF" ]; then
-	echo "OFF" >/var/run/floodlight.status
-	brightness_pct=0
-	echo "Setting brightness to 0"
-	brightness_string=$(get_floodlight_command_string 0)
-	printf '%b' "${brightness_string}" >"$DEVICE"
-fi
+while getopts "vh" flag; do
+	case "$flag" in
+		v) VERBOSE=1 ;;
+		*)
+			usage
+			exit 1
+			;;
+	esac
+done
+shift "$((OPTIND - 1))"
 
-# if the argument is on, set the brightness to the value
-if [ "$1" = "on" ] || [ "$1" = "ON" ]; then
-	if [ $# -ne 2 ]; then
-		echo "Invalid number of arguments"
-		help
+[ $# -eq 0 ] && {
+	usage
+	exit 1
+}
+
+case "$1" in
+off | OFF)
+	echo "OFF" >/var/run/floodlight.status
+	printf '%b' "$(get_floodlight_command_string 0)" >"$DEVICE"
+	log "Setting brightness to 0"
+	;;
+on | ON)
+	[ $# -ne 2 ] && {
+		usage
 		exit 1
-	fi
+	}
 	if [ "$2" -lt 1 ] || [ "$2" -gt 100 ]; then
-		echo "Invalid brightness value"
-		help
+		echo "Invalid brightness value" >&2
+		usage
 		exit 1
 	fi
 	brightness_pct=$2
 	echo "ON" >/var/run/floodlight.status
 	echo "${brightness_pct}" >/var/run/floodlight.brightness
-	echo "Brightness PCT is ${brightness_pct}"
-	brightness_string=$(get_floodlight_command_string "${brightness_pct}")
-	echo "Setting brightness to ${brightness_pct}: [${brightness_string}]"
-	printf '%b' "${brightness_string}" >"$DEVICE"
-fi
+	printf '%b' "$(get_floodlight_command_string "$brightness_pct")" >"$DEVICE"
+	log "Setting brightness to ${brightness_pct}"
+	;;
+*)
+	usage
+	exit 1
+	;;
+esac
+
+exit 0

--- a/package/wyze-accessory/files/floodlight_ctl
+++ b/package/wyze-accessory/files/floodlight_ctl
@@ -53,31 +53,31 @@ shift "$((OPTIND - 1))"
 }
 
 case "$1" in
-off | OFF)
-	echo "OFF" >/var/run/floodlight.status
-	printf '%b' "$(get_floodlight_command_string 0)" >"$DEVICE"
-	log "Setting brightness to 0"
-	;;
-on | ON)
-	[ $# -ne 2 ] && {
+	off | OFF)
+		echo "OFF" >/var/run/floodlight.status
+		printf '%b' "$(get_floodlight_command_string 0)" >"$DEVICE"
+		log "Setting brightness to 0"
+		;;
+	on | ON)
+		[ $# -ne 2 ] && {
+			usage
+			exit 1
+		}
+		if [ "$2" -lt 1 ] || [ "$2" -gt 100 ]; then
+			echo "Invalid brightness value" >&2
+			usage
+			exit 1
+		fi
+		brightness_pct=$2
+		echo "ON" >/var/run/floodlight.status
+		echo "${brightness_pct}" >/var/run/floodlight.brightness
+		printf '%b' "$(get_floodlight_command_string "$brightness_pct")" >"$DEVICE"
+		log "Setting brightness to ${brightness_pct}"
+		;;
+	*)
 		usage
 		exit 1
-	}
-	if [ "$2" -lt 1 ] || [ "$2" -gt 100 ]; then
-		echo "Invalid brightness value" >&2
-		usage
-		exit 1
-	fi
-	brightness_pct=$2
-	echo "ON" >/var/run/floodlight.status
-	echo "${brightness_pct}" >/var/run/floodlight.brightness
-	printf '%b' "$(get_floodlight_command_string "$brightness_pct")" >"$DEVICE"
-	log "Setting brightness to ${brightness_pct}"
-	;;
-*)
-	usage
-	exit 1
-	;;
+		;;
 esac
 
 exit 0

--- a/package/wyze-accessory/wyze-accessory.mk
+++ b/package/wyze-accessory/wyze-accessory.mk
@@ -34,6 +34,9 @@ define WYZE_ACCESSORY_INSTALL_DOORBELL_BUTTON_CONF
 endef
 
 define WYZE_ACCESSORY_INSTALL_TARGET_CMDS_FLOODLIGHT
+	$(INSTALL) -D -m 0755 $(WYZE_ACCESSORY_PKGDIR)/files/floodlight_ctl \
+		$(TARGET_DIR)/usr/sbin/floodlight_ctl
+
 	$(INSTALL) -m 0755 -d $(TARGET_DIR)/etc/modules.d
 	echo ch341 >> $(TARGET_DIR)/etc/modules.d/50-accessory
 	echo snd-usb-audio >> $(TARGET_DIR)/etc/modules.d/50-accessory


### PR DESCRIPTION
## What

Adds a `floodlight_ctl` script to the `wyze-accessory` package (FLOODLIGHT option), installed as `/usr/sbin/floodlight_ctl`. This finally gives Floodlight v1 users a shipped way to control the light — previously the option only loaded the ch341/snd-usb-audio modules and the light board protocol was undocumented in this repo.

The light board is attached over the internal USB serial link (ch341, `/dev/ttyUSBx`) and speaks a simple framed protocol:

```