### PR TITLE
webui: let nav items fire an action instead of navigating away

### DIFF
--- a/docs/dev/plugin-system.md
+++ b/docs/dev/plugin-system.md
@@ -205,7 +205,11 @@ named `<plugin-name>.webui.json` and installed to
           // Optional.  Additional CSS class.
           "className": null,
           // Optional.  Hide the item (still in DOM).  Default false.
-          "hidden": false
+          "hidden": false,
+          // Optional.  Treat href as an action endpoint: request it and
+          // report the result in the message overlay instead of
+          // navigating there.  Default false.  See webui-plugin.md.
+          "action": false
         }
       ]
     }

--- a/docs/dev/webui-plugin.md
+++ b/docs/dev/webui-plugin.md
@@ -98,6 +98,74 @@ Validate with `scripts/check-plugins.sh` before building.
 | `"before:Network"` | Before item with matching label |
 | `"index:3"` | At 0-based position |
 
+### Nav item fields
+
+Consumed by `createAnchor()` in `navigation.js`. Unknown fields are ignored,
+so a manifest using a newer field still works against an older webui.
+
+| Field | Purpose |
+|-------|---------|
+| `label` | Link text (required) |
+| `href` | Target URL (required) |
+| `type` | `"divider"` renders a separator instead of a link |
+| `className` | Extra CSS classes; the `confirm` token asks for a confirmation dialog |
+| `trackActive` | `false` disables active-page highlighting for this item |
+| `target` / `rel` / `title` | Passed through to the `<a>` |
+| `hidden` | Render but hide the item (`d-none`) |
+| `action` | See below |
+
+## Action items
+
+A nav item is normally a link: clicking it navigates. That is wrong for a
+state-changing endpoint — the user ends up staring at the endpoint's raw
+response instead of the page they were on. Set `"action": true` and the item
+requests its `href` in the background and reports the outcome in the global
+message overlay, staying on the current page.
+
+```json
+{
+  "label": "Restart streamer",
+  "href": "/x/restart-mystreamer.cgi",
+  "className": "text-danger confirm",
+  "trackActive": false,
+  "action": true,
+  "confirm": {
+    "title": "Restart streamer",
+    "message": "Restart the streamer? The video stream will be interrupted.",
+    "confirmLabel": "Restart"
+  },
+  "actionPendingMessage": "Restarting streamer…",
+  "actionMessage": "Streamer restart initiated"
+}
+```
+
+| Field | Purpose |
+|-------|---------|
+| `action` | `true` enables the fetch-and-report behaviour |
+| `actionMethod` | HTTP method, default `GET` |
+| `actionPendingMessage` | Shown while the request is in flight; default `"<label>…"` |
+| `actionMessage` | Success text when the response carries none; default `"<label> done"` |
+| `confirm` | Message string, or an options object (`title`, `message`, `confirmLabel`, `cancelLabel`, `intent`) |
+
+The confirmation dialog appears when `className` contains `confirm` or when
+`confirm` is present. Action items drive it themselves, so `main.js`'s generic
+`.confirm` scanner is opted out via `data-confirm-skip` — its re-dispatch
+would otherwise fall back to plain anchor navigation.
+
+The endpoint should answer with JSON. Recognised shapes:
+
+| Response | Result |
+|----------|--------|
+| `{"status":"ok","message":"…"}` | success overlay showing `message` |
+| `{"status":"ok"}` | success overlay showing `actionMessage` |
+| `{"error":"…"}` or `{"error":{"message":"…"}}` | danger overlay showing the error |
+| 2xx with a non-JSON body | success overlay showing `actionMessage` |
+| non-2xx | danger overlay with the HTTP status |
+
+**Opt-in only.** Do not add `action` to an endpoint that answers with a
+redirect — `/x/reboot.cgi` (302 to `/wait.html`) and `/x/logout.cgi` are nav
+items that must keep navigating normally.
+
 ## Feature flags
 
 Declared flags are merged into `window.thinginoUIConfig.device`:

--- a/package/prudynt-t/files/prudynt.webui.json
+++ b/package/prudynt-t/files/prudynt.webui.json
@@ -66,7 +66,15 @@
           "label": "Restart streamer",
           "href": "/x/restart-prudynt.cgi",
           "className": "text-danger confirm",
-          "trackActive": false
+          "trackActive": false,
+          "action": true,
+          "confirm": {
+            "title": "Restart streamer",
+            "message": "Restart the prudynt streamer? The video stream will be interrupted for a few seconds.",
+            "confirmLabel": "Restart"
+          },
+          "actionPendingMessage": "Restarting streamer…",
+          "actionMessage": "Streamer restart initiated"
         }
       ]
     },

--- a/package/thingino-raptor/files/raptor.webui.json
+++ b/package/thingino-raptor/files/raptor.webui.json
@@ -62,7 +62,15 @@
           "label": "Restart streamer",
           "href": "/x/restart-streamer.cgi",
           "className": "text-danger confirm",
-          "trackActive": false
+          "trackActive": false,
+          "action": true,
+          "confirm": {
+            "title": "Restart streamer",
+            "message": "Restart the raptor streamer? The video stream will be interrupted for a few seconds.",
+            "confirmLabel": "Restart"
+          },
+          "actionPendingMessage": "Restarting streamer…",
+          "actionMessage": "Streamer restart initiated"
         }
       ]
     },

--- a/package/thingino-webui/files/www/a/navigation.js
+++ b/package/thingino-webui/files/www/a/navigation.js
@@ -249,6 +249,151 @@
     return "thingino";
   }
 
+  // Run fn once the offcanvas menu is closed, or immediately when it is not
+  // open (desktop nav, or offcanvas already hidden). Bootstrap's hide() is a
+  // no-op when the panel is not shown, so waiting for hidden.bs.offcanvas
+  // unconditionally would hang.
+  function closeOffcanvasThen(fn) {
+    const offcanvasEl = $("#navOffcanvas");
+    if (
+      offcanvasEl &&
+      offcanvasEl.classList.contains("show") &&
+      window.bootstrap
+    ) {
+      const instance =
+        bootstrap.Offcanvas.getInstance(offcanvasEl) ||
+        new bootstrap.Offcanvas(offcanvasEl);
+      offcanvasEl.addEventListener("hidden.bs.offcanvas", fn, { once: true });
+      instance.hide();
+      return;
+    }
+    fn();
+  }
+
+  // ---- Action items -------------------------------------------------
+  // A nav item with "action": true fires an HTTP request to its href and
+  // reports the result in the global message overlay instead of navigating
+  // to it. Opt-in only: /x/reboot.cgi and /x/logout.cgi are nav items that
+  // deliberately answer with a redirect and must keep navigating.
+
+  function reportNavAction(variant, message) {
+    if (!message) return;
+    if (typeof window.showOverlayMessage === "function") {
+      window.showOverlayMessage(message, variant);
+    } else if (typeof window.showAlert === "function") {
+      window.showAlert(variant, message);
+    } else {
+      console.log("[nav]", variant, message);
+    }
+  }
+
+  function navActionConfirmOptions(item) {
+    // Confirmation is expressed the way it is everywhere else in the UI: a
+    // "confirm" token in className. "confirm" may additionally carry a
+    // message string or a full options object to override the wording.
+    const wanted =
+      typeof item.className === "string" &&
+      item.className.split(/\s+/).indexOf("confirm") !== -1;
+    if (!wanted && !item.confirm) return null;
+    const options = {};
+    if (item.label) options.message = item.label + "?";
+    if (typeof item.confirm === "string") {
+      options.message = item.confirm;
+    } else if (item.confirm && typeof item.confirm === "object") {
+      Object.assign(options, item.confirm);
+    }
+    return options;
+  }
+
+  function runNavAction(anchor, item) {
+    const href = anchor.getAttribute("href");
+    if (!href || href === "#") return;
+    if (anchor.dataset.navActionBusy === "1") return;
+    anchor.dataset.navActionBusy = "1";
+    anchor.classList.add("pe-none");
+    const label = item.label || "Action";
+    reportNavAction("info", item.actionPendingMessage || label + "…");
+
+    const finish = function () {
+      delete anchor.dataset.navActionBusy;
+      anchor.classList.remove("pe-none");
+    };
+
+    fetch(href, {
+      method: item.actionMethod || "GET",
+      headers: { Accept: "application/json" },
+      credentials: "same-origin",
+      cache: "no-store",
+    })
+      .then(function (response) {
+        return response.text().then(function (body) {
+          return { ok: response.ok, status: response.status, body: body };
+        });
+      })
+      .then(function (res) {
+        let payload = null;
+        try {
+          payload = JSON.parse(res.body);
+        } catch (err) {
+          // Not JSON; fall back to the manifest/label wording below.
+        }
+        // Accepted shapes: {"status":"ok","message":...},
+        // {"error":"..."} and {"error":{"message":"..."}}.
+        const err = payload && payload.error;
+        const errText = err && (typeof err === "string" ? err : err.message);
+        const failed =
+          !res.ok ||
+          Boolean(errText) ||
+          Boolean(payload && payload.status && payload.status !== "ok");
+        const message =
+          errText ||
+          (payload && payload.message) ||
+          (failed
+            ? label + " failed (HTTP " + res.status + ")"
+            : item.actionMessage || label + " done");
+        reportNavAction(failed ? "danger" : "success", message);
+        finish();
+      })
+      .catch(function (err) {
+        reportNavAction(
+          "danger",
+          label + " failed: " + ((err && err.message) || err),
+        );
+        finish();
+      });
+  }
+
+  function bindNavAction(anchor, item) {
+    const confirmOptions = navActionConfirmOptions(item);
+    anchor.dataset.navAction = "1";
+    // main.js scans for ".confirm" and re-dispatches the click after the user
+    // confirms, which would land back on plain anchor navigation. Take
+    // ownership of the confirmation instead. The anchor is not in the
+    // document yet, so the scanner cannot have claimed it before this runs.
+    anchor.dataset.confirmSkip = "1";
+    anchor.addEventListener("click", function (e) {
+      e.preventDefault();
+      const el = this;
+      closeOffcanvasThen(function () {
+        if (!confirmOptions) {
+          runNavAction(el, item);
+          return;
+        }
+        const ask =
+          typeof window.thinginoConfirm === "function"
+            ? window.thinginoConfirm(confirmOptions)
+            : Promise.resolve(
+                typeof window.nativeConfirm === "function"
+                  ? window.nativeConfirm(confirmOptions.message)
+                  : true,
+              );
+        Promise.resolve(ask).then(function (confirmed) {
+          if (confirmed) runNavAction(el, item);
+        });
+      });
+    });
+  }
+
   function createAnchor(item, defaultClass) {
     const anchor = document.createElement("a");
     const classes = [defaultClass];
@@ -267,6 +412,9 @@
       item.href.startsWith("/");
     if (shouldTrack) {
       anchor.dataset.navPath = normalizePath(item.href);
+    }
+    if (item.action && typeof item.href === "string" && item.href !== "#") {
+      bindNavAction(anchor, item);
     }
     return anchor;
   }
@@ -408,6 +556,21 @@
     return nav;
   }
 
+  // Offcanvas entries navigate only after the panel has closed, so the page
+  // swap does not happen behind a still-open menu. Action items already own
+  // their click (bindNavAction closes the panel itself).
+  function bindOffcanvasNavigation(anchor) {
+    anchor.addEventListener("click", function (e) {
+      if (this.dataset.navAction === "1") return;
+      const href = this.getAttribute("href");
+      if (!href || href === "#") return;
+      e.preventDefault();
+      closeOffcanvasThen(function () {
+        window.location.href = href;
+      });
+    });
+  }
+
   function createOffcanvasList(menuItems) {
     const list = document.createElement("ul");
     list.className = "list-unstyled";
@@ -464,31 +627,7 @@
               "d-block py-1 text-decoration-none",
             );
             if (subItem.id) anchor.id = subItem.id + "-offcanvas";
-
-            // Handle navigation after offcanvas closes
-            anchor.addEventListener("click", function (e) {
-              const href = this.getAttribute("href");
-              if (href && href !== "#") {
-                e.preventDefault();
-                const offcanvasEl = $("#navOffcanvas");
-                if (offcanvasEl && window.bootstrap) {
-                  const offcanvasInstance =
-                    bootstrap.Offcanvas.getInstance(offcanvasEl) ||
-                    new bootstrap.Offcanvas(offcanvasEl);
-                  offcanvasEl.addEventListener(
-                    "hidden.bs.offcanvas",
-                    function () {
-                      window.location.href = href;
-                    },
-                    { once: true },
-                  );
-                  offcanvasInstance.hide();
-                } else {
-                  window.location.href = href;
-                }
-              }
-            });
-
+            bindOffcanvasNavigation(anchor);
             li.appendChild(anchor);
             subList.appendChild(li);
           }
@@ -503,31 +642,7 @@
           item,
           "d-block fw-bold text-decoration-none p-3",
         );
-
-        // Handle navigation after offcanvas closes
-        anchor.addEventListener("click", function (e) {
-          const href = this.getAttribute("href");
-          if (href && href !== "#") {
-            e.preventDefault();
-            const offcanvasEl = $("#navOffcanvas");
-            if (offcanvasEl && window.bootstrap) {
-              const offcanvasInstance =
-                bootstrap.Offcanvas.getInstance(offcanvasEl) ||
-                new bootstrap.Offcanvas(offcanvasEl);
-              offcanvasEl.addEventListener(
-                "hidden.bs.offcanvas",
-                function () {
-                  window.location.href = href;
-                },
-                { once: true },
-              );
-              offcanvasInstance.hide();
-            } else {
-              window.location.href = href;
-            }
-          }
-        });
-
+        bindOffcanvasNavigation(anchor);
         li.appendChild(anchor);
         list.appendChild(li);
       }

--- a/package/timps/files/timps.webui.json
+++ b/package/timps/files/timps.webui.json
@@ -82,7 +82,15 @@
           "label": "Restart streamer",
           "href": "/x/restart-prudynt.cgi",
           "className": "text-danger confirm",
-          "trackActive": false
+          "trackActive": false,
+          "action": true,
+          "confirm": {
+            "title": "Restart streamer",
+            "message": "Restart the timps streamer? The video stream will be interrupted for a few seconds.",
+            "confirmLabel": "Restart"
+          },
+          "actionPendingMessage": "Restarting streamer…",
+          "actionMessage": "Streamer restart initiated"
         }
       ]
     },


### PR DESCRIPTION
## Summary
- Clicking "Restart streamer" (and any similarly-shaped nav item) navigated the browser to its CGI href and left the user staring at the raw JSON response, having lost whatever page they were on. The action itself worked correctly - only the UX was wrong.
- Root cause: the nav-menu renderer treats every menu entry as a plain page link (`window.location.href = href`) for both the desktop dropdown and the offcanvas/mobile menu. The `"confirm"` className shows a dialog first, but `main.js` re-dispatches the click after confirming, which still lands on plain navigation.
- All three streamer backends share the identical broken item shape (`timps.webui.json`, `prudynt.webui.json`, `raptor.webui.json` all declare `"href": "/x/restart-*.cgi", "className": "text-danger confirm"`), so this wasn't timps-specific.
- Fix: new opt-in `"action": true` nav-item field. An action item `fetch()`s its href and reports the result via the existing message-overlay system instead of navigating. Deliberately opt-in rather than a heuristic (e.g. "any CGI href is an action") - `/x/reboot.cgi` and `/x/logout.cgi` are nav items that legitimately need to keep navigating (they answer with real redirects), so a heuristic would have broken both. Action items own their own confirmation dialog (`data-confirm-skip` keeps the generic scanner off them), close the offcanvas panel before prompting, and guard against double submits while a request is in flight.
- Also folds two byte-identical offcanvas click handlers into one `bindOffcanvasNavigation()`, and fixes a latent bug in it: it now waits for `hidden.bs.offcanvas` only when the panel is actually open (`Bootstrap`'s `hide()` is a no-op otherwise, so the event would never fire and navigation would hang).
- Applied `"action": true` to the one broken item in each of the three streamer manifests (timps/prudynt-t/raptor); documented the new nav-item schema fields in `docs/webui-plugin.md` (previously undocumented).

## Test plan
- [x] Built an offline test harness from the actual packed `rootfs.squashfs` content, driven with a real browser: desktop and offcanvas paths, cancel vs. accept, four rapid clicks during a slow request (busy guard - exactly one HTTP request fires), five different CGI error-response shapes (`HTTP 500`, `{"error":"..."}`, `{"error":{"message":...}}`, non-JSON 200, `404`) all reported correctly without navigating, and a regression check that ordinary nav items (dropdown sub-item and top-level) still navigate normally, and that `Reboot camera`/`Logout` (no `action` field) are untouched
- [x] Built and reflashed a real camera (`cinnado_d1_t31l_sc2336_atbm6031`); verified md5 of the served `navigation.js` matches source -> package -> squashfs -> device -> HTTP exactly
- [x] Manually confirmed in a browser against the live device: clicking "Restart streamer" shows the confirmation dialog, then stays on the same page with a success toast instead of navigating to the raw JSON