### PR TITLE
configs: sort wansview_a1_t23zn_os02g10_atbm6461 defconfig

### DIFF
--- a/configs/cameras/wansview_a1_t23zn_os02g10_atbm6461/wansview_a1_t23zn_os02g10_atbm6461_defconfig
+++ b/configs/cameras/wansview_a1_t23zn_os02g10_atbm6461/wansview_a1_t23zn_os02g10_atbm6461_defconfig
@@ -21,7 +21,6 @@
 #  - GPIO: ircut=57 (single-pin, phwi0 double/single states), ir940=38 (phwi1),
 #    phwi2=GPIO16 (role TBD: audio amp?), led_b=49, led_r=50
 #    All assignments from AJCloud binary analysis; verify on hardware
-
 BR2_INGENIC_SOC_MODEL="t23zn"
 BR2_ISP_CLKA_600MHZ=y
 BR2_ISP_CLKA_SCLKA=y


### PR DESCRIPTION
The defconfig added in 6960c758f was not run through scripts/sort_defconfig.py, leaving an extra blank line at line 24. This causes the lint workflow defconfig sort check to fail for every open PR against master, since the check runs over all defconfigs, not just changed ones.