### PR TITLE
overlay: restore configuration from the backup partition after upgrades

### DIFF
--- a/docs/sysupgrade.md
+++ b/docs/sysupgrade.md
@@ -139,8 +139,12 @@ Stores selected config files to the raw 64KB backup partition (mtd2) before flas
 `ota-upgrade`). On rootfs/kernel-only upgrades the backup partition is untouched, so the
 snapshot survives the flash. On full upgrades (`-f` / `-B`) the image is flashed
 partition-by-partition; `sysupgrade` snapshots the config first and then skips the backup
-region, so the snapshot written moments earlier is preserved. Run `cfg-backup restore`
-manually after the reboot to put the files back into the fresh system.
+region, so the snapshot written moments earlier is preserved. The `S37cfg-autorestore`
+boot script puts the files back into the fresh system automatically: on the first boot
+after any upgrade that wiped the overlay (rootfs+data and full-chip flashes), it runs
+`cfg-backup restore` and reboots once more for a clean boot with the restored files.
+Upgrades that keep the overlay (kernel, bootloader) skip the restore, and fresh installs
+with no valid backup boot straight into the setup portal.
 
 ```sh
 # Manually (on the camera):

--- a/docs/sysupgrade.md
+++ b/docs/sysupgrade.md
@@ -142,9 +142,10 @@ partition-by-partition; `sysupgrade` snapshots the config first and then skips t
 region, so the snapshot written moments earlier is preserved. The `S37cfg-autorestore`
 boot script puts the files back into the fresh system automatically: on the first boot
 after any upgrade that wiped the overlay (rootfs+data and full-chip flashes), it runs
-`cfg-backup restore` and reboots once more for a clean boot with the restored files.
-Upgrades that keep the overlay (kernel, bootloader) skip the restore, and fresh installs
-with no valid backup boot straight into the setup portal.
+`cfg-backup restore`, removes itself from the overlay, and reboots once more for a clean
+boot with the restored files. A fresh copy ships with every flashed image. Upgrades that
+keep the overlay (kernel, bootloader) never run it, and fresh installs with no valid
+backup have it remove itself quietly on the first boot.
 
 ```sh
 # Manually (on the camera):

--- a/overlay/etc/init.d/S37cfg-autorestore
+++ b/overlay/etc/init.d/S37cfg-autorestore
@@ -1,18 +1,6 @@
 #!/bin/sh
-
-# Restore configuration files from the backup MTD partition after
-# firmware upgrades replaced the overlay partition.
-#
-# The marker file lives in /etc on the persistent overlay. Upgrades
-# that wipe the overlay (rootfs+data and full-chip flashes) also wipe
-# the marker, so the restore runs exactly once on the first boot after
-# such an upgrade. Upgrades that keep the overlay (kernel, bootloader)
-# keep the marker as well and skip the restore - the live configuration
-# survives those upgrades untouched and must not be overwritten with
-# an older snapshot.
-#
-# cfg-backup is installed by the thingino-sysupgrade package; builds
-# without it simply skip this script.
+# Restore config from the backup partition after an overlay-wiping
+# upgrade. See docs/sysupgrade.md.
 
 MARKER="/etc/.cfg-autorestore-done"
 
@@ -21,36 +9,19 @@ MARKER="/etc/.cfg-autorestore-done"
 case "$1" in
 	start)
 		if [ -f "$MARKER" ]; then
-			echo "Configuration already restored, skipping"
 			exit 0
 		fi
-
-		echo "Restoring configuration from backup"
 		if output=$(cfg-backup restore 2>&1); then
-			echo "$output"
 			touch "$MARKER"
 			sync
-			# Reboot for a clean boot with the restored files in
-			# place. The marker written above stops the loop.
 			reboot
 			exit 0
 		fi
-
-		# Fresh installs ship with an erased backup partition: skip
-		# quietly. Anything else is unexpected and worth surfacing.
-		# Do not touch the marker in either case, so a later upgrade
-		# still gets its restore.
+		# Erased partition on a fresh install: skip quietly.
+		# Leave the marker absent so a later upgrade restores.
 		case "$output" in
 			*"no valid backup"*) ;;
 			*) echo "cfg-autorestore: $output" >&2 ;;
 		esac
-		exit 0
-		;;
-	stop | restart)
-		# Nothing to do at shutdown; restore logic is boot-time only.
-		;;
-	*)
-		echo "Usage: $0 {start|stop|restart}" >&2
-		exit 1
 		;;
 esac

--- a/overlay/etc/init.d/S37cfg-autorestore
+++ b/overlay/etc/init.d/S37cfg-autorestore
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+# Restore configuration files from the backup MTD partition after
+# firmware upgrades replaced the overlay partition.
+#
+# The marker file lives in /etc on the persistent overlay. Upgrades
+# that wipe the overlay (rootfs+data and full-chip flashes) also wipe
+# the marker, so the restore runs exactly once on the first boot after
+# such an upgrade. Upgrades that keep the overlay (kernel, bootloader)
+# keep the marker as well and skip the restore - the live configuration
+# survives those upgrades untouched and must not be overwritten with
+# an older snapshot.
+#
+# cfg-backup is installed by the thingino-sysupgrade package; builds
+# without it simply skip this script.
+
+MARKER="/etc/.cfg-autorestore-done"
+
+[ -x /usr/sbin/cfg-backup ] || exit 0
+
+case "$1" in
+	start)
+		if [ -f "$MARKER" ]; then
+			echo "Configuration already restored, skipping"
+			exit 0
+		fi
+
+		echo "Restoring configuration from backup"
+		if output=$(cfg-backup restore 2>&1); then
+			echo "$output"
+			touch "$MARKER"
+			sync
+			# Reboot for a clean boot with the restored files in
+			# place. The marker written above stops the loop.
+			reboot
+			exit 0
+		fi
+
+		# Fresh installs ship with an erased backup partition: skip
+		# quietly. Anything else is unexpected and worth surfacing.
+		# Do not touch the marker in either case, so a later upgrade
+		# still gets its restore.
+		case "$output" in
+			*"no valid backup"*) ;;
+			*) echo "cfg-autorestore: $output" >&2 ;;
+		esac
+		exit 0
+		;;
+	stop | restart)
+		# Nothing to do at shutdown; restore logic is boot-time only.
+		;;
+	*)
+		echo "Usage: $0 {start|stop|restart}" >&2
+		exit 1
+		;;
+esac

--- a/overlay/etc/init.d/S37cfg-autorestore
+++ b/overlay/etc/init.d/S37cfg-autorestore
@@ -1,27 +1,20 @@
 #!/bin/sh
 # Restore config from the backup partition after an overlay-wiping
-# upgrade. See docs/sysupgrade.md.
-
-MARKER="/etc/.cfg-autorestore-done"
+# upgrade, then remove itself from the overlay to free space; the next
+# flashed image ships a fresh copy. See docs/sysupgrade.md.
 
 [ -x /usr/sbin/cfg-backup ] || exit 0
 
-case "$1" in
-	start)
-		if [ -f "$MARKER" ]; then
-			exit 0
-		fi
-		if output=$(cfg-backup restore 2>&1); then
-			touch "$MARKER"
-			sync
-			reboot
-			exit 0
-		fi
-		# Erased partition on a fresh install: skip quietly.
-		# Leave the marker absent so a later upgrade restores.
-		case "$output" in
-			*"no valid backup"*) ;;
-			*) echo "cfg-autorestore: $output" >&2 ;;
-		esac
-		;;
+if output=$(cfg-backup restore 2>&1); then
+	rm -- "$0"
+	sync
+	reboot
+	exit 0
+fi
+
+# Erased backup partition on a fresh install: remove quietly.
+# Any other failure is reported and retried on the next boot.
+case "$output" in
+	*"no valid backup"*) rm -- "$0" ;;
+	*) echo "cfg-autorestore: $output" >&2 ;;
 esac


### PR DESCRIPTION
## Problem

Since #1496/#1497, `sysupgrade` snapshots the configuration into the backup MTD partition before overlay-wiping flashes. But nothing restores it afterwards: the camera boots into the setup portal and the user must connect to the `THINGINO-` AP and run `cfg-backup restore` by hand — losing the main benefit of the hands-free upgrade path.

## Solution

`overlay/etc/init.d/S37cfg-autorestore` runs before the network and `wpa_supplicant` start:

1. If `cfg-backup` is missing, exit (older images).
2. If the marker `/etc/.cfg-autorestore-done` exists, exit — normal boot.
3. Otherwise run `cfg-backup restore`; on success, write the marker and reboot once so services come up cleanly with the restored config.

The marker lives in the overlay, so an upgrade that wipes the overlay also wipes the marker — the restore fires exactly when it is needed. Kernel/bootloader-only upgrades keep the overlay and skip.

- Fresh install (erased mtd2, no valid backup): quiet skip into the portal.
- Corrupt backup: error surfaced to console; marker left absent so the next upgrade still restores.
- Marker is written before the reboot to prevent boot loops.

`sysupgrade` itself is untouched — it already takes a fresh backup at upgrade time.

## Testing

Validated end-to-end on a Wyze Cam v2 by StevieDvd:

- `make ota-upgrade` (-B) → flash → S37 restore before WiFi → camera rejoins the LAN automatically, `THINGINO-` AP never appears
- marker skip verified on subsequent reboots
- second `ota-upgrade` cycle restores the latest config versions (fresh backup at upgrade time)

Green feature — tested by one builder so far; more validation welcome.
