### PR TITLE
timps: gate the diagnostic scripts, write the board's sensor, drop two orphaned www files

### DIFF
--- a/package/timps/Config.in
+++ b/package/timps/Config.in
@@ -257,3 +257,21 @@ config BR2_PACKAGE_TIMPS_AUDIO_PRESET_MINIMAL
 endchoice
 
 endif # BR2_PACKAGE_TIMPS
+
+config BR2_PACKAGE_TIMPS_DIAG_TOOLS
+	bool "Diagnostic scripts (self-test, log shipping, exposure log)"
+	default n
+	help
+	  Install the shell helpers used to investigate a camera rather than
+	  to run it: timps-selftest, timps-logcat-ship (forwards the vendor
+	  alog into syslog) and timps-dn-isp-log (samples the ISP exposure
+	  state once a minute for day/night analysis).
+
+	  Nothing on the camera calls any of them - they are driven by cron
+	  or by hand, and the last two only make sense when something is
+	  collecting what they emit. Off by default: together they are about
+	  9 KB of shell on a device whose writable partition is under a
+	  megabyte, and a normal installation has no use for them.
+
+	  This is separate from TIMPS_TRACE, which instruments the daemon
+	  itself and is deliberately not reachable from menuconfig.

--- a/package/timps/files/timps-dn-isp-log
+++ b/package/timps/files/timps-dn-isp-log
@@ -1,0 +1,31 @@
+#!/bin/sh
+# day/night exposure-index measurement - see scripts/dn-isp-probe.sh in timps
+# Prefer the SD card so a reboot does not discard the series (/tmp is tmpfs).
+# Deliberately NOT falling back to the /etc overlay: this runs once a MINUTE,
+# and 1440 jffs2 writes a day would trade a rare reboot for certain flash wear.
+# Boards without an SD card keep /tmp and get fetched more promptly instead.
+OUT=""
+for d in /mnt/mmcblk0p1 /media/mmcblk0p1 /sdcard; do
+  [ -d "$d" ] && [ -w "$d" ] && { OUT="$d/dn-isp.csv"; break; }
+done
+[ -n "$OUT" ] || OUT=/tmp/dn-isp.csv
+# carry over whatever the earlier /tmp-only version already collected
+[ -f /tmp/dn-isp.csv ] && [ ! -f "$OUT" ] && cp /tmp/dn-isp.csv "$OUT" 2>/dev/null
+MAX=4000                      # ~66 h at one sample a minute, ~250 KB
+# T31 exposes isp-m0, T20 only isp_info; the field names match, but T20 has no
+# max integration time, so that column stays empty there.
+D=$(cat /proc/jz/isp/isp-m0 2>/dev/null)
+[ -n "$D" ] || D=$(cat /proc/jz/isp/isp_info 2>/dev/null)
+[ -n "$D" ] || exit 0
+[ -f "$OUT" ] || echo "epoch,mode,int,max_int,again,dgain,ispdgain" > "$OUT"
+[ "$(wc -l < "$OUT")" -lt "$MAX" ] || exit 0
+f() { echo "$D" | sed -n "s/^$1 : *\([0-9]*\).*/\1/p" | head -1; }
+M=$(echo "$D" | sed -n 's/.*ISP Runing Mode : *//p' | tr -d ' \r' | head -1)
+ROW="$(date +%s),${M:-?},$(f 'SENSOR Integration Time'),$(f 'SENSOR Max Integration Time'),$(f 'SENSOR analog gain'),$(f 'SENSOR digital gain'),$(f 'ISP digital gain')"
+echo "$ROW" >> "$OUT"
+
+# Optional syslog copy - OFF by default: this runs once a MINUTE.
+#   jct /etc/thingino.json set dnlog.isp_syslog true|false
+# The local CSV is written either way and stays authoritative (syslog is UDP).
+[ "$(jct /etc/thingino.json get dnlog.isp_syslog 2>/dev/null)" = "true" ] &&
+	logger -t dnisp "$ROW" 2>/dev/null

--- a/package/timps/files/timps-irprobe
+++ b/package/timps/files/timps-irprobe
@@ -1,10 +1,13 @@
 #!/bin/sh
 # daynight.irprobe_cmd target: timps execs "<cmd> on|off" with no shell.
 #
-# The "off" path arms a detached watchdog before it does anything, because the
-# daemon has no failsafe: if it dies during the 8 s dark window the illuminator
-# stays off until something else turns it on. 60 s is far past probe_settle_s,
-# and a later "on" is idempotent.
+# The three names are light's infrared types, tried in that order because 940nm
+# is invisible and 850nm faintly red; `light` resolves the pin per camera from
+# thingino.json. Enumerating gpio.* instead would reach `white` and `flood`.
+#
+# "off" arms a detached watchdog first: the daemon has no failsafe, so if it
+# dies during the dark window the illuminator would stay off. A later "on" is
+# idempotent.
 for t in ir940 ir850 ir; do
 	if [ -n "$(light $t gpio 2>/dev/null)" ]; then
 		[ "$1" = off ] && ( sleep 60; light $t on ) >/dev/null 2>&1 &

--- a/package/timps/files/timps-irprobe
+++ b/package/timps/files/timps-irprobe
@@ -1,0 +1,14 @@
+#!/bin/sh
+# daynight.irprobe_cmd target: timps execs "<cmd> on|off" with no shell.
+#
+# The "off" path arms a detached watchdog before it does anything, because the
+# daemon has no failsafe: if it dies during the 8 s dark window the illuminator
+# stays off until something else turns it on. 60 s is far past probe_settle_s,
+# and a later "on" is idempotent.
+for t in ir940 ir850 ir; do
+	if [ -n "$(light $t gpio 2>/dev/null)" ]; then
+		[ "$1" = off ] && ( sleep 60; light $t on ) >/dev/null 2>&1 &
+		exec light $t "$1"
+	fi
+done
+exit 1   # no switchable illuminator: timps logs the failure and skips the probe

--- a/package/timps/files/timps-logcat-ship
+++ b/package/timps/files/timps-logcat-ship
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Forward NEW lines of the Ingenic alog into syslog. `logcat -t` prefixes each
+# line with the event's own epoch time, so the marker is that timestamp: it
+# survives a ring wrap, a reboot and a truncated buffer without counting lines.
+# The forwarded line keeps its prefix - syslog's own time is the shipping time,
+# which for a once-a-minute cron is up to 60 s late.
+TAG=logcat
+STATE=/tmp/.logcat-ship
+DUMP=/tmp/.logcat-dump.$$
+
+trap 'rm -f "$DUMP"' EXIT
+logcat -t >"$DUMP" 2>/dev/null || exit 0
+[ -s "$DUMP" ] || exit 0
+
+last=0
+[ -r "$STATE" ] && read -r last <"$STATE" 2>/dev/null
+case "$last" in ''|*[!0-9.]*) last=0 ;; esac
+
+# awk keeps the numeric compare in one pass; the timestamps are epoch seconds
+# with a fractional part, so a string compare would be wrong.
+awk -v last="$last" '$1 + 0 > last + 0' "$DUMP" | while IFS= read -r line; do
+	[ -n "$line" ] && logger -t "$TAG" "$line"
+done
+
+newest=$(awk 'BEGIN{m=0} $1 + 0 > m + 0 {m = $1} END{print m}' "$DUMP")
+[ -n "$newest" ] && printf '%s\n' "$newest" >"$STATE"

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -247,6 +247,15 @@ define TIMPS_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/timps.conf \
 		$(TARGET_DIR)/etc/timps.conf
 
+	# One template for every board means every other sensor warns once per
+	# start. Buildroot knows the right name - the kernel driver is built from
+	# it. i2c_addr stays as shipped: buildroot does not carry it, and
+	# /proc/jz/sensor supplies it wherever that exists.
+	if [ -n "$(call qstrip,$(BR2_SENSOR_1_NAME))" ]; then \
+		$(SED) 's|^sensor.model .*|sensor.model    = $(call qstrip,$(BR2_SENSOR_1_NAME))|' \
+			$(TARGET_DIR)/etc/timps.conf; \
+	fi
+
 	# Install init script
 	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/S95timps \
 		$(TARGET_DIR)/etc/init.d/S95timps
@@ -258,6 +267,8 @@ define TIMPS_INSTALL_TARGET_CMDS
 	fi
 
 	# Install the self-test helper
+	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/timps-irprobe \
+		$(TARGET_DIR)/usr/bin/timps-irprobe
 	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/timps-selftest.sh \
 		$(TARGET_DIR)/usr/bin/timps-selftest
 

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -269,8 +269,19 @@ define TIMPS_INSTALL_TARGET_CMDS
 	# Install the self-test helper
 	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/timps-irprobe \
 		$(TARGET_DIR)/usr/bin/timps-irprobe
-	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/timps-selftest.sh \
-		$(TARGET_DIR)/usr/bin/timps-selftest
+
+	# Diagnostic helpers: nothing on the camera calls them, and the two
+	# collectors only pay off where something gathers what they emit.
+	# /usr/bin rather than an /etc overlay - squashfs compresses and
+	# deduplicates, the writable jffs2 does neither.
+	if [ "$(BR2_PACKAGE_TIMPS_DIAG_TOOLS)" = "y" ]; then \
+		$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/timps-dn-isp-log \
+			$(TARGET_DIR)/usr/bin/timps-dn-isp-log; \
+		$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/timps-logcat-ship \
+			$(TARGET_DIR)/usr/bin/timps-logcat-ship; \
+		$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/timps-selftest.sh \
+			$(TARGET_DIR)/usr/bin/timps-selftest; \
+	fi
 
 	# System-sound play wrapper: enqueues PLAY/STOP onto timps's /run/timps/
 	# audio_out FIFO (native IMP_AO). Same interface prudynt/raptor ship, so the

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -446,6 +446,18 @@ define TIMPS_INSTALL_WEBUI
 	      $(TARGET_DIR)/var/www/x/json-prudynt-save.cgi \
 	      $(TARGET_DIR)/var/www/x/json-timegraph-stream.cgi
 	rm -f $(TARGET_DIR)/var/www/x/ch0.mjpg $(TARGET_DIR)/var/www/x/ch1.mjpg
+	# CAVEAT on the two rm -f above (measured 2026-08-19, flash-headroom audit):
+	# deleting from THIS tree only works for a path thingino-webui no longer
+	# ships at all - which is true of all nine paths listed here, so they are
+	# effectively no-ops kept as documentation. It does NOT work for a stock
+	# file that still exists: this hook runs in timps's PER-PACKAGE tree, and
+	# the global merge then rsyncs a pristine copy back in from every other
+	# package that inherited thingino-webui's www tree (verified: preview.js
+	# survives here via thingino-gpio, thingino-mosquitto-20x, thingino-motors,
+	# thingino-webui and wireguard-tools). That is the delete-side of exactly
+	# the same per-package-merge problem the big comment above documents for
+	# the install side. A live stock file has to be removed from the global
+	# TARGET_FINALIZE phase instead - see TIMPS_PURGE_STOCK_WEBUI below.
 	# Snapshot CGIs: the x/ loop above already replaced the stock prudynt
 	# x/ch0.jpg with timps's loopback-fetch script; clone it to the other
 	# three names the WebUI expects (channel/disposition are derived from the
@@ -547,7 +559,38 @@ define TIMPS_REAPPLY_WEBUI_OVERLAY
 	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/www/x/json-heartbeat-slow.cgi \
 		$(TARGET_DIR)/var/www/x/json-heartbeat-slow.cgi
 endef
+
+# The delete-side counterpart, and the only place a LIVE thingino-webui file
+# can actually be removed (see the CAVEAT in TIMPS_INSTALL_WEBUI above): the
+# global TARGET_FINALIZE phase, after the per-package merge has put every
+# inherited pristine copy into the real $(TARGET_DIR).
+#
+# Both entries are stock scripts the preview swap orphaned. Neither has a
+# caller anywhere in the MERGED /var/www - checked against the built tree, not
+# against this package's own files:
+#   a/preview.js    thingino-webui's stock streamer preview, driving the
+#                   prudynt bridge CGIs. TIMPS_REAPPLY_WEBUI_OVERLAY above
+#                   replaces preview.html wholesale with the native MSE/fMP4
+#                   page, which loads a/timps-preview.js instead. No
+#                   <script src="/a/preview.js"> survives on a timps image;
+#                   the only remaining mention is prose in a comment.
+#   a/sei-rotate.js referenced only from prudynt-t's and thingino-raptor's
+#                   streamer-*.html. "Streamer" is a Kconfig choice
+#                   (package/thingino-streamer/Config.in), so neither package
+#                   can be installed next to timps and neither page can exist
+#                   here. The script also early-returns on /preview.html.
+#
+# Worth 39.4 KB uncompressed but only 4096 bytes off the packed image
+# (measured: rootfs.squashfs 5246976 -> 5242880, -b 256K -comp xz). JS
+# compresses about tenfold and squashfs pads to 4K, so uncompressed script
+# sizes overstate the win by roughly an order of magnitude - do not size
+# future www cleanups off `du`.
+define TIMPS_PURGE_STOCK_WEBUI
+	rm -f $(TARGET_DIR)/var/www/a/preview.js \
+	      $(TARGET_DIR)/var/www/a/sei-rotate.js
+endef
 TARGET_FINALIZE_HOOKS := TIMPS_REAPPLY_WEBUI_OVERLAY $(TARGET_FINALIZE_HOOKS)
+TARGET_FINALIZE_HOOKS += TIMPS_PURGE_STOCK_WEBUI
 endif
 
 # NOTE: motors-detection fix. Stock S48webui-config reports


### PR DESCRIPTION
Three independent changes to `package/timps`, split into three commits.

### 1. Two callerless www files, and a purge that never ran

`a/preview.js` and `a/sei-rotate.js` are thingino-webui files that the timps preview swap orphaned. Neither has a caller anywhere in the **merged** `/var/www` — checked against the built tree, not against this package's own files:

* `a/preview.js` drives the prudynt bridge CGIs. `TIMPS_REAPPLY_WEBUI_OVERLAY` replaces `preview.html` wholesale with the native MSE/fMP4 page, which loads `a/timps-preview.js`. No `<script src="/a/preview.js">` survives on a timps image.
* `a/sei-rotate.js` is referenced only from prudynt-t's and thingino-raptor's `streamer-*.html`. "Streamer" is a Kconfig choice, so neither package can be installed next to timps.

The removal has to happen in the **global** `TARGET_FINALIZE` phase — that is the only point where a live thingino-webui file can actually be removed, after the per-package merge has put every inherited pristine copy into the real `$(TARGET_DIR)`.

Worth 39.4 KB uncompressed but only **4096 bytes** off the packed image (measured: `rootfs.squashfs` 5246976 → 5242880). JS compresses about tenfold and squashfs pads to 4K, so uncompressed sizes overstate this kind of win by roughly an order of magnitude.

### 2. The board's own sensor in `timps.conf`

The config template names one sensor for every board, so every camera that is not a `gc2053` corrects it at runtime and warns while doing so. Buildroot already holds the right name in `BR2_SENSOR_1_NAME` — the kernel sensor driver is built from it, so there is no second source that could disagree.

Runtime detection via `/proc/jz/sensor` still wins where it exists. What changes is that the shipped file is honest, and that T40/T41 — which have no such proc entry, where the config value is all there is — get a correct value instead of the template's fallback. `i2c_addr` is left alone: buildroot does not carry it.

This commit also ships `timps-irprobe`, the target of `daynight.irprobe_cmd`. It drives the IR illuminator alone, without moving the IR-cut filter, which is what the silent day/night probe needs. It tries `ir940`, `ir850` and `ir` in turn — `light`'s infrared types, in that order because 940nm is invisible and 850nm faintly red — and gives up if the board has none, at which point the daemon stops attempting silent probes. The pin is not hardcoded; `light` resolves it per camera from `thingino.json`. The `off` path arms a detached 60s watchdog that turns the illuminator back on, because the daemon has no failsafe if it dies during the dark window.

### 3. `BR2_PACKAGE_TIMPS_DIAG_TOOLS`, default n

`timps-selftest`, plus two collectors — `timps-logcat-ship` (forwards the vendor alog into syslog) and `timps-dn-isp-log` (samples the ISP exposure state once a minute for day/night analysis).

Nothing on the camera calls any of them: they are driven by cron or by hand, and the two collectors only pay off where something is gathering what they emit. Together about 9 KB of shell on a device whose writable partition is under a megabyte, so they are now opt-in.

This is deliberately **separate from `TIMPS_TRACE`**, which instruments the daemon itself and is intentionally not reachable from menuconfig.

They install to `/usr/bin` rather than through an `/etc` overlay: squashfs compresses and deduplicates across a fleet, the writable jffs2 does neither, and it is the partition that runs out first.

---

Built and verified on four profiles (T31/T23/T20, sc4336p/sc2336/jxf23/jxf22): the sensor lands correctly in each image, the gated scripts appear only with the option set, and `timps-irprobe` — which is *not* gated, since it is operational rather than diagnostic — is present in all of them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)