### PR TITLE
motors: one logical frame for tilt, honour invert_x/invert_y once, reload without modprobe

### DIFF
--- a/package/thingino-motors/0001-motor-daemon-apply-inversion-to-absolute-positions.patch
+++ b/package/thingino-motors/0001-motor-daemon-apply-inversion-to-absolute-positions.patch
@@ -1,0 +1,163 @@
+From: Lu-Fi <lutz@fiebach.de>
+Date: Sun, 16 Aug 2026 18:20:00 +0200
+Subject: [PATCH] motor-daemon: apply axis inversion to absolute positions too
+
+motor_steps_impl() converts relative moves out of the caller's logical
+frame into raw motor steps, so invert_x/invert_y work for the web UI
+arrows, ptz-ctrl and ONVIF RelativeMove. Absolute positions never got
+the same treatment: the 'h' handler subtracted the raw current position
+from the requested target and then pre-inverted the delta so the two
+inversions cancelled, and the status replies handed the raw counter
+straight back out. An absolute target therefore addressed the raw frame
+and ignored inversion entirely.
+
+That is not a corner case. ONVIF ContinuousMove implements "pan right"
+as an absolute move to max_step_x (see the move_x/move_y/move_both
+commands in onvif.json), so on an inverted unit ONVIF and the web UI
+drove the same axis in opposite physical directions, and no amount of
+invert_x/invert_y changed the ONVIF one.
+
+Convert at the IPC boundary instead: mirror an incoming absolute target
+into the raw frame, and mirror the reported position back out. For a
+bounded axis the relation is L = max - R rather than a sign flip, and it
+is its own inverse. Internal logic (homing, clamping, the profiled move
+worker) keeps working in raw steps and is untouched, and because the
+conversion sits on the socket, no caller can reach the motors in the raw
+frame by accident.
+
+Note for anyone with a stored pos_0 or ptz_presets entry on an inverted
+axis: those were recorded in the raw frame and are now read as logical,
+so they need re-saving (or mirroring once) on inverted units.
+---
+--- a/src/motor-daemon.c	2026-08-16 18:18:32.827784675 +0200
++++ b/src/motor-daemon.c	2026-08-16 18:21:27.594754094 +0200
+@@ -445,6 +445,15 @@
+   if (parsed) {
+     sanitize_axis_cfg(&g_cfg.pan);
+     sanitize_axis_cfg(&g_cfg.tilt);
++    // pos_0 / home_pan / home_tilt are written by humans and by the web UI,
++    // so they are logical like every other coordinate that crosses the socket.
++    // Everything that consumes g_cfg.*.home below (limit seeding, the homing
++    // center target) works in raw steps, so mirror once here and let the rest
++    // of the daemon stay raw.
++    if (g_cfg.pan.max_steps > 0 && (motor_inversion_state & MOTOR_INVERT_X))
++      g_cfg.pan.home = g_cfg.pan.max_steps - g_cfg.pan.home;
++    if (g_cfg.tilt.max_steps > 0 && (motor_inversion_state & MOTOR_INVERT_Y))
++      g_cfg.tilt.home = g_cfg.tilt.max_steps - g_cfg.tilt.home;
+     g_cfg.loaded = true;
+   } else {
+     syslog(LOG_DEBUG, "Config file missing required keys; using defaults");
+@@ -1075,6 +1084,53 @@
+     *dy = -*dy;
+ }
+ 
++// Coordinate frames.
++//
++// Everything inside this daemon - homing, clamping, the kernel counter itself
++// - works in RAW steps, which run in whatever direction the hardware happens
++// to be wired. Everything outside it (the web UI, ONVIF, ptz_presets, the init
++// script) speaks a LOGICAL frame in which +x/+y always mean the same apparent
++// direction on screen, whichever way this particular unit is mounted.
++//
++// Relative moves were already converted, by motor_steps_impl(). Absolute
++// positions were not: an absolute target and a reported position both went
++// through untranslated, so a caller that says "go to x=3700" reached the same
++// physical end stop no matter what invert_x said, while "jog by +100" went the
++// other way. ONVIF ContinuousMove is exactly such a caller - it implements
++// "pan right" as an absolute move to max_step_x - which is why inversion had
++// no effect on it.
++//
++// For a bounded axis the logical/raw relation is a mirror, L = max - R, not a
++// sign flip; the mapping is its own inverse, so one helper serves both ways.
++// Applied at the IPC boundary only (request in, reply out) so that no caller
++// can reach the motors in the raw frame, and no internal logic has to care.
++static int axis_mirror(int value, unsigned int max_steps, bool inverted) {
++  if (!inverted || max_steps == 0)
++    return value;
++  return (int)max_steps - value;
++}
++
++static int motor_x_to_raw(int logical, const struct motor_message *msg) {
++  return axis_mirror(logical, msg->x_max_steps,
++                     (motor_inversion_state & MOTOR_INVERT_X) != 0);
++}
++
++static int motor_y_to_raw(int logical, const struct motor_message *msg) {
++  return axis_mirror(logical, msg->y_max_steps,
++                     (motor_inversion_state & MOTOR_INVERT_Y) != 0);
++}
++
++// Status as the outside world should see it: raw counter mirrored back into
++// the logical frame, so that a position read here can be handed straight back
++// as an absolute target.
++static void motor_status_get_logical(struct motor_message *msg) {
++  motor_status_get(msg);
++  msg->x = axis_mirror(msg->x, msg->x_max_steps,
++                       (motor_inversion_state & MOTOR_INVERT_X) != 0);
++  msg->y = axis_mirror(msg->y, msg->y_max_steps,
++                       (motor_inversion_state & MOTOR_INVERT_Y) != 0);
++}
++
+ static void dispatch_profiled_move(int xsteps, int ysteps, int speed,
+                                    const char *log_tag) {
+   if (start_profiled_move_async(xsteps, ysteps, speed) == 0) {
+@@ -1629,13 +1685,22 @@
+           break;
+         case 'h': // absolute movement
+           motor_status_get(&motor_message);
++          // The target arrives in the logical frame; everything below this
++          // point is raw. An axis the caller did not specify keeps the raw
++          // current position, so it must not be mirrored.
+           if (request_message.got_x == 0)
+             request_message.x =
+                 motor_message.x; // as we are rewriting initial between requests
+                                  // this should not be necessary but leaving as
+                                  // is as to not break anything
++          else
++            request_message.x =
++                motor_x_to_raw(request_message.x, &motor_message);
+           if (request_message.got_y == 0)
+             request_message.y = motor_message.y;
++          else
++            request_message.y =
++                motor_y_to_raw(request_message.y, &motor_message);
+           {
+             int target_x = request_message.x;
+             int target_y = request_message.y;
+@@ -1741,23 +1806,23 @@
+         // This doesnt seem right, we are returning current information instead
+         // of initial parameters not correcting for now, as we want to have
+         // functional parity
+-        motor_status_get(&motor_message);
++        motor_status_get_logical(&motor_message);
+         syslog(LOG_DEBUG, "Got current status to load into command");
+         write(clientfd, &motor_message, sizeof(struct motor_message));
+         break;
+       case 'j': // get json
+-        motor_status_get(&motor_message);
++        motor_status_get_logical(&motor_message);
+         syslog(LOG_DEBUG, "Got current status to load into command");
+         write(clientfd, &motor_message, sizeof(struct motor_message));
+         break;
+       case 'p': // get simple x y position
+-        motor_status_get(&motor_message);
++        motor_status_get_logical(&motor_message);
+         syslog(LOG_DEBUG, "Got current status to load into command");
+         write(clientfd, &motor_message, sizeof(struct motor_message));
+ 
+         break;
+       case 'b': // is busy
+-        motor_status_get(&motor_message);
++        motor_status_get_logical(&motor_message);
+         syslog(LOG_DEBUG, "Got current status to load into command");
+         write(clientfd, &motor_message, sizeof(struct motor_message));
+ 
+@@ -1793,7 +1858,7 @@
+         }
+         break;
+       case 'S': // show status
+-        motor_status_get(&motor_message);
++        motor_status_get_logical(&motor_message);
+         motor_message.inversion_state = motor_inversion_state;
+         write(clientfd, &motor_message, sizeof(struct motor_message));
+         syslog(LOG_DEBUG, "Sent motor status");

--- a/package/thingino-motors/0002-motors-add-R-config-reload-command.patch
+++ b/package/thingino-motors/0002-motors-add-R-config-reload-command.patch
@@ -1,0 +1,229 @@
+From: Lu-Fi <lutz@fiebach.de>
+Date: Sun, 16 Aug 2026 21:55:00 +0200
+Subject: [PATCH] motors: add 'R' IPC command - reload config without touching
+ the kernel module
+
+On the GPIO/TCU driver path invert_x/invert_y are not kernel module
+parameters at all; motors-daemon reads them from /etc/thingino.json once
+in load_config_file() at startup. The only way to make a change take
+effect used to be restarting the whole motor stack, and "S59motor
+restart" does a modprobe -r / modprobe cycle that has produced a real
+kernel oops ("Unable to handle kernel paging request", recursive fault,
+reboot required) on a live Cinnado D1. A config flip as small as
+invert_y therefore currently costs a full reboot.
+
+Add a reload path that never goes near the kernel module:
+
+- daemon: new 'R' IPC command re-runs load_config_file() and re-derives
+  the default speed, then acks with the fresh logical status so the
+  caller can verify the new inversion state. It issues no ioctl beyond
+  the ordinary status read for the ack; the position counter lives in
+  the kernel driver and is untouched. Any in-flight profiled move is
+  cancelled first (the async workers read g_cfg without locking) and
+  allowed to wind down before the config is rewritten under it.
+
+- load_config_file() now zeroes motor_inversion_state before parsing.
+  parse_modern_layout() XORs invert_x/invert_y into that state, so
+  without the reset a reload with an unchanged file would toggle
+  inversion straight back off. Startup behavior is unchanged (the state
+  was already zero there); runtime "motors -I" toggles are discarded by
+  a reload, exactly as a daemon restart always discarded them.
+
+- CLI: "motors -R" sends the command and prints the acked status JSON.
+  Against an older daemon (no 'R' handler) the connection is closed
+  without a reply; detect the short read and fail loudly instead of
+  pretending the reload happened.
+
+Keys that really are kernel module parameters (gpio pins, steps_pan/
+steps_tilt as hmaxstep/vmaxstep) are re-read into g_cfg but cannot
+reprogram the loaded module; those still need a full stop/start.
+
+A SIGHUP-based reload was considered and rejected: daemonsetup()
+deliberately ignores SIGHUP, load_config_file() is nothing like
+async-signal-safe, and the main loop treats accept() == -1 (which an
+unhandled EINTR would produce) as a fatal error, so a signal path would
+have to touch all of that for no benefit over an IPC verb that runs in
+the same thread as every other config-mutating command ('I', 's') and
+can acknowledge synchronously.
+---
+--- a/src/motor-daemon.c	2026-08-16 21:51:48.268557515 +0200
++++ b/src/motor-daemon.c	2026-08-16 21:52:42.960063133 +0200
+@@ -308,7 +308,9 @@
+     parsed = true;
+   }
+   // Apply config-time axis inversion (invert_x / invert_y from thingino.json).
+-  // These XOR into motor_inversion_state so runtime IPC toggles still work.
++  // load_config_file() zeroes motor_inversion_state before calling here, so
++  // these XORs act as an idempotent set; runtime "motors -I" IPC toggles then
++  // XOR on top until the next reload/restart.
+   bool invert_x = false, invert_y = false;
+   if (json_get_bool_jct(motors, "invert_x", &invert_x)) {
+     if (invert_x)
+@@ -423,6 +425,13 @@
+ static void load_config_file(void) {
+   JsonValue *root = parse_json_file("/etc/thingino.json");
+   reset_config_defaults();
++  // The config file is authoritative for axis inversion on every (re)load.
++  // parse_modern_layout() XORs invert_x/invert_y into this state, so it must
++  // start from a known zero: without this reset, a reload ('R' command) with
++  // an unchanged file would toggle inversion straight back OFF. This also
++  // discards any runtime "motors -I" toggles, exactly as a daemon restart
++  // always has.
++  motor_inversion_state = MOTOR_NO_INVERSION;
+   if (!root) {
+     syslog(LOG_DEBUG, "No config file found; using defaults");
+     return;
+@@ -495,8 +504,8 @@
+ };
+ 
+ struct request {
+-  char command; // d,r,s,p,b,S,i,j (move, reset,set speed,get position, is
+-                // busy,Status,initial,JSON)
++  char command; // d,r,s,p,b,S,i,j,R (move, reset,set speed,get position, is
++                // busy,Status,initial,JSON,Reload config)
+   char type;    // g,h,c,s (absolute,relative,cruise,stop)
+   int x;
+   int got_x;
+@@ -570,6 +579,21 @@
+ static int get_motion_timeout_ms(void);
+ static void physical_delta_to_steps(int *dx, int *dy);
+ 
++// Derive the default speed from the loaded config. Shared between startup
++// and the 'R' (reload) IPC command so both apply identical semantics.
++static void apply_config_speed_default(void) {
++  if (!g_cfg.loaded)
++    return;
++
++  int cfg_speed = 0;
++  if (g_cfg.pan.speed > 0)
++    cfg_speed = g_cfg.pan.speed;
++  if (g_cfg.tilt.speed > 0 && g_cfg.tilt.speed > cfg_speed)
++    cfg_speed = g_cfg.tilt.speed;
++  if (cfg_speed > 0)
++    last_known_speed = cfg_speed;
++}
++
+ static int sanitize_requested_speed(int requested, int fallback) {
+   int speed = (requested > 0) ? requested : fallback;
+ 
+@@ -1439,15 +1463,7 @@
+ 
+   // Load configuration early
+   load_config_file();
+-  if (g_cfg.loaded) {
+-    int cfg_speed = 0;
+-    if (g_cfg.pan.speed > 0)
+-      cfg_speed = g_cfg.pan.speed;
+-    if (g_cfg.tilt.speed > 0 && g_cfg.tilt.speed > cfg_speed)
+-      cfg_speed = g_cfg.tilt.speed;
+-    if (cfg_speed > 0)
+-      last_known_speed = cfg_speed;
+-  }
++  apply_config_speed_default();
+ 
+   while ((c = getopt(argc, argv, "dhpD")) != -1) {
+     switch (c) {
+@@ -1857,6 +1873,38 @@
+           break;
+         }
+         break;
++      case 'R': // reload userspace config from /etc/thingino.json
++        // Lets invert_x/invert_y (and speeds, accel, timeouts, pos_0) take
++        // effect without restarting this process and, critically, without
++        // the modprobe -r/modprobe cycle in "S59motor restart" that has
++        // oopsed live kernels. The kernel module is never touched here:
++        // no ioctl is issued beyond the ordinary status read for the ack,
++        // and the position counter lives in the driver, so tracking is
++        // preserved across the reload.
++        //
++        // The async move workers read g_cfg without locking (established
++        // behavior throughout this file), so cancel any in-flight profiled
++        // move and let it wind down before rewriting the config under it.
++        motion_cancel_all(true);
++        remove_motion_active_flag();
++        (void)wait_until_idle(2000, 20);
++        usleep(50 * 1000); // let cancelled workers pass their final checks
++
++        load_config_file();
++        apply_config_speed_default();
++        syslog(LOG_INFO,
++               "Config reloaded from /etc/thingino.json (inversion=0x%x, "
++               "default speed=%d)",
++               (unsigned int)motor_inversion_state, last_known_speed);
++
++        // Ack with fresh logical status so "motors -R" callers can verify
++        // the new inversion state took effect. Note: keys that are kernel
++        // module parameters (gpio pins, hmaxstep/vmaxstep) are re-read into
++        // g_cfg but cannot reprogram the loaded module; they still need a
++        // full stop/start of S59motor.
++        motor_status_get_logical(&motor_message);
++        write(clientfd, &motor_message, sizeof(struct motor_message));
++        break;
+       case 'S': // show status
+         motor_status_get_logical(&motor_message);
+         motor_message.inversion_state = motor_inversion_state;
+--- a/src/motor.c	2026-08-16 21:51:48.269557524 +0200
++++ b/src/motor.c	2026-08-16 21:52:59.682219020 +0200
+@@ -41,8 +41,8 @@
+ };
+ 
+ struct request {
+-  char command; // d,r,s,p,b,S,i,j (move, reset,set speed,get position, is
+-                // busy,Status,initial,JSON)
++  char command; // d,r,s,p,b,S,i,j,R (move, reset,set speed,get position, is
++                // busy,Status,initial,JSON,Reload config)
+   char type;    // g,h,c,s (absolute,relative,cruise,stop)
+   int x;
+   int got_x;
+@@ -334,7 +334,7 @@
+     exit(EXIT_FAILURE);
+   debug_log("Connected to %s (fd=%d)", SV_SOCK_PATH, serverfd);
+ 
+-  while ((c = getopt(argc, argv, "d:s:x:y:jipSrvbI:D")) != -1) {
++  while ((c = getopt(argc, argv, "d:s:x:y:jipSrvbI:DR")) != -1) {
+     switch (c) {
+     case 'd':
+       request_message.command = 'd';
+@@ -454,6 +454,31 @@
+       log_request("TX", &request_message);
+       write(serverfd, &request_message, sizeof(struct request));
+       return 0;
++    case 'R': // ask the daemon to reload its config from /etc/thingino.json
++      request_message.command = 'R';
++      has_command = true;
++      if (verbose)
++        print_request_message(&request_message);
++      log_request("TX", &request_message);
++      write(serverfd, &request_message, sizeof(struct request));
++
++      struct motor_message reloaded;
++      ssize_t reload_n =
++          read(serverfd, &reloaded, sizeof(struct motor_message));
++      if (reload_n != (ssize_t)sizeof(struct motor_message)) {
++        // An older daemon has no 'R' handler: it silently drops the request
++        // and closes the connection, so read() returns 0. Fail loudly rather
++        // than pretending the reload happened.
++        fprintf(stderr,
++                "Reload not acknowledged; is the running motors-daemon too "
++                "old to support -R?\n");
++        return EXIT_FAILURE;
++      }
++      debug_log("RX reload ack: x=%d y=%d speed=%d invert=%u", reloaded.x,
++                reloaded.y, reloaded.speed, reloaded.inversion_state);
++
++      JSON_status(&reloaded);
++      return 0;
+     case 'b': // is moving?
+       request_message.command = 'b';
+       has_command = true;
+@@ -487,7 +512,9 @@
+           "\t -p return xpos,ypos as a string\n"
+           "\t -b prints 1 if motor is (b)usy moving or 0 if is not\n"
+           "\t -S show status\n"
+-          "\t -I Invert motor direction with 'x', 'y', or 'b' for both axes\n",
++          "\t -I Invert motor direction with 'x', 'y', or 'b' for both axes\n"
++          "\t -R reload daemon config from /etc/thingino.json (invert_x/"
++          "invert_y, speeds, accel, timeouts, pos_0) without restarting\n",
+           argv[0]);
+       exit(EXIT_FAILURE);
+     }

--- a/package/thingino-motors/0002-motors-add-R-config-reload-command.patch
+++ b/package/thingino-motors/0002-motors-add-R-config-reload-command.patch
@@ -45,9 +45,46 @@ unhandled EINTR would produce) as a fatal error, so a signal path would
 have to touch all of that for no benefit over an IPC verb that runs in
 the same thread as every other config-mutating command ('I', 's') and
 can acknowledge synchronously.
----
---- a/src/motor-daemon.c	2026-08-16 21:51:48.268557515 +0200
-+++ b/src/motor-daemon.c	2026-08-16 21:52:42.960063133 +0200
+
+Follow-up fixes from code review of the above:
+
+- load_config_file() now returns bool instead of void. It returned early
+  (leaving g_cfg zeroed by reset_config_defaults() and g_cfg.loaded false)
+  when /etc/thingino.json is missing, unreadable, or its root is not a JSON
+  object; the 'R' handler had nothing to check that against, so a broken
+  config file made "motors -R" silently ack success while max-step
+  overrides, position clamping and the just-reloaded inversion state were
+  actually gone. The 'R' handler now syslogs a LOG_WARNING on failure and
+  acks with a new MOTOR_RELOAD_FAILED status value (added to the
+  motor_status enum in both motor-daemon.c and motor.c) instead of the
+  ordinary idle/running status, so the CLI can tell the caller the reload
+  did not happen; "motors -R" prints an error to stderr and exits non-zero
+  in that case. The daemon startup call site is unaffected: a missing
+  config was already handled by falling back to defaults there, so it now
+  just ignores the (bool) return the same way it ignored the (void) one.
+
+- After a successful reload, compare the freshly loaded steps_pan/
+  steps_tilt against the kernel's already-programmed hmaxstep/vmaxstep
+  (read via the existing motor_get_maxsteps_sysfs() helper). Those are
+  real kernel module parameters that seed_driver_limits_from_config()
+  only ever (re)programs once at startup (limits_seeded); re-seeding here
+  would need MOTOR_RESET, which destroys the position tracking this
+  reload path exists to preserve, so it is deliberately not done. If the
+  values disagree, motor_status_get()'s max-step override/clamp and
+  motor_status_get_logical()/motor_x_to_raw()'s mirroring silently desync
+  from what the kernel enforces; syslog a LOG_WARNING naming both values
+  and stating that a full restart is required for new step limits to
+  take effect at the kernel level. Diagnostic only, no behavior change.
+
+- The 'R' handler's wait_until_idle(2000, 20) call now logs a LOG_WARNING
+  if the motors are still moving after the 2s wait instead of silently
+  proceeding into the reload.
+
+- motor.c: brace the 'R' case body. It declares locals (reloaded,
+  reload_n) directly after the case label; -Wjump-misses-init flags that
+  because a later case label could jump in past their initializers.
+--- a/src/motor-daemon.c	2026-08-16 22:21:12.839631140 +0200
++++ b/src/motor-daemon.c	2026-08-16 22:21:12.841812353 +0200
 @@ -308,7 +308,9 @@
      parsed = true;
    }
@@ -59,8 +96,17 @@ can acknowledge synchronously.
    bool invert_x = false, invert_y = false;
    if (json_get_bool_jct(motors, "invert_x", &invert_x)) {
      if (invert_x)
-@@ -423,6 +425,13 @@
- static void load_config_file(void) {
+@@ -420,18 +422,30 @@
+   return parsed;
+ }
+ 
+-static void load_config_file(void) {
++// Returns true if /etc/thingino.json was found, was a JSON object, and got
++// parsed into g_cfg (even if some individual keys were missing and defaults
++// were used for those); false if the file is missing, unreadable, or not a
++// JSON object at the root, in which case g_cfg is left at reset_config_defaults()
++// and callers must not treat the (re)load as having taken effect.
++static bool load_config_file(void) {
    JsonValue *root = parse_json_file("/etc/thingino.json");
    reset_config_defaults();
 +  // The config file is authoritative for axis inversion on every (re)load.
@@ -72,8 +118,36 @@ can acknowledge synchronously.
 +  motor_inversion_state = MOTOR_NO_INVERSION;
    if (!root) {
      syslog(LOG_DEBUG, "No config file found; using defaults");
-     return;
-@@ -495,8 +504,8 @@
+-    return;
++    return false;
+   }
+ 
+   if (root->type != JSON_OBJECT) {
+     syslog(LOG_DEBUG, "Config file root is not a JSON object; ignoring");
+     free_json_value(root);
+-    return;
++    return false;
+   }
+ 
+   bool parsed = false;
+@@ -460,6 +474,7 @@
+   }
+ 
+   free_json_value(root);
++  return true;
+ }
+ 
+ #define SV_SOCK_PATH "/dev/md"
+@@ -492,11 +507,17 @@
+ enum motor_status {
+   MOTOR_IS_STOP,
+   MOTOR_IS_RUNNING,
++  // Only ever sent as the status field of the 'R' (reload) ack, never
++  // produced by MOTOR_GET_STATUS. Lets "motors -R" tell a failed reload
++  // (config missing/invalid, defaults now in effect) apart from a normal
++  // idle/running status without changing the wire format for any other
++  // command. Keep this enum's values identical to the copy in motor.c.
++  MOTOR_RELOAD_FAILED,
  };
  
  struct request {
@@ -84,7 +158,7 @@ can acknowledge synchronously.
    char type;    // g,h,c,s (absolute,relative,cruise,stop)
    int x;
    int got_x;
-@@ -570,6 +579,21 @@
+@@ -570,6 +591,21 @@
  static int get_motion_timeout_ms(void);
  static void physical_delta_to_steps(int *dx, int *dy);
  
@@ -106,10 +180,12 @@ can acknowledge synchronously.
  static int sanitize_requested_speed(int requested, int fallback) {
    int speed = (requested > 0) ? requested : fallback;
  
-@@ -1439,15 +1463,7 @@
+@@ -1437,17 +1473,12 @@
+   debug_mode = debug_requested;
+   configure_logmask();
  
-   // Load configuration early
-   load_config_file();
+-  // Load configuration early
+-  load_config_file();
 -  if (g_cfg.loaded) {
 -    int cfg_speed = 0;
 -    if (g_cfg.pan.speed > 0)
@@ -119,11 +195,16 @@ can acknowledge synchronously.
 -    if (cfg_speed > 0)
 -      last_known_speed = cfg_speed;
 -  }
++  // Load configuration early. A missing/invalid config file is not fatal
++  // here (defaults apply and load_config_file() already logs the specific
++  // reason at LOG_DEBUG) - matches the pre-existing behavior of this call
++  // site, which never checked for failure either.
++  (void)load_config_file();
 +  apply_config_speed_default();
  
    while ((c = getopt(argc, argv, "dhpD")) != -1) {
      switch (c) {
-@@ -1857,6 +1873,38 @@
+@@ -1857,6 +1888,86 @@
            break;
          }
          break;
@@ -141,30 +222,85 @@ can acknowledge synchronously.
 +        // move and let it wind down before rewriting the config under it.
 +        motion_cancel_all(true);
 +        remove_motion_active_flag();
-+        (void)wait_until_idle(2000, 20);
++        if (wait_until_idle(2000, 20) != 0)
++          syslog(LOG_WARNING,
++                 "motors -R: motors still moving after 2s wait; reloading "
++                 "config anyway");
 +        usleep(50 * 1000); // let cancelled workers pass their final checks
 +
-+        load_config_file();
-+        apply_config_speed_default();
-+        syslog(LOG_INFO,
-+               "Config reloaded from /etc/thingino.json (inversion=0x%x, "
-+               "default speed=%d)",
-+               (unsigned int)motor_inversion_state, last_known_speed);
++        {
++          bool reload_ok = load_config_file();
++          apply_config_speed_default();
 +
-+        // Ack with fresh logical status so "motors -R" callers can verify
-+        // the new inversion state took effect. Note: keys that are kernel
-+        // module parameters (gpio pins, hmaxstep/vmaxstep) are re-read into
-+        // g_cfg but cannot reprogram the loaded module; they still need a
-+        // full stop/start of S59motor.
-+        motor_status_get_logical(&motor_message);
-+        write(clientfd, &motor_message, sizeof(struct motor_message));
++          if (!reload_ok) {
++            // load_config_file() already reset g_cfg to defaults (see its
++            // own early-return logging above for the specific reason), so
++            // g_cfg.loaded is now false: max-step overrides and position
++            // clamping in motor_status_get() are gone until the next
++            // successful load. Do not ack success.
++            syslog(LOG_WARNING,
++                   "motors -R: reload FAILED (/etc/thingino.json missing, "
++                   "unreadable, or not a JSON object); config reset to "
++                   "defaults, previous settings are NOT in effect");
++          } else {
++            syslog(LOG_INFO,
++                   "Config reloaded from /etc/thingino.json (inversion=0x%x, "
++                   "default speed=%d)",
++                   (unsigned int)motor_inversion_state, last_known_speed);
++
++            // steps_pan/steps_tilt are real kernel module parameters
++            // (hmaxstep/vmaxstep); seed_driver_limits_from_config() only
++            // ever (re)programs them once at startup (limits_seeded), and
++            // deliberately not here, because doing so needs MOTOR_RESET,
++            // which would destroy the position tracking this reload path
++            // exists to preserve. If the freshly loaded config now disagrees
++            // with what the kernel actually has loaded, userspace's
++            // clamping/mirroring math (motor_status_get(),
++            // motor_status_get_logical(), motor_x_to_raw()) silently
++            // desyncs from kernel-enforced limits. Warn loudly; do not
++            // try to auto-fix it here.
++            unsigned int kernel_max_x = 0, kernel_max_y = 0;
++            motor_get_maxsteps_sysfs(&kernel_max_x, &kernel_max_y);
++            bool pan_mismatch = kernel_max_x > 0 && g_cfg.pan.max_steps > 0 &&
++                                kernel_max_x != (unsigned int)g_cfg.pan.max_steps;
++            bool tilt_mismatch = kernel_max_y > 0 && g_cfg.tilt.max_steps > 0 &&
++                                 kernel_max_y != (unsigned int)g_cfg.tilt.max_steps;
++            if (pan_mismatch || tilt_mismatch) {
++              syslog(LOG_WARNING,
++                     "motors -R: reloaded steps_pan/steps_tilt (%d/%d) "
++                     "differ from the kernel's already-loaded limits "
++                     "(hmaxstep=%u, vmaxstep=%u); a full restart (S59motor "
++                     "restart / reboot) is required for the new step "
++                     "limits to take effect at the kernel level",
++                     g_cfg.pan.max_steps, g_cfg.tilt.max_steps, kernel_max_x,
++                     kernel_max_y);
++            }
++          }
++
++          // Ack with fresh logical status so "motors -R" callers can verify
++          // the new inversion state took effect. Note: keys that are kernel
++          // module parameters (gpio pins, hmaxstep/vmaxstep) are re-read
++          // into g_cfg but cannot reprogram the loaded module; they still
++          // need a full stop/start of S59motor.
++          motor_status_get_logical(&motor_message);
++          if (!reload_ok)
++            motor_message.status = MOTOR_RELOAD_FAILED;
++          write(clientfd, &motor_message, sizeof(struct motor_message));
++        }
 +        break;
        case 'S': // show status
          motor_status_get_logical(&motor_message);
          motor_message.inversion_state = motor_inversion_state;
---- a/src/motor.c	2026-08-16 21:51:48.269557524 +0200
-+++ b/src/motor.c	2026-08-16 21:52:59.682219020 +0200
-@@ -41,8 +41,8 @@
+--- a/src/motor.c	2026-08-16 22:21:12.839713537 +0200
++++ b/src/motor.c	2026-08-16 22:21:12.841879120 +0200
+@@ -38,11 +38,15 @@
+ enum motor_status {
+   MOTOR_IS_STOP,
+   MOTOR_IS_RUNNING,
++  // Only ever received as the status field of the 'R' (reload) ack; see the
++  // matching enum in motor-daemon.c. Values must stay identical between the
++  // two copies.
++  MOTOR_RELOAD_FAILED,
  };
  
  struct request {
@@ -175,7 +311,7 @@ can acknowledge synchronously.
    char type;    // g,h,c,s (absolute,relative,cruise,stop)
    int x;
    int got_x;
-@@ -334,7 +334,7 @@
+@@ -334,7 +338,7 @@
      exit(EXIT_FAILURE);
    debug_log("Connected to %s (fd=%d)", SV_SOCK_PATH, serverfd);
  
@@ -184,11 +320,11 @@ can acknowledge synchronously.
      switch (c) {
      case 'd':
        request_message.command = 'd';
-@@ -454,6 +454,31 @@
+@@ -454,6 +458,44 @@
        log_request("TX", &request_message);
        write(serverfd, &request_message, sizeof(struct request));
        return 0;
-+    case 'R': // ask the daemon to reload its config from /etc/thingino.json
++    case 'R': { // ask the daemon to reload its config from /etc/thingino.json
 +      request_message.command = 'R';
 +      has_command = true;
 +      if (verbose)
@@ -208,15 +344,28 @@ can acknowledge synchronously.
 +                "old to support -R?\n");
 +        return EXIT_FAILURE;
 +      }
-+      debug_log("RX reload ack: x=%d y=%d speed=%d invert=%u", reloaded.x,
-+                reloaded.y, reloaded.speed, reloaded.inversion_state);
++      debug_log("RX reload ack: x=%d y=%d speed=%d invert=%u status=%d",
++                reloaded.x, reloaded.y, reloaded.speed,
++                reloaded.inversion_state, reloaded.status);
++
++      if (reloaded.status == MOTOR_RELOAD_FAILED) {
++        // Daemon left /etc/thingino.json unreadable/invalid and reset to
++        // defaults instead of applying it; see its syslog for the reason.
++        fprintf(stderr,
++                "Reload FAILED: /etc/thingino.json is missing, unreadable, "
++                "or not valid JSON; motors-daemon reset to default config "
++                "instead. Check syslog on the camera for details.\n");
++        JSON_status(&reloaded);
++        return EXIT_FAILURE;
++      }
 +
 +      JSON_status(&reloaded);
 +      return 0;
++    }
      case 'b': // is moving?
        request_message.command = 'b';
        has_command = true;
-@@ -487,7 +512,9 @@
+@@ -487,7 +529,9 @@
            "\t -p return xpos,ypos as a string\n"
            "\t -b prints 1 if motor is (b)usy moving or 0 if is not\n"
            "\t -S show status\n"

--- a/package/thingino-motors/files/S59motor
+++ b/package/thingino-motors/files/S59motor
@@ -178,6 +178,21 @@ stop() {
 	fi
 }
 
+reload() {
+	echo -c 15 "Reloading motors config"
+
+	# Re-read userspace motor settings (invert_x/invert_y, speeds, accel,
+	# timeouts, pos_0) in the running daemon without touching the kernel
+	# module. "restart" cycles the motor module through modprobe -r/modprobe,
+	# which has oopsed live kernels; prefer reload for config-only changes.
+	# Keys that are kernel module parameters (gpio pins, steps_pan/steps_tilt
+	# as hmaxstep/vmaxstep) still require a full stop/start.
+	if ! motors -R; then
+		echo "Reload failed; is motors-daemon running?" >&2
+		exit 1
+	fi
+}
+
 case "$1" in
 	start)
 		start
@@ -190,8 +205,11 @@ case "$1" in
 		sleep 1
 		start
 		;;
+	reload)
+		reload
+		;;
 	*)
-		echo "Usage: $0 {start|stop|restart}"
+		echo "Usage: $0 {start|stop|restart|reload}"
 		exit 1
 		;;
 esac

--- a/package/thingino-motors/files/S59motor
+++ b/package/thingino-motors/files/S59motor
@@ -151,13 +151,10 @@ start() {
 	# FIXME: daemon should be reporting running state from the very first moment
 	sleep 1
 
-	# GPIO/TCU driver has no invert_x/invert_y module params (SPI-only); apply
-	# inversion at runtime via IPC instead. Daemon starts un-inverted on every
-	# boot, so this must run every time, not just on first module load.
-	if [ "true" != "$is_spi" ]; then
-		[ "true" = "$invert_x" ] && motors -I x
-		[ "true" = "$invert_y" ] && motors -I y
-	fi
+	# NOTE: do not apply invert_x/invert_y here. motors-daemon reads them from
+	# thingino.json itself at startup, and "motors -I" is an XOR toggle, not an
+	# idempotent set - sending it here would flip the daemon's already-correct
+	# state back off. SPI keeps using the modprobe params above.
 
 	# FIXME: motors may have different speeds for pan and tilt
 	set_motors_speed $speed_pan

--- a/package/thingino-motors/files/ptz-ctrl
+++ b/package/thingino-motors/files/ptz-ctrl
@@ -12,10 +12,10 @@ while true; do
 
 	case $key in
 		w | W)
-			motors -d g -y -$step # Up is negative
+			motors -d g -y $step # Up is positive in the daemon's logical frame
 			;;
 		s | S)
-			motors -d g -y $step # Down is positive
+			motors -d g -y -$step # Down is negative
 			;;
 		a | A)
 			motors -d g -x -$step # Left is negative


### PR DESCRIPTION
Five related fixes to the motors package, found while getting PTZ to behave consistently across the web UI, ONVIF and the CLI.

**Direction handling.** `invert_x`/`invert_y` were applied twice — once in `S59motor` and again in the daemon — so a camera configured to invert ended up not inverted. Absolute positions ignored them entirely. And `ptz-ctrl` alone spoke the opposite tilt convention from everything else: the web UI arrows send `+step` for up and ONVIF maps positive tilt to `max_step_y`, while `ptz-ctrl`’s `w` key sent `-step`. On a camera whose `invert_y` is set so that logical y+ is physically up, the keyboard keys moved the wrong way.

Direction belongs in the daemon at the IPC boundary; every caller should speak the same logical frame. That is what these commits make true.

**Reload.** `motors -R` now reloads configuration without the modprobe cycle, which avoided a kernel module unload/reload on a live camera — that path caused a kernel oops here at least once. It also fixes `-R` reporting success on a bad config while leaving the kernel step count desynchronised from the daemon.