### PR TITLE
timps: don't let the stock-webui purge delete timps's own restart CGI

### DIFF
--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -620,10 +620,11 @@ define TIMPS_PURGE_STOCK_WEBUI
 	#
 	# NOT included here: var/www/x/restart-prudynt.cgi. That filename is
 	# stock prudynt's, but the file at this path is timps's OWN replacement
-	# (see files/www/x/restart-prudynt.cgi's own header comment - same name,
-	# same URL, on purpose, because the stock WebUI pages call
-	# /x/restart-prudynt.cgi by that literal path). TIMPS_INSTALL_WEBUI
-	# installs it earlier in the same target-finalize pass; deleting it here
+	# (see files/www/x/restart-prudynt.cgi's own header comment - same
+	# name, same URL, on purpose: it's timps's own files/www/a/timps-
+	# preview.js that calls /x/restart-prudynt.cgi by that literal path,
+	# not anything in the stock/base WebUI). TIMPS_INSTALL_WEBUI installs
+	# it earlier in the same target-finalize pass; deleting it here
 	# unconditionally removed timps's own file, not a stock leftover, and
 	# left the WebUI's "Restart" button 404ing on every image since the file
 	# was added (2026-08-16) - found 2026-08-24 when a user's restart-required

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -613,13 +613,23 @@ define TIMPS_PURGE_STOCK_WEBUI
 	# Same argument, two orders of magnitude larger: "streamer" is a Kconfig
 	# choice, so prudynt and raptor cannot be installed beside timps - yet
 	# thingino-agent ships an adapter for each, 85 KB and 79 KB of shell that
-	# nothing on this image can ever call, plus prudynt's restart CGI and its
-	# helper directory. Removed here for the same reason as the two scripts
-	# above, and it has to be here: deleting them from $(TARGET_DIR) earlier
-	# is undone by the per-package merge that target-finalize runs first.
+	# nothing on this image can ever call, plus prudynt's helper directory.
+	# Removed here for the same reason as the two scripts above, and it has
+	# to be here: deleting them from $(TARGET_DIR) earlier is undone by the
+	# per-package merge that target-finalize runs first.
+	#
+	# NOT included here: var/www/x/restart-prudynt.cgi. That filename is
+	# stock prudynt's, but the file at this path is timps's OWN replacement
+	# (see files/www/x/restart-prudynt.cgi's own header comment - same name,
+	# same URL, on purpose, because the stock WebUI pages call
+	# /x/restart-prudynt.cgi by that literal path). TIMPS_INSTALL_WEBUI
+	# installs it earlier in the same target-finalize pass; deleting it here
+	# unconditionally removed timps's own file, not a stock leftover, and
+	# left the WebUI's "Restart" button 404ing on every image since the file
+	# was added (2026-08-16) - found 2026-08-24 when a user's restart-required
+	# setting change appeared to silently do nothing.
 	rm -f $(TARGET_DIR)/usr/libexec/thingino-agent/adapters/prudynt.sh \
-	      $(TARGET_DIR)/usr/libexec/thingino-agent/adapters/raptor.sh \
-	      $(TARGET_DIR)/var/www/x/restart-prudynt.cgi
+	      $(TARGET_DIR)/usr/libexec/thingino-agent/adapters/raptor.sh
 	rm -rf $(TARGET_DIR)/usr/share/prudynt-helpers
 endef
 TARGET_FINALIZE_HOOKS := TIMPS_REAPPLY_WEBUI_OVERLAY $(TARGET_FINALIZE_HOOKS)


### PR DESCRIPTION
## Summary
- `TIMPS_PURGE_STOCK_WEBUI` removes stock prudynt/raptor files that can never be reached on a timps image (streamer backend is an exclusive Kconfig choice) - but its list included `var/www/x/restart-prudynt.cgi`, which is *also* the exact path timps installs its own replacement restart CGI under (same name/URL on purpose - `timps-preview.js` calls that literal path).
- Both hooks run in the same `target-finalize` pass; the purge ran after the install and silently deleted timps's own file on every image built since the file was added - the WebUI's "Restart streamer" action has 404'd on every timps image since then.
- Fix: drop that one path from the purge list, with a comment explaining why it must stay excluded.

## Test plan
- [x] Rebuilt and reflashed two cameras (T31 boards, `wuuk_y0510_t31x_sc4336p_ssv6158` and `cinnado_d1_t31l_sc2336_atbm6031`)
- [x] Verified `/var/www/x/restart-prudynt.cgi` is present post-flash on both
- [x] `curl .../x/restart-prudynt.cgi` now returns `401 auth-required` (found and executed) instead of `404 not-found` (silently missing)