### PR TITLE
wireguard: install the watchdog cron before the network-active check

### DIFF
--- a/package/thingino-wireguard-tools/files/S42wireguard
+++ b/package/thingino-wireguard-tools/files/S42wireguard
@@ -131,14 +131,16 @@ start() {
 	wireguard_load_config || exit 1
 	wireguard_validate_config || exit 1
 
-	if ! network_is_active; then
-		echo -c 240 -e "- No active network connection"
-		return 0
-	fi
-
 	if [ "true" != "$wireguard_enabled" ] && [ "force" != "$1" ]; then
 		echo -c 160 -e "WireGuard disabled" >&2
 		exit 1
+	fi
+
+	wireguard_watchdog_install_cron || exit 1
+
+	if ! network_is_active; then
+		echo -c 240 -e "- No active network connection; watchdog will retry"
+		return 0
 	fi
 
 	if ip link show $WIREGUARD_INTERFACE 2>&1 | grep -q 'UP'; then
@@ -201,8 +203,6 @@ start() {
 		echo -c 240 -e "- Add routing to $r"
 		ip route add $r dev $WIREGUARD_INTERFACE
 	done
-
-	wireguard_watchdog_install_cron || exit 1
 }
 
 stop() {


### PR DESCRIPTION
## Summary

`S42wireguard`'s `start()` returns early via `network_is_active()` before
ever reaching `wireguard_watchdog_install_cron`, which only ran at the
very end of a successful start.

If this script runs before the network is actually up (e.g. at boot,
before DHCP/RA has assigned an address), `network_is_active()` finds
nothing, `start()` returns early, and the watchdog cron — the thing
that would otherwise retry and self-heal exactly this situation —
never gets installed either. Nothing brings WireGuard up until the
next reboot.

## Fix

Moves the watchdog cron install ahead of the network-active check
(right after the enabled check) so it's always armed whenever
`start()` runs with WireGuard enabled, regardless of whether the
network was ready yet. The watchdog's own `restart_wireguard` path
already handles "interface down or missing" correctly — it just
needed to actually be scheduled.

## Test plan

- [x] Reproduced on real hardware (camera booting before SLAAC/DHCP
      completed left WireGuard down indefinitely)
- [x] Confirmed fix: watchdog cron now installs on every `start()`
      call where WireGuard is enabled, verified via `crontab -l`
      immediately after a boot where the network-active check fails
- [x] Confirmed normal boot path (network already up) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)