### PR TITLE
package/compy: make FetchContent dependencies respect the download cache

### DIFF
--- a/package/compy/compy.hash
+++ b/package/compy/compy.hash
@@ -1,0 +1,8 @@
+# Locally calculated: FetchContent dependencies of compy, downloaded via
+# COMPY_EXTRA_DOWNLOADS so they land in the download cache and are
+# hash-checked. The main compy git tarball is exempted via
+# BR_NO_CHECK_HASH_FOR in compy.mk.
+sha256  07b06b29d06eb74798d85e34b2b50af330f5480e96457bcbfd20f5c6f61d1a30  slice99-v0.7.8.tar.gz
+sha256  f38c077afdb91b7d754321be5d3c4a43ed5420c1ad51514d1de20023960f9a8e  datatype99-v1.6.5.tar.gz
+sha256  8bd007c48cf05436ced60884e8e3a05ede46105f3efae9bf29e0f4d30f938f9e  interface99-v1.0.2.tar.gz
+sha256  f3d1607d76b4b081d3295661c4c2b8d5fde4d5018b1aa409c84fb3a6660ffb90  metalang99-v1.13.5.tar.gz

--- a/package/compy/compy.mk
+++ b/package/compy/compy.mk
@@ -15,9 +15,51 @@ COMPY_CONF_OPTS += -DCOMPY_TLS_MBEDTLS=ON
 COMPY_DEPENDENCIES += mbedtls
 endif
 
-# compy's CMakeLists.txt uses FetchContent for header-only macro
-# libraries (slice99, datatype99, interface99, metalang99).
-# These are fetched during the cmake configure step.
+# compy's CMakeLists.txt uses FetchContent to pull in four header-only
+# macro libraries: slice99, datatype99, interface99, and (nested, from
+# datatype99/interface99) metalang99. Fetching them during the cmake
+# configure step bypasses the Buildroot download cache, so a clean build
+# fails whenever GitHub is unreachable or rate-limits us (HTTP 429).
+# Declare them as extra downloads instead, so they are fetched once into
+# the download cache and hash-checked like any other source, and point
+# FetchContent at the pre-extracted directories via
+# FETCHCONTENT_SOURCE_DIR_<NAME> so configure never touches the network.
+COMPY_SLICE99_VERSION = 0.7.8
+COMPY_DATATYPE99_VERSION = 1.6.5
+COMPY_INTERFACE99_VERSION = 1.0.2
+COMPY_METALANG99_VERSION = 1.13.5
+
+COMPY_EXTRA_DOWNLOADS = \
+	https://github.com/Hirrolot/slice99/archive/refs/tags/v$(COMPY_SLICE99_VERSION)/slice99-v$(COMPY_SLICE99_VERSION).tar.gz \
+	https://github.com/Hirrolot/datatype99/archive/refs/tags/v$(COMPY_DATATYPE99_VERSION)/datatype99-v$(COMPY_DATATYPE99_VERSION).tar.gz \
+	https://github.com/Hirrolot/interface99/archive/refs/tags/v$(COMPY_INTERFACE99_VERSION)/interface99-v$(COMPY_INTERFACE99_VERSION).tar.gz \
+	https://github.com/Hirrolot/metalang99/archive/refs/tags/v$(COMPY_METALANG99_VERSION)/metalang99-v$(COMPY_METALANG99_VERSION).tar.gz
+
+# The compy sources themselves come from git, so they have no stable
+# hash; the hashes in compy.hash only cover the extra downloads above.
+BR_NO_CHECK_HASH_FOR += compy-$(COMPY_VERSION).tar.gz
+
+COMPY_CONF_OPTS += \
+	-DFETCHCONTENT_SOURCE_DIR_SLICE99=$(@D)/_deps/slice99-src \
+	-DFETCHCONTENT_SOURCE_DIR_DATATYPE99=$(@D)/_deps/datatype99-src \
+	-DFETCHCONTENT_SOURCE_DIR_INTERFACE99=$(@D)/_deps/interface99-src \
+	-DFETCHCONTENT_SOURCE_DIR_METALANG99=$(@D)/_deps/metalang99-src
+
+# Populate the _deps/<name>-src directories FetchContent would have
+# created, so the install commands below keep working unchanged.
+define COMPY_SETUP_FETCHCONTENT_SOURCES
+	mkdir -p $(@D)/_deps/slice99-src $(@D)/_deps/datatype99-src \
+		$(@D)/_deps/interface99-src $(@D)/_deps/metalang99-src
+	$(TAR) --strip-components=1 -C $(@D)/_deps/slice99-src \
+		-xf $(COMPY_DL_DIR)/slice99-v$(COMPY_SLICE99_VERSION).tar.gz
+	$(TAR) --strip-components=1 -C $(@D)/_deps/datatype99-src \
+		-xf $(COMPY_DL_DIR)/datatype99-v$(COMPY_DATATYPE99_VERSION).tar.gz
+	$(TAR) --strip-components=1 -C $(@D)/_deps/interface99-src \
+		-xf $(COMPY_DL_DIR)/interface99-v$(COMPY_INTERFACE99_VERSION).tar.gz
+	$(TAR) --strip-components=1 -C $(@D)/_deps/metalang99-src \
+		-xf $(COMPY_DL_DIR)/metalang99-v$(COMPY_METALANG99_VERSION).tar.gz
+endef
+COMPY_POST_EXTRACT_HOOKS += COMPY_SETUP_FETCHCONTENT_SOURCES
 
 # No install() rules in upstream CMakeLists.txt, so install manually.
 define COMPY_INSTALL_STAGING_CMDS


### PR DESCRIPTION
compy's CMakeLists.txt uses FetchContent to pull in four header-only macro libraries (slice99, datatype99, interface99, and nested metalang99) from GitHub during the cmake configure step. This bypasses the Buildroot download cache entirely, so a clean build re-downloads them every time and fails whenever GitHub is unreachable or rate-limits us (HTTP 429).

Fix it purely in the packaging layer, without touching upstream sources:

- `COMPY_EXTRA_DOWNLOADS` for the four tarballs, using the `archive/<ref>/<name>-v<version>.tar.gz` URL form so each gets a distinct cacheable filename (the four tags would otherwise collide as bare `v<version>.tar.gz` in `dl/`).
- `compy.hash` with the four sha256 sums, so the extra downloads are hash-checked like any other source.
- `BR_NO_CHECK_HASH_FOR += compy-$(COMPY_VERSION).tar.gz` — critical detail: once a `.hash` file exists for a package, dl-wrapper exit-3 ("no hash for basename") becomes a hard error for the git-method main tarball (only bzr/cvs/hg are auto-exempted).
- `FETCHCONTENT_SOURCE_DIR_<NAME>` cache vars point FetchContent at pre-extracted directories so configure never touches the network.
- A `COMPY_POST_EXTRACT_HOOKS` step untars the cached tarballs into `_deps/<name>-src`, replicating what FetchContent would have created, so the existing staging install commands that copy headers out of `_deps` keep working unchanged.

Dependency pins and hashes verified against the upstream tag tarballs; the nested metalang99 v1.13.5 pin matches both datatype99 and interface99 CMakeLists.txt.

Reported-by: Josh (WLTechBlog)

Not yet compile-tested (no output tree with compy enabled on my host; builds were blocked by today's GitHub outage). Cleanbuild validation happens on this PR.

<!-- git-tree -->