### PR TITLE
overlay: derive hostname suffix from the same serial->MAC function

### DIFF
--- a/overlay/etc/init.d/S03mac
+++ b/overlay/etc/init.d/S03mac
@@ -1,4 +1,5 @@
 #!/bin/sh
+# shellcheck disable=SC2004,SC2086,SC1091,SC2154
 
 CONFIG_JSON="/etc/thingino.json"
 
@@ -7,34 +8,10 @@ command -v jct >/dev/null 2>&1 || exit 0
 # If eth.mac already set, nothing to do
 jct "$CONFIG_JSON" get eth.mac >/dev/null 2>&1 && exit 0
 
-# Read SoC serial number registers
-b1=$(devmem 0x13540200 2>/dev/null) || exit 0
-b2=$(devmem 0x13540204 2>/dev/null) || exit 0
-b3=$(devmem 0x13540208 2>/dev/null) || exit 0
-b4=$(devmem 0x1354023C 2>/dev/null) || exit 0
+# Shared serial -> MAC derivation (also used for the hostname suffix)
+. /etc/init.d/lib-serial-mac
 
-# Convert to integer
-b1=$((b1))
-b2=$((b2))
-b3=$((b3))
-b4=$((b4))
-
-# All zero means no serial number available
-[ "$b1" -eq 0 ] && [ "$b2" -eq 0 ] && [ "$b3" -eq 0 ] && [ "$b4" -eq 0 ] && exit 0
-
-# Generate ETH MAC address (algorithm from U-Boot cmd_ethaddr.c)
-if [ "$b4" -ne 0 ]; then
-	m1=$(((b4 >> 24) & 255))
-	m2=$(((b4 >> 16) & 255))
-	m3=$(((b4 >> 8) & 255))
-	m4=$((b4 & 255))
-else
-	m1=$(((b1 >> 24) & 255))
-	m2=$(((b1 >> 16) & 255))
-	m3=$(((b2 >> 24) & 255))
-	m4=$(((b2 >> 16) & 255))
-fi
-m5=$((((b1 ^ b2 ^ b3 ^ b4) & 255) | 1))
+derive_serial_mac || exit 0
 
 eth_mac=$(printf "02:%02x:%02x:%02x:%02x:%02x" $m1 $m2 $m3 $m4 $m5)
 echo -c 240 -e "- Generated ETH MAC: $eth_mac"

--- a/overlay/etc/init.d/S04hostname
+++ b/overlay/etc/init.d/S04hostname
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck disable=SC2005,SC2034,SC2086,SC2155,SC3043
+# shellcheck disable=SC2005,SC2034,SC2086,SC2155,SC3043,SC1091,SC2154
 
 HOSTNAME_FILE="/etc/hostname"
 HOSTS_FILE="/etc/hosts"
@@ -74,12 +74,21 @@ set_hostname() {
 
 generate() {
 	local unique_id
-	unique_id=$(command -v soc >/dev/null 2>&1 && soc -s 2>/dev/null)
-	[ -n "$unique_id" ] || unique_id=$(jct /etc/thingino.json get wlan.mac 2>/dev/null || fw_printenv -n wlan_mac 2>/dev/null)
-	[ -n "$unique_id" ] || unique_id=$(fw_printenv -n ethaddr 2>/dev/null)
-	[ -n "$unique_id" ] || unique_id=$(cat /sys/class/net/eth0/address 2>/dev/null | tr -d ':')
-	[ -n "$unique_id" ] || unique_id=$(cat /sys/class/net/wlan0/address 2>/dev/null | tr -d ':')
-	local generated_hostname="$(default_hostname)-$(echo $unique_id | sed -E 's/://g;s/.*(.{4})$/\1/')"
+	local suffix
+
+	# Same serial -> MAC derivation as S03mac
+	if [ -r /etc/init.d/lib-serial-mac ] && . /etc/init.d/lib-serial-mac && derive_serial_mac; then
+		unique_id=$(printf "%02x%02x%02x%02x%02x" $m1 $m2 $m3 $m4 $m5)
+	else
+		# Fall back to an already-assigned MAC
+		unique_id=$(jct /etc/thingino.json get wlan.mac 2>/dev/null || fw_printenv -n wlan_mac 2>/dev/null)
+		[ -n "$unique_id" ] || unique_id=$(fw_printenv -n ethaddr 2>/dev/null)
+		[ -n "$unique_id" ] || unique_id=$(cat /sys/class/net/eth0/address 2>/dev/null | tr -d ':')
+		[ -n "$unique_id" ] || unique_id=$(cat /sys/class/net/wlan0/address 2>/dev/null | tr -d ':')
+	fi
+
+	suffix=$(echo "$unique_id" | sed -E 's/://g;s/.*(.{4})$/\1/')
+	local generated_hostname="$(default_hostname)-$suffix"
 
 	echo -c 240 -e "- Generated name: $generated_hostname"
 	set_hostname "$generated_hostname" "auto-generated"

--- a/overlay/etc/init.d/lib-serial-mac
+++ b/overlay/etc/init.d/lib-serial-mac
@@ -1,0 +1,36 @@
+#!/bin/sh
+# shellcheck disable=SC2004,SC2034,SC2086
+#
+# Serial number -> MAC derivation (U-Boot cmd_ethaddr.c), shared by
+# S03mac and S04hostname. Sourced, not an init entry point.
+
+# Sets m1..m5 from the serial registers; returns 1 when none is present.
+derive_serial_mac() {
+	b1=$(devmem 0x13540200 2>/dev/null) || return 1
+	b2=$(devmem 0x13540204 2>/dev/null) || return 1
+	b3=$(devmem 0x13540208 2>/dev/null) || return 1
+	b4=$(devmem 0x1354023C 2>/dev/null) || return 1
+
+	b1=$((b1))
+	b2=$((b2))
+	b3=$((b3))
+	b4=$((b4))
+
+	# All zero means no serial number
+	[ "$b1" -eq 0 ] && [ "$b2" -eq 0 ] && [ "$b3" -eq 0 ] && [ "$b4" -eq 0 ] && return 1
+
+	if [ "$b4" -ne 0 ]; then
+		m1=$(((b4 >> 24) & 255))
+		m2=$(((b4 >> 16) & 255))
+		m3=$(((b4 >> 8) & 255))
+		m4=$((b4 & 255))
+	else
+		m1=$(((b1 >> 24) & 255))
+		m2=$(((b1 >> 16) & 255))
+		m3=$(((b2 >> 24) & 255))
+		m4=$(((b2 >> 16) & 255))
+	fi
+
+	m5=$((((b1 ^ b2 ^ b3 ^ b4) & 255) | 1))
+	return 0
+}


### PR DESCRIPTION
S03mac derives the ETH/WLAN MAC from the SoC serial number registers (algorithm from U-Boot cmd_ethaddr.c). S04hostname previously derived its suffix by taking the last 4 chars of the raw serial/MAC, which collides across similar hardware and drifts from the MAC derivation.

Extract the serial->MAC byte derivation into a shared library (overlay/etc/init.d/lib-serial-mac) and have both scripts source it:

- S03mac builds the full ETH/WLAN MAC from the shared m1..m5 bytes.
- S04hostname uses the same derivation for its suffix (last 4 hex chars of the derived MAC, minus colons), falling back to an already-assigned MAC when no serial number is present.

This keeps the hostname and the MAC in lockstep, coming from one source of truth instead of a hash.

Referenced by the closure of PRs #1491 and #1492.