### PR TITLE
agent-adapter: restart audio thread on mic/speaker enable changes

### DIFF
--- a/package/prudynt-t/files/agent-adapter
+++ b/package/prudynt-t/files/agent-adapter
@@ -1672,14 +1672,14 @@ agent_set_setting() {
 		audio/mic-enabled)
 			value=$(agent_setting_value "$body_file" mic_enabled) || return 1
 			agent_validate_bool "$value" || return 1
-			agent_apply_payload "{\"audio\":{\"mic_enabled\":$value}}" || return 1
+			agent_apply_payload "{\"audio\":{\"mic_enabled\":$value},\"action\":{\"restart_thread\":4}}" || return 1
 			agent_persist_value audio.mic_enabled "$value"
 			agent_print_setting_update "$path" mic_enabled "$value"
 			;;
 		audio/spk-enabled)
 			value=$(agent_setting_value "$body_file" spk_enabled) || return 1
 			agent_validate_bool "$value" || return 1
-			agent_apply_payload "{\"audio\":{\"spk_enabled\":$value}}" || return 1
+			agent_apply_payload "{\"audio\":{\"spk_enabled\":$value},\"action\":{\"restart_thread\":4}}" || return 1
 			agent_persist_value audio.spk_enabled "$value"
 			agent_print_setting_update "$path" spk_enabled "$value"
 			;;


### PR DESCRIPTION
## Problem

Toggling the speaker (or mic) button on the preview page turns the button off (gray) for a moment, then it flips back to on (orange).

The preview page sends `PATCH /api/v1/settings/audio/spk-enabled`. The agent-adapter applies the payload `{"audio":{"spk_enabled":false}}` to prudynt but **does not request a restart**. Prudynt treats `mic_enabled` and `spk_enabled` as restart-required parameters (audio + RTSP threads), so the running streamer keeps the old state and the new value only takes effect after a prudynt restart. Meanwhile `S99heartbeat` polls the live state every second, sees the speaker still enabled, and the UI flips back.

The setting *is* persisted to `/etc/prudynt.json` (via `agent_persist_value`), so it applies on the next restart — which is why the flip-back looks like a "stuck" toggle rather than a failed save.

## Fix

Include the audio-thread restart action in the payloads for `audio/mic-enabled` and `audio/spk-enabled`:

```
--- a/package/prudynt-t/files/agent-adapter
+++ b/package/prudynt-t/files/agent-adapter
@@ agent_set_setting()
 	agent_apply_payload "{\"audio\":{\"mic_enabled\":$value},\"action\":{\"restart_thread\":4}}" || return 1
 	agent_apply_payload "{\"audio\":{\"spk_enabled\":$value},\"action\":{\"restart_thread\":4}}" || return 1
```

This matches the two existing paths that work correctly:
- `speaker` CLI tool (ships with prudynt-t): sends `action.restart_thread: 4`
- Audio settings page (`config-audio` + `audio.js`): sends `action.restart_thread: ThreadAudio` (4)

## Testing

- Reproduced on wyze_cam3_t31x_gc2053_rtl8189ftv running ciao 3a6c603 (2026-08-22 build): toggle off -> heartbeat flips it back within ~1 s.
- Not yet hardware-verified with the patch applied. Happy to test on the reporting camera before merge if that is preferred.
- `shfmt -i 0 -ci` and `shellcheck` clean; repo pre-commit gates pass.


---

**Related Discord discussion:** https://discord.com/channels/1086012062649565286/1540820730227466380