### PR TITLE
thingino-diag: add per-command watchdog to prevent hangs on wedged subsystems

### DIFF
--- a/package/thingino-diag/files/thingino-diag
+++ b/package/thingino-diag/files/thingino-diag
@@ -22,6 +22,11 @@ Options:
 	-f               Force: skip consent prompt
 	-h               Show this help
 
+Environment:
+	DIAG_CMD_TIMEOUT  Per-command watchdog in seconds (default: 15).
+	                  Commands blocked by a wedged daemon are killed
+	                  and noted in the report instead of hanging.
+
 Legacy options:
 	-l [path]        Save to local file (default: /tmp)
 
@@ -43,9 +48,30 @@ infocat() {
 	cat "$1"
 }
 
+# Per-command watchdog. Commands that talk to the IMP/ISP layer
+# (libimp-debug, sensor, lsusb) or wireless tools can block
+# indefinitely when the underlying daemon or hardware is wedged;
+# without a timeout the whole diagnostics run hangs.
+DIAG_CMD_TIMEOUT="${DIAG_CMD_TIMEOUT:-15}"
+
 inforun() {
 	tmp=$(mktemp) || exit 1
-	eval "$1" >"$tmp"
+	eval "$1" >"$tmp" &
+	cmd_pid=$!
+	(
+		sleep "$DIAG_CMD_TIMEOUT"
+		kill "$cmd_pid" 2>/dev/null
+		sleep 1
+		kill -9 "$cmd_pid" 2>/dev/null
+	) &
+	watchdog_pid=$!
+	wait "$cmd_pid" 2>/dev/null
+	cmd_status=$?
+	kill "$watchdog_pid" 2>/dev/null
+	wait "$watchdog_pid" 2>/dev/null
+	if [ "$cmd_status" -ge 128 ]; then
+		echo "! command killed after ${DIAG_CMD_TIMEOUT}s (subsystem may be wedged): $1" >>"$tmp"
+	fi
 	if [ -s "$tmp" ]; then
 		[ -n "$2" ] && header "$2"
 		cat "$tmp"


### PR DESCRIPTION
## Problem

When a camera subsystem is wedged (e.g. rvd dead and the IMP layer unresponsive), `thingino-diag` hangs indefinitely instead of producing a report. Observed live on a T23N camera: `libimp-debug --system_info` blocked forever after an rvd crash, so `thingino-diag -u` never finished and never uploaded — exactly when a diagnostics report is most needed.

Blocked commands seen in the wild:
- `libimp-debug --system_info / --fs_info / --enc_info` (IMP layer queries)
- `sensor -a`
- `lsusb` (USB WiFi dongles)

## Change

`inforun()` now runs each command under a background watchdog (`DIAG_CMD_TIMEOUT`, default 15 s, env-overridable, documented in `-h`). If the timeout hits, the command is killed (TERM then KILL after 1 s) and a note is appended to the report section:

```
! command killed after 15s (subsystem may be wedged): libimp-debug --system_info
```

so the note itself is diagnostic data. Empty-output behavior is unchanged.

## Implementation notes

A sleep+kill subshell is used rather than busybox `timeout` because several captured commands are pipelines or `(a || b)` lists (e.g. the WIFI-INFO, NETWORK and ROUTE sections) which `timeout` cannot wrap. Tested locally with a hang-simulation harness: normal commands pass through, infinite commands are killed at the deadline with the note written, pipelines and or-lists behave identically.

## Credit

Reported-by: **DoctorBob** (Discord)
Requested-by: **gtxaspec**
