### PR TITLE
daynight: fix stale "halve FPS" comment

### DIFF
--- a/package/thingino-daynightd/files/daynight
+++ b/package/thingino-daynightd/files/daynight
@@ -124,7 +124,9 @@ controls_color() {
 switch_to_day() {
 	echo_info "Switching to day mode..."
 
-	# Notify prudynt to restore full FPS (day mode)
+	# Notify prudynt of the running mode (day) so it applies the matching
+	# ISP tuning (monochrome/color, AE strategy, IRCUT). Framerate is
+	# left unchanged.
 	if command_present prudyntctl; then
 		prudyntctl json '{"image":{"running_mode":0}}' >/dev/null 2>&1
 	fi
@@ -160,7 +162,9 @@ switch_to_day() {
 switch_to_night() {
 	echo_info "Switching to night mode..."
 
-	# Notify prudynt to halve FPS (night mode)
+	# Notify prudynt of the running mode (night) so it applies the matching
+	# ISP tuning (monochrome/color, AE strategy, IRCUT). Framerate is
+	# left unchanged.
 	if command_present prudyntctl; then
 		prudyntctl json '{"image":{"running_mode":1}}' >/dev/null 2>&1
 	fi


### PR DESCRIPTION
The `running_mode` switch in the daynight script only applies ISP tuning
(monochrome/color, AE strategy, IRCUT). It no longer changes the framerate
— the halving was removed from prudynt, but the comment still claims it
"halves FPS (night mode)" and "restores full FPS (day mode)".

This misled multiple reporters in #1401 into chasing a framerate change
that no longer exists. Update both comments to describe what actually
happens: running-mode notification only, framerate left unchanged.

Refs: https://github.com/themactep/thingino-firmware/issues/1401