### PR TITLE
timps: bump to v1.9.3 (fixes the stale hash from #1503) + WebUI encoder/OSD fixes

### DIFF
--- a/package/timps/files/www/a/streamer-encoder.js
+++ b/package/timps/files/www/a/streamer-encoder.js
@@ -5,8 +5,17 @@
  * page-streamer-substream -> 1).
  *
  * Every change goes to timpsApi.set({video:{idx:{key:val}}}) (audio switch
- * -> {audio:{enabled}}); ALL video/sensor keys are restart-required, so each
- * change shows the restart hint. Kept lean on purpose (embedded target): no
+ * -> {audio:{enabled}}). Since the live rate-control work, video keys are no
+ * longer uniformly restart-required: the daemon advertises the keys THIS
+ * camera can apply to the running encoder as caps.video_live, and every POST
+ * reply lists what did NOT apply live in deferred_keys. The per-save toast
+ * keys off the reply (runtime truth), the field styling keys off the caps
+ * (platform truth). Rate-control fields that cannot do anything on this
+ * SoC/mode/codec are disabled with the reason in their tooltip instead of
+ * being silently accepted. The read-only "Encoder readback" line shows what
+ * the encoder ACTUALLY holds (encoder.<n>.rc, GET /control) so a write can
+ * be checked against reality - the T23 investigation found knobs that
+ * persist fine and do nothing. Kept lean on purpose (embedded target): no
  * libraries, no polling, changes fire on 'change' only.
  */
 (function () {
@@ -36,7 +45,32 @@
     buffers: { key: "buffers", type: "int" },
     rtsp_endpoint: { key: "rtsp_path", type: "str" },
     enabled: { key: "enabled", type: "bool" },
+    qp: { key: "qp", type: "int" },
+    min_qp: { key: "min_qp", type: "int" },
+    max_qp: { key: "max_qp", type: "int" },
+    quality_lvl: { key: "quality_lvl", type: "int" },
+    change_pos: { key: "change_pos", type: "int" },
+    i_bias_lvl: { key: "i_bias_lvl", type: "int" },
+    fluc_lvl: { key: "fluc_lvl", type: "int" },
   };
+
+  // rate-control field applicability: which rc_mode / codec the SDK consults
+  // the field in, and whether only the classic SoCs (T10..T30) have it at
+  // all. Mirrors the field docs in timps.conf.example; the daemon accepts
+  // and persists everything regardless - this is about not offering a knob
+  // that provably does nothing on this camera.
+  var RC_FIELDS = {
+    qp: { modes: ["FIXQP"] },
+    min_qp: {},
+    max_qp: {},
+    quality_lvl: { modes: ["VBR", "SMART"], classicOnly: true },
+    change_pos: { modes: ["VBR", "SMART"], classicOnly: true },
+    i_bias_lvl: {},   // per-SoC: classic yes, T31/C100 via QpIPDelta, T40/T41 no
+    fluc_lvl: { codecs: ["H265"], classicOnly: true },
+  };
+  var CLASSIC_FAMS = ["t10", "t20", "t21", "t23", "t30"];
+  var NO_IBIAS_FAMS = ["t40", "t41"];
+  var videoLive = null; // caps.video_live once known (keys that apply live)
 
   // page codec/mode spelling <-> timps canonical (lowercase) spelling
   function codecToTimps(v) { return String(v).toLowerCase(); }        // H264 -> h264
@@ -83,6 +117,18 @@
       "Setting saved. Encoder changes take effect after a streamer restart (Restart streamer in the menu).",
       8000,
     );
+  }
+
+  // Per-save verdict from the POST reply (runtime truth, see control.h):
+  // deferred_keys lists the changed video/sensor keys that did NOT reach the
+  // running encoder. Absent field (older daemon) -> conservative restart
+  // hint, the pre-live behaviour.
+  function saveVerdict(r, fullKey) {
+    if (!r || !Array.isArray(r.deferred_keys)) { restartHint(); return; }
+    if (r.deferred_keys.indexOf(fullKey) >= 0) { restartHint(); return; }
+    if (r.changed > 0)
+      toast("success", "Applied to the running encoder; takes effect at the next keyframe.", 4000);
+    // unchanged re-post: nothing to announce
   }
 
   function setEnabled(id, on) {
@@ -155,7 +201,13 @@
     if (el) el.classList.add("opacity-75");
     window.timpsApi
       .set({ video: video })
-      .then(function (r) { applyCorrections(r); restartHint(); }, function (err) {
+      .then(function (r) {
+        applyCorrections(r);
+        saveVerdict(r, "video" + idx + "." + map.key);
+        if (RC_FIELDS[suffix] || suffix === "mode" || suffix === "format" || suffix === "bitrate")
+          rcGate();          // mode/codec switch changes which rc fields count
+        refreshRcHolds();    // show what the encoder holds after the write
+      }, function (err) {
         console.error("timps set failed:", err);
         toast("danger", "Failed to save setting: " + (err.message || err));
       })
@@ -210,6 +262,76 @@
     var video = {};
     video[FIELD_MAP[suffix].key] = data.value;
     populate(suffix, FIELD_MAP[suffix], video);
+    if (suffix === "mode" || suffix === "format") rcGate();
+  }
+
+  // Disable rc fields that provably cannot do anything with the current
+  // SoC/mode/codec, and say why in the tooltip; annotate the rest with
+  // whether they apply live (caps.video_live) or need a restart. Never
+  // guesses: an unknown SoC family stays fully enabled.
+  function rcGate() {
+    var fam = socFamily(
+      (window.thinginoUIConfig && window.thinginoUIConfig.device &&
+       window.thinginoUIConfig.device.soc) || null);
+    var classic = fam ? CLASSIC_FAMS.indexOf(fam) >= 0 : null;
+    var modeEl = $id(P + "mode"), fmtEl = $id(P + "format");
+    var mode = modeEl ? modeEl.value : "";
+    var codec = fmtEl ? fmtEl.value : "";
+    Object.keys(RC_FIELDS).forEach(function (suffix) {
+      var info = RC_FIELDS[suffix];
+      var el = $id(P + suffix);
+      if (!el) return;
+      var off = null;
+      if (classic === false && info.classicOnly)
+        off = "No effect on this SoC (new encoder API has no such field)";
+      else if (classic === false && suffix === "i_bias_lvl" &&
+               NO_IBIAS_FAMS.indexOf(fam) >= 0)
+        off = "This SoC's SDK cannot set the I-frame bias";
+      else if (info.modes && mode && info.modes.indexOf(mode) < 0)
+        off = "Only used in mode: " + info.modes.join("/");
+      else if (info.codecs && codec && info.codecs.indexOf(codec) < 0)
+        off = "Only used with codec: " + info.codecs.join("/");
+      setEnabled(P + suffix, !off);
+      var base = el.getAttribute("data-base-title");
+      if (base === null) {
+        base = el.title || "";
+        el.setAttribute("data-base-title", base);
+      }
+      var liveNote = "";
+      if (videoLive)
+        liveNote = videoLive.indexOf(FIELD_MAP[suffix].key) >= 0
+          ? " Applies live (next keyframe)."
+          : " Takes effect after a streamer restart.";
+      el.title = off ? off : (base + liveNote);
+    });
+  }
+
+  // Read-only line under the rc fields: what the encoder ACTUALLY holds
+  // (encoder.<idx>.rc from GET /control). Deliberately shown next to the
+  // editable (configured) values so written vs held can be compared - the
+  // whole point of the readback.
+  var RC_HOLD_ORDER = ["rc_mode", "bitrate", "max_bitrate", "qp", "min_qp",
+    "max_qp", "quality_lvl", "change_pos", "i_bias_lvl", "fluc_lvl",
+    "static_time", "frm_qp_step", "gop_qp_step", "ip_delta", "pb_delta",
+    "max_psnr"];
+  function refreshRcHolds() {
+    var el = $id(P + "rc_holds");
+    if (!el || !window.timpsApi) return;
+    window.timpsApi.get().then(function (json) {
+      var rc = json.encoder && json.encoder[idx] && json.encoder[idx].rc;
+      if (!rc) {
+        el.textContent =
+          "Encoder readback: not available (channel not running, or the daemon predates it).";
+        return;
+      }
+      var parts = [];
+      RC_HOLD_ORDER.forEach(function (k) {
+        if (rc[k] !== undefined) parts.push(k.replace(/_/g, " ") + " " + rc[k]);
+      });
+      el.textContent = "Encoder holds: " + parts.join(", ");
+    }, function () {
+      el.textContent = "Encoder readback: unavailable (streamer not reachable).";
+    });
   }
 
   function wireControls() {
@@ -278,6 +400,9 @@
           if (audio.enabled !== undefined) au.checked = !!Number(audio.enabled);
           setEnabled(P + "audio_enabled", true);
         }
+        videoLive = (json.caps && json.caps.video_live) || [];
+        rcGate();
+        refreshRcHolds();
         var offline = $id("timps-offline-notice");
         if (offline) offline.remove();
       })

--- a/package/timps/files/www/a/streamer-osd.js
+++ b/package/timps/files/www/a/streamer-osd.js
@@ -87,6 +87,19 @@
   // last loaded item snapshot per stream (for the other stream in "both"
   // scope auto-detect and to remember a card's current type)
   var itemData = { 0: {}, 1: {} };
+  // per-item "Apply to" scope the USER explicitly picked on this page, keyed
+  // by item index. load() rebuilds every card from scratch (a fresh GET, or
+  // a re-render triggered by this page's own /events "config" echo - see
+  // onConfigEvent), and until this was tracked separately, buildCard() re-
+  // derived the scope every time from itemsIdentical() alone: any edit that
+  // did not (yet) make EVERY tracked leaf byte-identical on both streams -
+  // in practice nearly always, since x/y rarely match across two streams
+  // with different resolutions - silently reverted the dropdown to "This
+  // stream" on the very next reload, so only the field that happened to be
+  // in flight when "Both streams" was selected actually landed on both
+  // sides. An explicit choice now sticks until the user changes it again or
+  // removes the card.
+  var scopeChoice = {};
 
   // ---- POST helpers ----------------------------------------------------
 
@@ -376,10 +389,13 @@
     card.querySelector(".osd-trans").value = tr;
     card.querySelector(".osd-trans-val").textContent = "(" + tr + ")";
 
-    // ---- scope: default "this"; auto-detect "both" only when this item is
-    // enabled and byte-identical on both streams (a nice-to-have, never for
-    // empty/default slots) ----
-    if (Number(data.enabled) && itemsIdentical(item)) {
+    // ---- scope: an explicit user choice for this item always wins (see
+    // scopeChoice above). Otherwise default "this"; auto-detect "both" only
+    // when this item is enabled and byte-identical on both streams (a nice-
+    // to-have, never for empty/default slots) ----
+    if (Object.prototype.hasOwnProperty.call(scopeChoice, item)) {
+      card.querySelector(".osd-scope").value = scopeChoice[item];
+    } else if (Number(data.enabled) && itemsIdentical(item)) {
       card.querySelector(".osd-scope").value = "both";
     }
     syncBothNote(card);
@@ -423,10 +439,12 @@
       if (restart) p.then(restartHint);
     });
 
-    // scope change: no POST by itself; just re-flags the "both" note. Existing
-    // values are re-pushed to the other stream on the next edit (nudge any
-    // field to copy immediately).
+    // scope change: no POST by itself; just records the choice (so it
+    // survives the next load()/rebuild, see scopeChoice above) and re-flags
+    // the "both" note. Existing values are re-pushed to the other stream on
+    // the next edit (nudge any field to copy immediately).
     card.querySelector(".osd-scope").addEventListener("change", function () {
+      scopeChoice[item] = cardScope(card);
       syncBothNote(card);
     });
 
@@ -493,9 +511,13 @@
     });
 
     // remove: disable (live-hide + persist) and drop the card. A fixed slot
-    // is never destroyed server-side; disabling it frees it for reuse.
+    // is never destroyed server-side; disabling it frees it for reuse, so
+    // also forget any explicit scope choice for it - a future re-add should
+    // start from the auto-detect default, not a stale pick for a slot that
+    // may now hold unrelated content.
     card.querySelector(".osd-remove").addEventListener("click", function () {
       push({ enabled: 0 }, card);
+      delete scopeChoice[item];
       card.parentNode.removeChild(card);
       refreshSlotUI();
     });

--- a/package/timps/files/www/streamer-main.html
+++ b/package/timps/files/www/streamer-main.html
@@ -102,6 +102,55 @@
       </div>
     </div>
 
+    <h5 class="mt-2">Rate control</h5>
+    <p class="text-secondary small mb-2">
+      Saved instantly. Fields the camera can apply to the <em>running</em> encoder take effect
+      at the next keyframe; everything else needs a streamer restart &mdash; each save says which.
+      Which fields do anything depends on the mode and SoC: quality level and change position
+      count only for VBR/SMART on the older SoCs (T10&hellip;T30), fixed QP only in FIXQP mode.
+      Measured on T23: quality level reliably lowers the bitrate; change position showed no
+      measurable effect there.
+    </p>
+    <div class="row g-2">
+      <div class="col">
+        <p>
+          <label for="stream0_min_qp">Min QP</label>
+          <input type="text" id="stream0_min_qp" name="stream0_min_qp" class="form-control" value="" title="1..51, lower bound for the rate controller">
+        </p>
+        <p>
+          <label for="stream0_max_qp">Max QP</label>
+          <input type="text" id="stream0_max_qp" name="stream0_max_qp" class="form-control" value="" title="1..51, upper bound for the rate controller">
+        </p>
+      </div><!-- .col -->
+      <div class="col">
+        <p>
+          <label for="stream0_qp">Fixed QP</label>
+          <input type="text" id="stream0_qp" name="stream0_qp" class="form-control" value="" title="1..51, only used in FIXQP mode">
+        </p>
+        <p>
+          <label for="stream0_i_bias_lvl">I-frame bias</label>
+          <input type="text" id="stream0_i_bias_lvl" name="stream0_i_bias_lvl" class="form-control" value="" title="-3..3; negative spends more bits on keyframes">
+        </p>
+      </div><!-- .col -->
+      <div class="col">
+        <p>
+          <label for="stream0_quality_lvl">Quality level</label>
+          <input type="text" id="stream0_quality_lvl" name="stream0_quality_lvl" class="form-control" value="" title="0..7, VBR/SMART on T10..T30 only; lower = better picture, higher bitrate">
+        </p>
+        <p>
+          <label for="stream0_change_pos">Change position</label>
+          <input type="text" id="stream0_change_pos" name="stream0_change_pos" class="form-control" value="" title="50..100 %, VBR/SMART on T10..T30 only; no measurable effect in T23 tests">
+        </p>
+      </div><!-- .col -->
+      <div class="col">
+        <p>
+          <label for="stream0_fluc_lvl">Fluctuation level</label>
+          <input type="text" id="stream0_fluc_lvl" name="stream0_fluc_lvl" class="form-control" value="" title="0..4, H265 on T10..T30 only">
+        </p>
+      </div><!-- .col -->
+    </div>
+    <p id="stream0_rc_holds" class="form-text mt-2">Encoder readback: &hellip;</p>
+
     <button type="button" id="save-prudynt-config" class="btn btn-primary mt-3">
       <i class="bi bi-floppy me-1"></i> Save configuration to file
     </button>

--- a/package/timps/files/www/streamer-main.html
+++ b/package/timps/files/www/streamer-main.html
@@ -108,14 +108,15 @@
       at the next keyframe; everything else needs a streamer restart &mdash; each save says which.
       Which fields do anything depends on the mode and SoC: quality level and change position
       count only for VBR/SMART on the older SoCs (T10&hellip;T30), fixed QP only in FIXQP mode.
-      Measured on T23: quality level reliably lowers the bitrate; change position showed no
-      measurable effect there.
+      Measured on T23: the controller is quality-seeking, so <em>Min QP</em> is the strongest
+      lever (raising it lowers the bitrate); quality level moves it more gently; change position
+      showed no measurable effect there.
     </p>
     <div class="row g-2">
       <div class="col">
         <p>
           <label for="stream0_min_qp">Min QP</label>
-          <input type="text" id="stream0_min_qp" name="stream0_min_qp" class="form-control" value="" title="1..51, lower bound for the rate controller">
+          <input type="text" id="stream0_min_qp" name="stream0_min_qp" class="form-control" value="" title="1..51. On T23-class SoCs the strongest bitrate lever: the controller encodes the best quality this allows (measured 20/30/38 -> 1743/1181/235 kbit/s)">
         </p>
         <p>
           <label for="stream0_max_qp">Max QP</label>

--- a/package/timps/files/www/streamer-substream.html
+++ b/package/timps/files/www/streamer-substream.html
@@ -102,6 +102,55 @@
       </div>
     </div>
 
+    <h5 class="mt-2">Rate control</h5>
+    <p class="text-secondary small mb-2">
+      Saved instantly. Fields the camera can apply to the <em>running</em> encoder take effect
+      at the next keyframe; everything else needs a streamer restart &mdash; each save says which.
+      Which fields do anything depends on the mode and SoC: quality level and change position
+      count only for VBR/SMART on the older SoCs (T10&hellip;T30), fixed QP only in FIXQP mode.
+      Measured on T23: quality level reliably lowers the bitrate; change position showed no
+      measurable effect there.
+    </p>
+    <div class="row g-2">
+      <div class="col">
+        <p>
+          <label for="stream1_min_qp">Min QP</label>
+          <input type="text" id="stream1_min_qp" name="stream1_min_qp" class="form-control" value="" title="1..51, lower bound for the rate controller">
+        </p>
+        <p>
+          <label for="stream1_max_qp">Max QP</label>
+          <input type="text" id="stream1_max_qp" name="stream1_max_qp" class="form-control" value="" title="1..51, upper bound for the rate controller">
+        </p>
+      </div><!-- .col -->
+      <div class="col">
+        <p>
+          <label for="stream1_qp">Fixed QP</label>
+          <input type="text" id="stream1_qp" name="stream1_qp" class="form-control" value="" title="1..51, only used in FIXQP mode">
+        </p>
+        <p>
+          <label for="stream1_i_bias_lvl">I-frame bias</label>
+          <input type="text" id="stream1_i_bias_lvl" name="stream1_i_bias_lvl" class="form-control" value="" title="-3..3; negative spends more bits on keyframes">
+        </p>
+      </div><!-- .col -->
+      <div class="col">
+        <p>
+          <label for="stream1_quality_lvl">Quality level</label>
+          <input type="text" id="stream1_quality_lvl" name="stream1_quality_lvl" class="form-control" value="" title="0..7, VBR/SMART on T10..T30 only; lower = better picture, higher bitrate">
+        </p>
+        <p>
+          <label for="stream1_change_pos">Change position</label>
+          <input type="text" id="stream1_change_pos" name="stream1_change_pos" class="form-control" value="" title="50..100 %, VBR/SMART on T10..T30 only; no measurable effect in T23 tests">
+        </p>
+      </div><!-- .col -->
+      <div class="col">
+        <p>
+          <label for="stream1_fluc_lvl">Fluctuation level</label>
+          <input type="text" id="stream1_fluc_lvl" name="stream1_fluc_lvl" class="form-control" value="" title="0..4, H265 on T10..T30 only">
+        </p>
+      </div><!-- .col -->
+    </div>
+    <p id="stream1_rc_holds" class="form-text mt-2">Encoder readback: &hellip;</p>
+
     <button type="button" id="save-prudynt-config" class="btn btn-primary mt-3">
       <i class="bi bi-floppy me-1"></i> Save configuration to file
     </button>

--- a/package/timps/files/www/streamer-substream.html
+++ b/package/timps/files/www/streamer-substream.html
@@ -108,14 +108,15 @@
       at the next keyframe; everything else needs a streamer restart &mdash; each save says which.
       Which fields do anything depends on the mode and SoC: quality level and change position
       count only for VBR/SMART on the older SoCs (T10&hellip;T30), fixed QP only in FIXQP mode.
-      Measured on T23: quality level reliably lowers the bitrate; change position showed no
-      measurable effect there.
+      Measured on T23: the controller is quality-seeking, so <em>Min QP</em> is the strongest
+      lever (raising it lowers the bitrate); quality level moves it more gently; change position
+      showed no measurable effect there.
     </p>
     <div class="row g-2">
       <div class="col">
         <p>
           <label for="stream1_min_qp">Min QP</label>
-          <input type="text" id="stream1_min_qp" name="stream1_min_qp" class="form-control" value="" title="1..51, lower bound for the rate controller">
+          <input type="text" id="stream1_min_qp" name="stream1_min_qp" class="form-control" value="" title="1..51. On T23-class SoCs the strongest bitrate lever: the controller encodes the best quality this allows (measured 20/30/38 -> 1743/1181/235 kbit/s)">
         </p>
         <p>
           <label for="stream1_max_qp">Max QP</label>

--- a/package/timps/timps.hash
+++ b/package/timps/timps.hash
@@ -1,2 +1,2 @@
 # Locally calculated
-sha256  709c4fe3281c58191b2c6323ec72f1e9c4de362cd1a879e019db827ef797970e  timps-v1.9.1.tar.gz
+sha256  42ed60ccf97a0bb43380d27dd89a9c42e4b351b3046d96262419e30595b6f638  timps-v1.9.3-git4.tar.gz

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,7 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.9.1
+TIMPS_VERSION = v1.9.3
 TIMPS_LICENSE = MIT
 # Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
 # once it exists so legal-info can capture it.


### PR DESCRIPTION
## Summary

- **Bumps `TIMPS_VERSION` to v1.9.3 and regenerates `timps.hash` in the same commit.** Upstream is still pinned at v1.9.1 with a hash for `timps-v1.9.1.tar.gz` that was already reported broken by @Ph0rk0z in #1503 (wrong filename format - this Buildroot's git backend names the archive `<name>-<version>-git4.tar.gz`, not `<name>-<version>.tar.gz`). Verified by temporarily disabling `TIMPS_OVERRIDE_SRCDIR` and running the real Buildroot git-fetch + hash-check for this package twice: both runs produced the identical sha256 for `timps-v1.9.3-git4.tar.gz`, and `check-hash` accepts it. `make timps-source` now succeeds from a clean checkout.
- **WebUI: per-channel rate-control fields with live/restart truth + readback** - adds Main/Sub encoder controls to the streamer pages that reflect what `/control`'s `caps.video_live` and `encoder.<n>.rc` actually report for the running build, instead of assuming every field behaves the same on every SoC.
- **WebUI: names Min QP as the measured T23 lever** - corrects a tooltip that pointed at the wrong control for tuning the T23's operating point (see timps's `Rate-Control-Parameters.md` for the underlying measurement).
- **timps: fixes OSD "Apply to both streams" reverting after the first edit** - a real bug in `streamer-osd.js` where a second field edit on the same overlay slot silently discarded the "apply to both" choice made on the first edit.

## Why v1.9.3, not v1.9.2

v1.9.2 already shipped a hash-file fix for a different stale-hash incident (see the note further down `timps.mk`'s history), but that fix never made it into this fork's own pin, and it used the same wrong (non-`git4`) filename format this PR corrects. v1.9.3 also carries a set of daemon reliability fixes (a real-restart bring-up bug that could strand the daemon dark, an encoder rate-control grading fix, day/night boot-time measurement instead of trusting a persisted value) that are out of scope for this WebUI/build-only PR but are why the pin moves past v1.9.2 rather than to it - see the [timps CHANGELOG](https://github.com/Lu-Fi/timps/blob/main/CHANGELOG.md) for the full list.

## Test plan

- [x] `make timps-source` succeeds from a clean checkout (no `TIMPS_OVERRIDE_SRCDIR`) - confirms the hash fix
- [x] Verified reproducibly: two independent fetches of the `v1.9.3` tag produce the identical sha256
- [x] Full board build + OTA flash to hardware, `timps-qa.sh` clean pass
- [x] OSD "apply to both" fix and the new encoder fields manually exercised in the WebUI against a running camera

🤖 Generated with [Claude Code](https://claude.com/claude-code)