### PR TITLE
thingino-raptor: restrict WHIP DELETE target

### DIFF
--- a/package/thingino-raptor/files/www/x/webrtc-whip.cgi
+++ b/package/thingino-raptor/files/www/x/webrtc-whip.cgi
@@ -108,16 +108,22 @@ if [ "${REQUEST_METHOD:-}" = "DELETE" ]; then
 	session_raw="$(qs_get session)"
 	session="$(url_decode "${session_raw:-}")"
 
+	# Raptor returns a relative /whip/<id> Location. Allow its absolute form
+	# too, but keep DELETE on the fixed backend because curl may attach credentials.
 	case "$session" in
 		'')
 			send_json "400 Bad Request" '{"error":"missing_session"}'
 			exit 0
 			;;
-		http://* | https://*)
+		/whip/?*)
+			target="$BACKEND_BASE$session"
+			;;
+		"$BACKEND_BASE"/whip/?*)
 			target="$session"
 			;;
 		*)
-			target="$BACKEND_BASE$session"
+			send_json "400 Bad Request" '{"error":"invalid_session"}'
+			exit 0
 			;;
 	esac
 


### PR DESCRIPTION
## Summary

- restrict WHIP session teardown to `/whip/<id>` on the fixed Raptor backend
- retain both relative and exact-backend absolute session resource forms
- reject all other DELETE targets with `400 invalid_session` before invoking curl

## Why

The native preview exposes this CGI without WebUI authentication. Previously, any absolute HTTP(S) `session` value became the curl target, and the request could include the configured WebRTC Basic credentials. A caller could therefore trigger an authenticated DELETE to an arbitrary host, creating an SSRF and credential-disclosure path.

Raptor currently returns `Location: /whip/<session-id>`. The exact `https://127.0.0.1:8554/whip/<session-id>` form remains accepted for compatibility, while foreign origins and unrelated backend paths are rejected.

## Validation

- BusyBox ash functional checks for valid relative and exact-backend absolute resources
- rejection checks for missing/empty, foreign HTTP/HTTPS, userinfo-host, lookalike-host, protocol-relative, and unrelated-path values
- `sh -n` and `busybox sh -n`
- `shellcheck -s sh`
- `shfmt -d -i 0 -ci`
- `git diff --check`
- `scripts/check-do-not-edit.sh`

No firmware build was run; this changes only an installed CGI shell script.