### PR TITLE
package/prudynt-t: expose RTSP_IPV6 as a Kconfig option

### DIFF
--- a/package/prudynt-t/Config.in
+++ b/package/prudynt-t/Config.in
@@ -189,6 +189,23 @@ config BR2_PACKAGE_PRUDYNT_T_OSD_FONT_LIBSCHRIFT
 	  Adds ~17KB to the prudynt binary (libschrift is linked
 	  statically, matching the pre-2026 wiring).
 
+config BR2_PACKAGE_PRUDYNT_T_RTSP_IPV6
+	bool "IPv6-only RTSP server"
+	depends on BR2_PACKAGE_PRUDYNT_T
+	depends on BR2_PACKAGE_THINGINO_KOPT_IPV6
+	help
+	  Build the RTSP server and SDP generator to bind and advertise
+	  IPv6 only (AF_INET6, "IN IP6" in SDP origin lines) instead of
+	  the default IPv4-only server. Single-stack either way -- there
+	  is no dual-stack mode.
+
+	  Requires the global IPv6 option (thingino-kopt): kernel
+	  CONFIG_IPV6 plus DHCPv6 addressing via odhcp6c.
+
+comment "RTSP IPv6-only server needs thingino-kopt IPv6 (kernel CONFIG_IPV6)"
+	depends on BR2_PACKAGE_PRUDYNT_T
+	depends on !BR2_PACKAGE_THINGINO_KOPT_IPV6
+
 config BR2_PACKAGE_PRUDYNT_T_FFMPEG
 	bool "Enable FFmpeg integration (parsers/bitstream filters)"
 	depends on BR2_PACKAGE_PRUDYNT_T

--- a/package/prudynt-t/Config.in
+++ b/package/prudynt-t/Config.in
@@ -189,6 +189,15 @@ config BR2_PACKAGE_PRUDYNT_T_OSD_FONT_LIBSCHRIFT
 	  Adds ~17KB to the prudynt binary (libschrift is linked
 	  statically, matching the pre-2026 wiring).
 
+config BR2_PACKAGE_PRUDYNT_T_RTSP_IPV6
+	bool "IPv6-only RTSP server"
+	depends on BR2_PACKAGE_PRUDYNT_T
+	help
+	  Build the RTSP server and SDP generator to bind and advertise
+	  IPv6 only (AF_INET6, "IN IP6" in SDP origin lines) instead of
+	  the default IPv4-only server. Single-stack either way -- there
+	  is no dual-stack mode.
+
 config BR2_PACKAGE_PRUDYNT_T_FFMPEG
 	bool "Enable FFmpeg integration (parsers/bitstream filters)"
 	depends on BR2_PACKAGE_PRUDYNT_T

--- a/package/prudynt-t/prudynt-t.mk
+++ b/package/prudynt-t/prudynt-t.mk
@@ -210,6 +210,7 @@ define PRUDYNT_T_BUILD_CMDS
 		USE_OSD_FONT8X8=$(if $(BR2_PACKAGE_PRUDYNT_T_OSD_FONT_8X8),1,0) \
 		USE_OSD_FONT_UNIFONT=$(if $(BR2_PACKAGE_PRUDYNT_T_OSD_FONT_UNIFONT),1,0) \
 		USE_OSD_FONT_LIBSCHRIFT=$(if $(BR2_PACKAGE_PRUDYNT_T_OSD_FONT_LIBSCHRIFT),1,0) \
+		USE_RTSP_IPV6=$(if $(BR2_PACKAGE_PRUDYNT_T_RTSP_IPV6),1,0) \
 		-C $(@D) all commit_tag=$(shell cd $(PRUDYNT_T_OVERRIDE_SRCDIR) 2>/dev/null && git show -s --format=%h 2>/dev/null || git show -s --format=%h 2>/dev/null || echo unknown)
 endef
 


### PR DESCRIPTION
## Summary

prudynt-t's `stable` branch can build an IPv6-only RTSP server/SDP
generator (`USE_RTSP_IPV6=1`, single-stack, default off — see
[PR #35](https://github.com/themactep/prudynt-t/pull/35) on
themactep/prudynt-t), but this package never exposed it as a
Buildroot option or wired it into `PRUDYNT_T_BUILD_CMDS`, so it was
only reachable by hand-editing the make invocation.

Adds `BR2_PACKAGE_PRUDYNT_T_RTSP_IPV6`, following the same pattern as
the existing `OSD_FONT_8X8`/`OSD_FONT_UNIFONT`/`OSD_FONT_LIBSCHRIFT`
options just above it in Config.in.

## Test plan

- [x] `make menuconfig` shows the new option under prudynt-t, depends
      on `BR2_PACKAGE_PRUDYNT_T` like its siblings
- [x] Defaults off, matching prudynt-t's own default — no behavior
      change for anyone not opting in
- [x] Cross-compiled a T31 build with the option enabled; binary
      builds `RTSP_IPV6`-defined and links clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)