### PR TITLE
wireguard: check for either IPv4 or IPv6 connectivity, not just one

### DIFF
--- a/package/thingino-wireguard-tools/files/S42wireguard
+++ b/package/thingino-wireguard-tools/files/S42wireguard
@@ -13,7 +13,7 @@ WIREGUARD_WATCHDOG_PIDFILE="/run/wireguard-watchdog-loop.pid"
 
 network_is_active() {
 	command -v ip >/dev/null 2>&1 || return 1
-	ip -o -4 addr show up scope global 2>/dev/null | grep -q .
+	ip -o addr show up scope global 2>/dev/null | grep -q .
 }
 
 wireguard_json_get() {


### PR DESCRIPTION
## Summary

`network_is_active()` checked for a global-scope IPv4 address before
starting WireGuard. A camera with no IPv4 lease at all -- IPv6-only
via SLAAC, for example -- always fails this check even with full
connectivity, so WireGuard silently refuses to start ("No active
network connection") on an otherwise fully-working camera.

Drops the family flag entirely: `ip -o addr show` with neither `-4`
nor `-6` lists both address families, so the check now passes on a
global IPv4 address, a global IPv6 address, or both -- correct
regardless of which stack(s) a given deployment actually uses.

## Test plan

- [x] Verified `ip -o addr show` (no family flag) lists both `inet`
      and `inet6` global-scope lines
- [x] Verified on real hardware: WireGuard now starts correctly on an
      IPv6-only (SLAAC, no DHCP lease) camera, where it previously
      failed with "No active network connection"

🤖 Generated with [Claude Code](https://claude.com/claude-code)