### PR TITLE
thingino-motors: fix S59motor stop path wedging motors-daemon

### DIFF
--- a/package/thingino-motors/files/S59motor
+++ b/package/thingino-motors/files/S59motor
@@ -16,15 +16,58 @@ start_daemon() {
 	start-stop-daemon -S -b -m -p "$PIDFILE" -x "$DAEMON" -- $@
 }
 
+# Returns 0 only if the daemon is genuinely gone afterwards, 1 otherwise.
+# stop() depends on that contract -- see the rmmod guard there.
+#
+# The daemon self-daemonizes (double-fork + setsid under -d, see
+# motor-daemon.c), so the PID start-stop-daemon records via -m is the
+# intermediate child, which exits immediately: the pidfile is stale from
+# the moment it is written and -K can never match the real process.
+# Confirmed live -- this used to print "no /usr/bin/motors-daemon found;
+# none killed" while ps plainly showed the daemon running, after which
+# stop() went on to rmmod the module out from under it. Because motor_fops
+# in ingenic-sdk's motor.c has no .owner = THIS_MODULE (see
+# themactep/ingenic-sdk#45), opening /dev/motor never takes a module
+# reference (/proc/modules shows use count 0 with a live opener), so that
+# rmmod SUCCEEDS and frees the module's code, IRQ handler and completions
+# under the running daemon -- leaving it in permanently uninterruptible D
+# state, immune to SIGKILL, recoverable only by a power cycle.
+#
+# Match anchored on the binary path: an unanchored -f pattern also
+# matches any shell/ssh command line that merely mentions the path
+# (verified -- an unanchored pgrep matched this script's own caller).
 stop_daemon() {
 	if [ -f "$PIDFILE" ]; then
-		start-stop-daemon -K -p "$PIDFILE" -x "$DAEMON"
-		status=$?
+		start-stop-daemon -K -q -p "$PIDFILE" -x "$DAEMON" 2>/dev/null
 		rm -f "$PIDFILE"
-		return $status
 	fi
 
-	start-stop-daemon -K -x "$DAEMON"
+	if ! pgrep -f "^$DAEMON" >/dev/null 2>&1; then
+		return 0
+	fi
+
+	pkill -TERM -f "^$DAEMON" 2>/dev/null
+
+	# 5s for a graceful exit, then escalate. Fractional sleep is
+	# supported by this firmware's busybox (verified).
+	i=0
+	while [ "$i" -lt 25 ]; do
+		pgrep -f "^$DAEMON" >/dev/null 2>&1 || return 0
+		i=$((i + 1))
+		sleep 0.2
+	done
+
+	echo "motors-daemon ignored SIGTERM, escalating to SIGKILL" >&2
+	pkill -KILL -f "^$DAEMON" 2>/dev/null
+
+	i=0
+	while [ "$i" -lt 25 ]; do
+		pgrep -f "^$DAEMON" >/dev/null 2>&1 || return 0
+		i=$((i + 1))
+		sleep 0.2
+	done
+
+	return 1
 }
 
 MOTORS_CONFIG="/etc/thingino.json"
@@ -173,7 +216,16 @@ start() {
 stop() {
 	echo -c 15 "Stopping motors"
 
-	stop_daemon
+	# Refuse to unload the module while anything still holds /dev/motor.
+	# The kernel will NOT stop us -- motor_fops lacks .owner = THIS_MODULE
+	# (themactep/ingenic-sdk#45), so the module's use count stays 0 even
+	# with a live opener and rmmod succeeds, orphaning that opener in
+	# unkillable D state (power cycle only). Failing loudly here is
+	# strictly better than that.
+	if ! stop_daemon; then
+		echo "motors-daemon still running; refusing to rmmod (would wedge it)" >&2
+		exit 1
+	fi
 
 	if ! rmmod motor; then
 		echo "Failed to unload motor module." >&2


### PR DESCRIPTION
Fixes #1510.

## What's wrong

`S59motor`'s `stop_daemon` could never actually kill `motors-daemon`: the daemon self-daemonizes under `-d` (double-fork + `setsid`), so the PID `start-stop-daemon -m` records is the intermediate child, which exits immediately — the pidfile is stale from the moment it is written. `stop()` didn't check the result and ran `rmmod motor` anyway, which succeeds against the still-live daemon because `motor_fops` lacks `.owner = THIS_MODULE` (module use count stays 0 with a live opener — filed separately as themactep/ingenic-sdk#45). That leaves `motors-daemon` in permanently uninterruptible `D` state, immune to `SIGKILL`, recoverable only by a power cycle.

Full detail and live reproduction in #1510.

## What this changes

- `stop_daemon` now matches the real process (anchored on the binary path — an unanchored `pkill -f` pattern also matches the invoking shell) and escalates `SIGTERM` → `SIGKILL` with a bounded wait, returning a real status.
- `stop()` now refuses to `rmmod` unless the daemon is confirmed gone, turning the failure mode from an unrecoverable wedge into an ordinary loud error.

Both changes are scoped to `stop_daemon()`/`stop()`; nothing else in the file is touched.

## Testing

Live on an Eufy E220 (T8410C, T31X, `ciao+f433166`): the exact `S59motor restart` that previously wedged the daemon now completes cleanly, with the daemon healthy afterward and `motors -j` responsive. Reproduced (and now fixed) on both `motion_driver: legacy` and `profiled`, so this is unrelated to the acceleration settings, which were the original — wrong — suspect.

```
# /etc/init.d/S59motor restart
Stopping motors
Setting up motors
Set GPIO per motor phase
Load motor module with parameters: hmaxstep=4100 vmaxstep=1150 ...
Home motors
Move to 2050,450
# ps w | grep motors-daemon
30645 root      1132 S    /usr/bin/motors-daemon -d -p
# motors -j
{"status":"0","xpos":"2050","ypos":"450","speed":"900","invert":"0"}
```

---

*Investigated, tested, and drafted by an AI assistant while looking into PTZ motion behavior on this camera.*
