### PR TITLE
hostname: hash unique id before truncating to 4 characters

### DIFF
--- a/overlay/etc/init.d/S04hostname
+++ b/overlay/etc/init.d/S04hostname
@@ -79,7 +79,7 @@ generate() {
 	[ -n "$unique_id" ] || unique_id=$(fw_printenv -n ethaddr 2>/dev/null)
 	[ -n "$unique_id" ] || unique_id=$(cat /sys/class/net/eth0/address 2>/dev/null | tr -d ':')
 	[ -n "$unique_id" ] || unique_id=$(cat /sys/class/net/wlan0/address 2>/dev/null | tr -d ':')
-	local generated_hostname="$(default_hostname)-$(echo $unique_id | sed -E 's/://g;s/.*(.{4})$/\1/')"
+	local generated_hostname="$(default_hostname)-$(printf '%s' "$unique_id" | sha256sum | cut -c1-4)"
 
 	echo -c 240 -e "- Generated name: $generated_hostname"
 	set_hostname "$generated_hostname" "auto-generated"


### PR DESCRIPTION
Same-batch cameras get identical auto-generated hostnames. `soc -s` returns a genuinely unique per-chip serial, but S04hostname takes the last 4 raw characters — and serials from one manufacturing batch share a trailing digit sequence:

```
camera 1: 22606080725602754573019939840
camera 3: 20705603895602713613019939840
                                    tail -> both become jooan_a6m-9840
```

Fix: hash the unique id (sha256) before truncating to 4 characters:

```sh
# before
local generated_hostname="$(default_hostname)-$(echo $unique_id | sed -E 's/://g;s/.*(.{4})$/\1/')"
# after
local generated_hostname="$(default_hostname)-$(printf '%s' "$unique_id" | sha256sum | cut -c1-4)"
```

Notes:
- Uniform distribution regardless of serial structure; batch-correlated tails can no longer collide
- Output is lowercase hex, matching the existing `[0-9a-f]{4}` auto-generated hostname pattern — no check changes needed
- Legacy tail-4 hostnames (digits) still match that pattern, so upgraded cameras regenerate to the new scheme automatically
- `sha256sum` (busybox) is already used by `S98provision` in the same rootfs
- Colons from MAC fallbacks are hashed as-is; the explicit `sed `s/://g`` strip is no longer needed

Verified: the two colliding serials above now produce `5ce2` / `0fd7`.

Reported-by: Nic
