### PR TITLE
prudynt-t: fix motion suppression while PTZ motors move

### DIFF
--- a/package/prudynt-t/files/motion
+++ b/package/prudynt-t/files/motion
@@ -12,8 +12,6 @@ MOTION_ALARM="/run/motion/motion_alarm"
 MOTION_ALARM_DIR=$(dirname "$MOTION_ALARM")
 [ -d "$MOTION_ALARM_DIR" ] || mkdir -p "$MOTION_ALARM_DIR"
 
-MOTION_STOP_FILE="/run/motors.pid"
-
 MOTION_VIDEO_CHANNEL=0
 # Duration for motion clips (seconds). Read from config or default to 10.
 MOTION_VIDEO_LENGTH=$(jct /etc/prudynt.json get motion.video_length 2>/dev/null)
@@ -35,9 +33,14 @@ set_enabled() {
 
 start() {
 	echo_info "Start motion"
-	if [ -f "$MOTION_STOP_FILE" ]; then
-		echo_error "Motor motion file present. Exiting."
-		exit 1
+
+	# Suppress alerts while PTZ motors are moving. motors-daemon writes
+	# /run/motors-active on move start and removes it once the motors
+	# report idle (typically ~100ms). Check both the current flag and the
+	# legacy pidfile name used by older motors-daemon versions.
+	if [ -f /run/motors-active ] || [ -f /run/motors.pid ]; then
+		echo_error "Motors are moving. Suppressing motion event."
+		exit 0
 	fi
 
 	# Generate timestamp for this motion event


### PR DESCRIPTION
## Problem

On PTZ cameras running Prudynt, every pan/tilt move triggers a motion alert, because the motion hook's suppression check is dead code:

- `package/prudynt-t/files/motion` checked for `/run/motors.pid`
- `motors-daemon` never writes that path. It writes a `/run/motors-active` flag while a move is in progress (removed ~100ms after the motors report idle), and its pidfile is `/run/motors-daemon.pid`
- Nothing in either repo ever creates `/run/motors.pid`

## Fix

Check `/run/motors-active` (current flag) with `/run/motors.pid` kept as a legacy fallback, inside `start()` so that `stop` events still clear the alarm flag while motors move. Suppression then automatically covers WebUI arrows, ONVIF moves, and presets, for exactly the duration of the movement.

Reported by Klokkpahr on the Thingino Discord (Cinnado D1 PTZ, motion notifications working but false alarms on every move).