### PR TITLE
system: mount SD cards async with bounded dirty-page writeback

### DIFF
--- a/overlay/etc/sysctl.conf
+++ b/overlay/etc/sysctl.conf
@@ -18,3 +18,13 @@ net.ipv4.tcp_fin_timeout = 15
 # (SndbufErrors). raptor's rsd-555 requests rtsp.send_buffer_size
 # (512 KiB default) at sink setup, which this ceiling must admit.
 net.core.wmem_max = 1048576
+
+# Global bound on dirty-page writeback for all block devices (SD cards,
+# USB mass storage, anything on the generic writeback path), instead of
+# the kernel's default ratios: the flusher wakes at 512K dirty and writers
+# are throttled at 4M. Removable media mounts async (see automount), so
+# this caps both the RAM committed to writeback and the data at risk on
+# an unclean removal at 4M, while card-internal GC stalls are absorbed
+# by the budget instead of stalling the recorder/streamer.
+vm.dirty_background_bytes = 524288
+vm.dirty_bytes = 4194304

--- a/package/thingino-system/files/automount
+++ b/package/thingino-system/files/automount
@@ -12,13 +12,11 @@ echo -c 240 -e "- Device node: $device_node"
 mount_point="/mnt/$MDEV"
 echo -c 240 -e "- Mount point: $mount_point"
 
-# Camera SD cards favor immediate persistence. SATA and USB block storage are
-# also used by NVRs, where a synchronous mount would serialize every database
-# and recording write and needlessly wear the drive.
-mount_options="noatime,sync"
-case "$MDEV" in
-	sd[a-z][0-9]*) mount_options="noatime" ;;
-esac
+# Mount removable media async: sync serializes every write, so card-internal
+# GC pauses propagate straight into writers (dropped frames in the recorder).
+# Dirty pages are bounded globally by sysctl.conf (vm.dirty_bytes); do_umount
+# syncs before releasing the card on graceful removal.
+mount_options="noatime"
 
 diag="$mount_point/.diag"
 run="$mount_point/run.sh"
@@ -101,6 +99,7 @@ do_umount() {
 	if grep -qs "^$device_node " /proc/mounts; then
 		if umount -l "$mount_point"; then
 			echo -c 240 -e "- Unmounted $mount_point"
+			sync
 		else
 			echo -c 142 -e "Failed to unmount $mount_point" >&2
 		fi


### PR DESCRIPTION
## Problem

SD cards are automounted with `-o sync` (`/usr/lib/mdev/automount`). With a sync mount, every `write(2)` blocks until the SD card acknowledges it — only one write in flight per writer. That keeps RAM pressure down, but it means card-internal GC pauses (100 ms to over a second) propagate directly into whatever is writing: raptor/rmr drops frames while recording, timelapse stalls.

## Change

- **Drop `sync`** from the automount, keep `noatime` — this is the dominant change. `sync` is far more aggressive than anything else in this PR: zero buffering, every write blocks immediately, every card stall lands directly in the writer.
- **Bound dirty pages globally** in `/etc/sysctl.conf` (applied by `S00sysctl`):
  - `vm.dirty_background_bytes = 512K` — flusher wakes early, keeps steady-state dirty memory near zero
  - `vm.dirty_bytes = 4M` — hard throttle ceiling; the remaining headroom absorbs card stalls
- **`sync` on umount** — with an async mount, the lazy umount could otherwise leave up to 4 MB unflushed when the card is pulled.

RAM is still capped — 4 MB of dirty pages replaces "one write in flight" as the bound — but writes coalesce and GC stalls are absorbed by the dirty budget instead of stalling the recorder.

## Before / after

**Before:** sync mount. Zero dirty buffering on the card — writes block on every `write(2)`, so card GC pauses hit the recorder in full.

**After:** async mount with pinned byte limits. The kernel default would be ratio-based (`dirty_background_ratio = 10` / `dirty_ratio = 20` — ~4.3 MB / ~8.6 MB on a 43 MB board, scaling with RAM); this PR pins deterministic bytes instead so the limits are identical on every board. Compared to the sync mount, the write path is massively looser — up to 4 MB of buffering where before there was none.

## Testing

Not yet tested on hardware — validation on a real recording workload (raptor/rmr to SD) is pending. Feedback from testers on other SoC families and workloads welcome.