### PR TITLE
imp-control: use prudyntctl's local socket instead of the HTTP API

### DIFF
--- a/package/prudynt-t/files/imp-control
+++ b/package/prudynt-t/files/imp-control
@@ -1,16 +1,9 @@
 #!/bin/sh
 # shellcheck disable=SC3043
-# imp-control replacement - communicates with prudynt via HTTP JSON API
-# Defaults to local listener exposed by prudynt (/api/v1/config)
+# imp-control replacement - communicates with prudynt via prudyntctl's
+# local socket (not the HTTP API, which may be disabled/unreachable)
 
-: "${API_URL:=http://127.0.0.1:8080/api/v1/config}"
-
-# Read API key for authentication with prudynt
-API_KEY_FILE="/etc/thingino-api.key"
-API_KEY=""
-if [ -f "$API_KEY_FILE" ]; then
-	API_KEY=$(cat "$API_KEY_FILE" 2>/dev/null | tr -d '\n\r ')
-fi
+: "${PRUDYNTCTL:=prudyntctl}"
 
 usage() {
 	cat <<EOF
@@ -68,16 +61,7 @@ EOF
 
 send_config() {
 	local json="$1"
-	if [ -n "$API_KEY" ]; then
-		curl -s -X POST "$API_URL" \
-			-H "X-API-Key: $API_KEY" \
-			-H "Content-Type: application/json" \
-			-d "$json" >/dev/null 2>&1
-	else
-		curl -s -X POST "$API_URL" \
-			-H "Content-Type: application/json" \
-			-d "$json" >/dev/null 2>&1
-	fi
+	"$PRUDYNTCTL" json "$json" >/dev/null
 	return $?
 }
 


### PR DESCRIPTION
## Summary

`imp-control` talked to prudynt over its HTTP JSON API
(`127.0.0.1:8080/api/v1/config`) via `curl`. If that API is disabled
or unreachable — e.g. default credentials rejected, or the listener
turned off — `curl -s` swallows the connection error and
`imp-control` returns success anyway, so every command (day/night
color switching, brightness, contrast, white balance, bitrate, etc.)
silently no-ops.

`prudyntctl` talks to prudynt over `/run/prudynt/prudynt.sock`, a
Unix socket started unconditionally regardless of the HTTP server
setting, and is already used elsewhere (e.g. the daynight script for
FPS changes). Switching `imp-control` to the same local socket
removes the dependency on the HTTP listener entirely — same JSON
payloads, just over the socket instead of a network port that may
not be there.

## Test plan

- [x] Ran each `imp-control` subcommand against a live camera with
      the HTTP API disabled; all now apply instead of silently
      no-opping
- [x] Same JSON payloads as before, verified via `prudyntctl` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)