### PR TITLE
sysupgrade: install cfg-backup and preserve config backups on full upgrades (ciao)

### DIFF
--- a/docs/sysupgrade.md
+++ b/docs/sysupgrade.md
@@ -135,6 +135,13 @@ Anything else → aborts with an error.
 
 Stores selected config files to the raw 64KB backup partition (mtd2) before flashing.
 
+`sysupgrade` calls `cfg-backup write` before flashing (and `fw_ota.sh` does the same for
+`ota-upgrade`). On rootfs/kernel-only upgrades the backup partition is untouched, so the
+snapshot survives the flash. On full upgrades (`-f` / `-B`) the image is flashed
+partition-by-partition; `sysupgrade` snapshots the config first and then skips the backup
+region, so the snapshot written moments earlier is preserved. Run `cfg-backup restore`
+manually after the reboot to put the files back into the fresh system.
+
 ```sh
 # Manually (on the camera):
 cfg-backup write                     # backs up everything in /etc/cfg-backup.list

--- a/package/thingino-sysupgrade/files/sysupgrade
+++ b/package/thingino-sysupgrade/files/sysupgrade
@@ -342,7 +342,7 @@ handle_payload() {
 
 		echo_c 112 "\nDownload firmware"
 		if [ -n "$curl_range" ]; then
-			# curl range request – use -o to write directly
+			# curl range request - use -o to write directly
 			echo "Range: $curl_range"
 			if ! curl -fL# --url "$bin_url" -o "$fw_file" $curl_range; then
 				die "Cannot download firmware from specified URL."
@@ -549,7 +549,7 @@ case "$1" in
 		esac
 		;;
 	"")
-		# No file argument – default to GitHub for modes that support it
+		# No file argument - default to GitHub for modes that support it
 		case "$upgrade" in
 			rootfs | kernel | boot) url="$GITHUB_URL" ;;
 		esac
@@ -656,7 +656,7 @@ extract_rootfs_data() {
 		echo "Appended data partition: $((src_size - sqfs_aligned)) bytes"
 		dd if="$src" of="$workdir/data.bin" bs=1 skip=$sqfs_aligned 2>/dev/null
 	else
-		echo "No appended data — data partition unchanged"
+		echo "No appended data - data partition unchanged"
 	fi
 }
 
@@ -684,6 +684,18 @@ PARTLIST
 
 get_mtd_size() { awk "/\"$1\"$/{print \"0x\"\$2}" /proc/mtd; }
 get_mtd_dev() { awk -F: "/\"$1\"$/{print \$1}" /proc/mtd; }
+
+# Snapshot config files to the backup MTD partition before flashing.
+# cfg-backup is installed by this package (scripts/cfg-backup.sh).
+create_config_backup() {
+	[ "$do_backup" = "true" ] || return 0
+	echo_c 112 "\nCreating config backup before upgrade"
+	if cfg-backup write 2>/dev/null; then
+		echo "Config backup written to /dev/$(get_mtd_dev backup)"
+	else
+		echo_c 160 "Warning: cfg-backup failed (non-fatal)"
+	fi
+}
 # --- end helpers ---
 
 # upgrade bootloader only
@@ -795,7 +807,7 @@ if [ "rootfs" = "$upgrade" ]; then
 		sync
 		flash_partition "/dev/$ddev" "$workdir/data.bin" || die "data flash failed"
 	else
-		echo "No data partition in image — data unchanged"
+		echo "No data partition in image - data unchanged"
 	fi
 
 	echo_c 46 "\nRootfs upgrade complete. Rebooting..."
@@ -812,6 +824,7 @@ if [ -z "$mtd_dev" ]; then
 			# Full upgrade: flash each partition individually.
 			# Writing to "all" fails on kernels that protect overlapping MTD regions.
 			echo "Full firmware upgrade"
+			create_config_backup
 			# Clone busybox to tmpfs before the dd loop so that
 			# reboot -f runs from tmpfs, not the soon-to-be-overwritten rootfs.
 			clone_app /bin/busybox
@@ -864,6 +877,14 @@ if [ -z "$mtd_dev" ]; then
 				[ "$name" = "upgrade" ] && continue
 				[ "$needle" -ge "$fw_size" ] && break
 				sz_dec=$((0x$sz))
+				# The config backup written above lives on the backup partition;
+				# the image carries that region erased (0xFF). Skip it so the
+				# snapshot survives the full upgrade.
+				if [ "$do_backup" = "true" ] && [ "$name" = "backup" ]; then
+					echo_c 112 "Keeping config backup on $name"
+					needle=$((needle + sz_dec))
+					continue
+				fi
 				echo_c 112 "Flashing $name to /dev/$mtd ($sz_dec bytes at offset $needle)"
 				flash_eraseall "/dev/$mtd" 2>/dev/null || true
 				bs=$align_block
@@ -881,7 +902,7 @@ if [ -z "$mtd_dev" ]; then
 			echo_c 46 "Full upgrade complete. Rebooting..."
 			sync
 			# Disarm the tmpfs watchdog before triggering the WDT reset.
-			# Use the tmpfs busybox for every command — rootfs may already
+			# Use the tmpfs busybox for every command - rootfs may already
 			# be overwritten, so rootfs binaries can segfault.
 			$workdir/busybox killall watchdog 2>/dev/null && $workdir/busybox sleep 1
 			$workdir/busybox sleep 5
@@ -920,14 +941,7 @@ if [ -z "$mtd_dev" ]; then
 fi # end of [ -z "$mtd_dev" ] guard
 
 # --- config backup ---
-if [ "$do_backup" = "true" ]; then
-	echo_c 112 "\nCreating config backup before upgrade"
-	if cfg-backup write 2>/dev/null; then
-		echo "Config backup written to /dev/mtd2"
-	else
-		echo_c 160 "Warning: cfg-backup failed (non-fatal)"
-	fi
-fi
+create_config_backup
 # --- end backup ---
 
 #stop_services

--- a/package/thingino-sysupgrade/thingino-sysupgrade.mk
+++ b/package/thingino-sysupgrade/thingino-sysupgrade.mk
@@ -10,6 +10,9 @@ define THINGINO_SYSUPGRADE_INSTALL_TARGET_CMDS
 
 	$(INSTALL) -D -m 0755 $(THINGINO_SYSUPGRADE_PKGDIR)/files/sysupgrade-stage2 \
 		$(TARGET_DIR)/usr/sbin/sysupgrade-stage2
+
+	$(INSTALL) -D -m 0755 $(BR2_EXTERNAL_THINGINO_PATH)/scripts/cfg-backup.sh \
+		$(TARGET_DIR)/usr/sbin/cfg-backup
 endef
 
 $(eval $(generic-package))

--- a/scripts/cfg-backup.sh
+++ b/scripts/cfg-backup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # shellcheck shell=bash
-# cfg-backup — read/write config tarball to the raw 64KB backup MTD partition
+# cfg-backup - read/write config tarball to the raw 64KB backup MTD partition
 #
 # Usage:
 #   cfg-backup write [paths...]    (defaults to /etc/cfg-backup.list)
@@ -12,11 +12,11 @@
 #   md5=<32 hex>\n
 #   (padded with \n)
 #
-# Payload: tar (uncompressed — busybox tar lacks gzip)
+# Payload: tar (uncompressed - busybox tar lacks gzip)
 
 set -e
 
-MTD=${CFG_BACKUP_MTD:-/dev/mtd2}
+MTD=${CFG_BACKUP_MTD:-}
 HEADER_SIZE=64
 MAX_PAYLOAD=$((65536 - HEADER_SIZE))
 LIST_FILE=/etc/cfg-backup.list
@@ -25,6 +25,13 @@ die() {
 	echo "cfg-backup: $*" >&2
 	exit 1
 }
+
+# Resolve the backup MTD partition by name - partition numbers are not
+# stable across flash layouts (NOR vs NAND). $CFG_BACKUP_MTD overrides.
+if [ -z "$MTD" ]; then
+	MTD="/dev/$(awk -F: '/"backup"$/{print $1}' /proc/mtd)"
+fi
+[ -e "$MTD" ] || die "backup MTD partition not found ($MTD)"
 
 # Try to erase the MTD partition. Uses flash_eraseall (whole partition)
 # or flash_erase (count blocks to cover the partition size).
@@ -52,10 +59,26 @@ do_write() {
 			[ -n "$line" ] && set -- "$@" "$line"
 		done <"$LIST_FILE"
 	else
-		# CLI paths given — still prepend the list file so backups are
+		# CLI paths given - still prepend the list file so backups are
 		# self-describing.
 		set -- "$LIST_FILE" "$@"
 	fi
+
+	# Drop paths that do not exist so tar does not abort midway
+	# (the default list may name files a given camera does not have).
+	_count=$#
+	_i=0
+	while [ "$_i" -lt "$_count" ]; do
+		_p=$1
+		shift
+		if [ -e "$_p" ]; then
+			set -- "$@" "$_p"
+		else
+			echo "cfg-backup: skipping missing path: $_p" >&2
+		fi
+		_i=$((_i + 1))
+	done
+	[ $# -gt 0 ] || die "nothing to back up"
 
 	tmpd=$(mktemp -d)
 	trap 'rm -rf "$tmpd"' EXIT
@@ -105,7 +128,7 @@ do_restore() {
 	dd if="$tmpd/full" of="$tmpd/payload" bs=1 skip="$HEADER_SIZE" count="$sz" 2>/dev/null
 	computed_md5=$(md5sum "$tmpd/payload" | awk '{print $1}')
 
-	[ "$stored_md5" = "$computed_md5" ] || die "MD5 mismatch — backup is corrupt"
+	[ "$stored_md5" = "$computed_md5" ] || die "MD5 mismatch - backup is corrupt"
 
 	tar xf "$tmpd/payload" -C / || die "tar extract failed"
 	echo "cfg-backup: $sz bytes restored from $MTD"

--- a/scripts/fw_ota.sh
+++ b/scripts/fw_ota.sh
@@ -11,7 +11,7 @@ die() {
 }
 
 set -eu
-# NOTE: no pipefail — the sysupgrade pipeline at line ~261 captures
+# NOTE: no pipefail - the sysupgrade pipeline at line ~261 captures
 # ${PIPESTATUS[0]} to check remote_run's exit code independently of
 # tee; pipefail would kill the script before PIPESTATUS can be read.
 
@@ -343,7 +343,7 @@ upload_flash_ota() {
 free_overlay_space
 
 if [ "$MODE" = "full" ]; then
-	# Full firmware — use traditional sysupgrade
+	# Full firmware - use traditional sysupgrade
 	echo "Transferring sysupgrade utility to device..."
 	upload_sysupgrade
 
@@ -398,7 +398,7 @@ if [ "$MODE" = "full" ]; then
 	die "Failed to flash firmware"
 fi
 
-# Boot / kernel / rootfs — use minimal flash-ota
+# Boot / kernel / rootfs - use minimal flash-ota
 
 echo "Transferring flash-ota utility to device..."
 upload_flash_ota
@@ -483,6 +483,11 @@ esac
 echo "Partition files uploaded."
 
 remote_run "touch /tmp/needs_reboot" || true
+
+if [ "$DO_BACKUP" -eq 1 ] && [ "$MODE" = "rootfs" ]; then
+	echo "Creating config backup on device..."
+	remote_run "cfg-backup write" || echo "Warning: cfg-backup failed (non-fatal)"
+fi
 
 echo "Flashing..."
 remote_run "$FLASH_CMD" || true


### PR DESCRIPTION
Backport of #1496 to ciao (256K boot partition).

Same change set, byte-identical hunks to the master PR, with ciao's own layout deltas preserved:
- `BRANCH="ciao"` (GitHub release branch)
- `range_end=$((256 * 1024 - 1))` and 256KB boot padding in `fw_ota.sh`

No hardcoded offsets in the fix itself: `cfg-backup` resolves the backup MTD by name from `/proc/mtd` and the full-upgrade loop walks the camera's partition table, so the backup lands at 320K (256K boot + 64K env) here vs 384K on master automatically.

## What it does

- **`scripts/cfg-backup.sh`** installed as `/usr/sbin/cfg-backup` via thingino-sysupgrade (was referenced by `sysupgrade -B` but never shipped — backups silently never happened)
  - backup MTD resolved by name from `/proc/mtd` (`CFG_BACKUP_MTD` overrides)
  - missing manifest paths dropped so busybox `tar` does not abort
  - ASCII-only
- **`sysupgrade`**: `-f -B` now snapshots config before the per-partition flash loop and skips the backup partition (`Keeping config backup on backup`) so the snapshot survives the full-chip flash
- **`fw_ota.sh`**: honors `-B` in rootfs mode
- **`docs/sysupgrade.md`**: documents `-B` behavior across upgrade modes

## Checks

- shellcheck clean, shfmt clean, `sh -n` clean, ASCII-only
- same field-tested flow as #1496 (validated on master hardware)