### PR TITLE
wireguard: bound the pre-start NTP sync with timeout(1)

### DIFF
--- a/package/thingino-wireguard-tools/files/S42wireguard
+++ b/package/thingino-wireguard-tools/files/S42wireguard
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck disable=SC2086,SC2154,SC2317,SC3043
+# shellcheck disable=SC2016,SC2086,SC2154,SC2317,SC3043
 
 CONFIG_JSON="${CONFIG_JSON:-/etc/thingino.json}"
 JCT_BIN="${JCT_BIN:-$(command -v jct 2>/dev/null)}"
@@ -119,8 +119,8 @@ start() {
 		exit 1
 	fi
 
-	# make sure the system clock is syncronized
-	ntpd -qnN
+	# sync clock; bounded so an unreachable NTP server can't deadlock boot
+	timeout 15 ntpd -qnN
 
 	echo -c 240 -e "- Create WireGuard network interface"
 	ip link add dev $WIREGUARD_INTERFACE type wireguard


### PR DESCRIPTION
## Summary

`start()` runs a blocking `ntpd -qnN` to sync the clock before
bringing up the interface, with no timeout. If the configured NTP
server isn't reachable at that point — e.g. it's only reachable
through the tunnel this script is about to create, or the network
just isn't up yet — this blocks indefinitely, which can deadlock boot
and prevent the watchdog from ever retrying a failed start.

Bounds it with `timeout(1)` instead: on timeout, `ntpd` exits and
`start()` continues (the clock stays whatever it was, same as any
other `ntpd` failure path here).

## Test plan

- [x] Confirmed `ntpd -qnN` has never had a timeout in this script's
      history (not a regression, a long-standing gap)
- [x] With an unreachable NTP server configured, `start()` now
      returns within ~15s instead of hanging
- [x] Normal case (reachable NTP server) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)