### PR TITLE
CI: lint only the shell scripts a PR actually changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,40 @@ jobs:
         run: sudo apt-get update -qq && sudo apt-get install -y -qq shellcheck
 
       - name: Lint shell scripts
-        run: find scripts/ -name '*.sh' ! -path '*.venv/*' -exec shellcheck -x {} +
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          set -eu
+          if [ -n "$BASE_SHA" ]; then
+            git fetch --no-tags --depth=1 origin "$BASE_SHA" >/dev/null 2>&1 || true
+          fi
+          if [ -z "$BASE_SHA" ] || ! git cat-file -e "$BASE_SHA^{commit}" 2>/dev/null; then
+            echo "No base SHA available; skipping shellcheck"
+            exit 0
+          fi
+          files="$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" HEAD)"
+          if [ -z "$files" ]; then
+            echo "No files changed; skipping shellcheck"
+            exit 0
+          fi
+          failed=0
+          for file in $files; do
+            [ -f "$file" ] || continue
+            case "$file" in
+              *.sh)
+                if ! shellcheck -x "$file"; then
+                  failed=1
+                fi
+                ;;
+            esac
+          done
+          if [ "$failed" -eq 1 ]; then
+            echo
+            echo "shellcheck found warnings in changed shell scripts. Fix them and commit again."
+            echo "Use '# shellcheck disable=SCxxxx' with a comment for intentional suppressions."
+            exit 1
+          fi
+          echo "Changed shell scripts pass shellcheck."
 
       - name: Check defconfig sort order
         run: |


### PR DESCRIPTION
## What

The lint job's shellcheck step ran `find scripts/ -name '*.sh'` and shellchecked **every** script in the tree on every pull request. Any pre-existing (or shellcheck-version-sensitive) finding anywhere in `scripts/` - including `info`-level suggestions - failed unrelated PRs.

## Change

Diff the PR base against HEAD and shellcheck only the `.sh` files that appeared in that diff, reusing the `BASE_SHA` pattern already used by the `Check do-not-edit paths` step. Works for both `pull_request` (base SHA) and `push` (falls back to `github.event.before`) events.

## Why

Observed on PR #1484: an unrelated PR was blocked by pre-existing `SC2015`/`SC2317` info findings in `scripts/cfg-backup.sh` and `scripts/test-snmpd.sh` that the PR never touched.