### PR TITLE
lightnvr: add embedded profile for A1 smart NVR

### DIFF
--- a/configs/cameras/smart_nvr_a1n_eth/kernel.config
+++ b/configs/cameras/smart_nvr_a1n_eth/kernel.config
@@ -1,0 +1,93 @@
+# Kernel size profile for the 16 MiB A1 Smart NVR.
+#
+# Keep the board-facing paths intact: framebuffer/VT, USB HID input, A1 video,
+# SATA/AHCI, USB mass storage, both Ethernet MACs, I2C, and RTC remain enabled.
+# This fragment removes services and compatibility interfaces that a fixed NVR
+# appliance does not use so the kernel fits the unchanged 1600 KiB partition.
+
+# Preserve the local display/keyboard foundation. The A1 VDE/VGA block and pin
+# mux remain enabled in the board DTS; these options keep console and USB HID
+# input available to software that adds a local display frontend later.
+CONFIG_FB=y
+CONFIG_VT=y
+CONFIG_VT_CONSOLE=y
+CONFIG_INPUT=y
+CONFIG_HID=y
+CONFIG_HID_GENERIC=y
+CONFIG_USB_HID=y
+
+# The appliance uses IPv4 on its camera/storage LAN and has no network root.
+# CONFIG_IPV6 is not set
+# CONFIG_NFS_FS is not set
+# CONFIG_IP_PNP is not set
+# CONFIG_IP_ADVANCED_ROUTER is not set
+# CONFIG_INET_DIAG is not set
+# CONFIG_XFRM is not set
+# CONFIG_NETWORK_PHY_TIMESTAMPING is not set
+
+# Keep ext4, FAT, JFFS2, and XZ SquashFS; drop unused alternatives/features.
+# CONFIG_EXT2_FS is not set
+# CONFIG_EXT4_USE_FOR_EXT2 is not set
+# CONFIG_JFFS2_FS_WBUF_VERIFY is not set
+# CONFIG_JFFS2_FS_XATTR is not set
+# CONFIG_SQUASHFS_ZLIB is not set
+
+# TCP/IP still selects the crypto core and AES. Remove algorithms unused by
+# the base network stack and the external WireGuard compatibility module.
+# CONFIG_CRYPTO_ARC4 is not set
+# CONFIG_CRYPTO_CCM is not set
+# CONFIG_CRYPTO_CMAC is not set
+# CONFIG_CRYPTO_CTR is not set
+# CONFIG_CRYPTO_DEFLATE is not set
+# CONFIG_CRYPTO_DRBG_MENU is not set
+# CONFIG_CRYPTO_ECB is not set
+# CONFIG_CRYPTO_GCM is not set
+# CONFIG_CRYPTO_GF128MUL is not set
+# CONFIG_CRYPTO_GHASH is not set
+# CONFIG_CRYPTO_HMAC is not set
+# CONFIG_CRYPTO_JITTERENTROPY is not set
+# CONFIG_CRYPTO_MD5 is not set
+# CONFIG_CRYPTO_NULL is not set
+# CONFIG_CRYPTO_SEQIV is not set
+# CONFIG_CRYPTO_SHA256 is not set
+# CONFIG_CRYPTO_SHA512 is not set
+
+# Keep the compact deadline scheduler for the NVR's sequential disk workload.
+# CONFIG_IOSCHED_CFQ is not set
+CONFIG_DEFAULT_DEADLINE=y
+
+# Remove kernel debugging and diagnostic surfaces from the production image.
+# CONFIG_DEBUG_FS is not set
+# CONFIG_DYNAMIC_DEBUG is not set
+# CONFIG_IKCONFIG is not set
+# CONFIG_MAGIC_SYSRQ is not set
+# CONFIG_PRINTK_TIME is not set
+# CONFIG_PROC_KCORE is not set
+# CONFIG_SCSI_LOGGING is not set
+# CONFIG_SCSI_PROC_FS is not set
+# CONFIG_SLUB_DEBUG is not set
+# CONFIG_STACKTRACE is not set
+# CONFIG_USB_ANNOUNCE_NEW_DEVICES is not set
+
+# Preserve USB HID keyboard/mouse support; only remove the legacy raw APIs.
+# CONFIG_HIDRAW is not set
+# CONFIG_USB_HIDDEV is not set
+# CONFIG_USB_DEFAULT_PERSIST is not set
+
+# The always-on appliance does not suspend or offline either of its two CPUs.
+# CONFIG_HOTPLUG_CPU is not set
+# CONFIG_SUSPEND is not set
+
+# Remove unused IPC, asynchronous-I/O, SCSI-generic, and legacy syscall APIs.
+# CONFIG_AIO is not set
+# CONFIG_CHR_DEV_SG is not set
+# CONFIG_MODULE_FORCE_UNLOAD is not set
+# CONFIG_POSIX_MQUEUE is not set
+# CONFIG_SGETMASK_SYSCALL is not set
+# CONFIG_SYSCTL_SYSCALL is not set
+# CONFIG_SYSFS_SYSCALL is not set
+# CONFIG_SYSVIPC is not set
+# CONFIG_USELIB is not set
+
+# Keep SATA/AHCI itself; only omit verbose libata error decoding.
+# CONFIG_ATA_VERBOSE_ERROR is not set

--- a/configs/cameras/smart_nvr_a1n_eth/smart_nvr_a1n_eth_defconfig
+++ b/configs/cameras/smart_nvr_a1n_eth/smart_nvr_a1n_eth_defconfig
@@ -24,6 +24,7 @@ BR2_PACKAGE_THINGINO_GPIO=n
 BR2_PACKAGE_THINGINO_KOPT_IPV6=n
 BR2_PACKAGE_THINGINO_KOPT_USB_MASS_STORAGE=y
 BR2_PACKAGE_THINGINO_STREAMER_NONE=y
+BR2_PACKAGE_THINGINO_SYSTEM_AUTOMOUNT=y
 BR2_PACKAGE_THINGINO_SYSTEM_SWAP=y
 # Avoid pulling the external WireGuard module and its FOU/XFRM kernel support
 # into a fixed LAN appliance. VPN access can terminate at the site gateway.

--- a/configs/cameras/smart_nvr_a1n_eth/smart_nvr_a1n_eth_defconfig
+++ b/configs/cameras/smart_nvr_a1n_eth/smart_nvr_a1n_eth_defconfig
@@ -2,6 +2,7 @@
 # FRAG: soc-xburst2 core
 BR2_ETHERNET=y
 BR2_INGENIC_SOC_MODEL="a1n"
+BR2_LINUX_KERNEL_CONFIG_FRAGMENT_FILES="$(BR2_EXTERNAL_THINGINO_PATH)/configs/cameras/smart_nvr_a1n_eth/kernel.config"
 BR2_LINUX_KERNEL_EXT_THINGINO_KOPT=y
 BR2_LINUX_KERNEL_EXT_THINGINO_KOPT_DTS=y
 BR2_LINUX_KERNEL_EXT_THINGINO_KOPT_DTS_A1_SMART_NVR=y
@@ -15,9 +16,18 @@ BR2_PACKAGE_HOST_NODEJS=y
 BR2_PACKAGE_LIBZLIB=y
 BR2_PACKAGE_LIGHTNVR=y
 BR2_PACKAGE_SMARTMONTOOLS=y
+# This fixed NVR profile has no GPIO list or camera GPIO configuration. Leaving
+# the generic helper enabled would also force the unused kernel debugfs on.
+BR2_PACKAGE_THINGINO_GPIO=n
+# The A1 appliance uses IPv4 on its camera/storage LAN. Override core.fragment
+# here so thingino-kopt does not re-enable IPv6 after the kernel fragment.
+BR2_PACKAGE_THINGINO_KOPT_IPV6=n
 BR2_PACKAGE_THINGINO_KOPT_USB_MASS_STORAGE=y
 BR2_PACKAGE_THINGINO_STREAMER_NONE=y
 BR2_PACKAGE_THINGINO_SYSTEM_SWAP=y
+# Avoid pulling the external WireGuard module and its FOU/XFRM kernel support
+# into a fixed LAN appliance. VPN access can terminate at the site gateway.
+BR2_PACKAGE_THINGINO_VPN_NONE=y
 BR2_PACKAGE_THINGINO_WEBUI=n
 BR2_TARGET_UBOOT_FORMAT_CUSTOM_NAME="u-boot-with-spl-lzma.bin"
 BR2_THINGINO_DEV_NVR=y

--- a/package/lightnvr/files/S95lightnvr
+++ b/package/lightnvr/files/S95lightnvr
@@ -6,7 +6,9 @@ DAEMON_ARGS=""
 PIDFILE="/var/run/lightnvr.pid"
 
 start_daemon() {
-	start-stop-daemon -S -b -m -p "$PIDFILE" -x "$DAEMON" -- $@
+	# LightNVR creates and locks its own PID file. Pre-creating it with -m makes
+	# the child mistake its own PID for an existing instance and signal itself.
+	start-stop-daemon -S -b -p "$PIDFILE" -x "$DAEMON" -- $@
 }
 
 stop_daemon() {

--- a/package/lightnvr/lightnvr.mk
+++ b/package/lightnvr/lightnvr.mk
@@ -1,6 +1,6 @@
 LIGHTNVR_SITE_METHOD = git
 LIGHTNVR_SITE = https://github.com/opensensor/lightNVR
-LIGHTNVR_VERSION = ca9c19d467573e9d04ba3b1efef20316dd897741
+LIGHTNVR_VERSION = 1755670975b54c20a0d645253c95b7e2e5deffa8
 
 LIGHTNVR_LICENSE = MIT
 LIGHTNVR_LICENSE_FILES = COPYING
@@ -21,6 +21,7 @@ endif
 
 # Enable SOD with dynamic linking and go2rtc, use bundled cJSON
 LIGHTNVR_CONF_OPTS = \
+	-DLIGHTNVR_PROFILE=embedded \
 	-DENABLE_SOD=OFF \
 	-DSOD_DYNAMIC_LINK=ON \
 	-DENABLE_GO2RTC=ON \
@@ -39,6 +40,8 @@ define LIGHTNVR_BUILD_WEB_ASSETS
 	cd $(@D)/web && \
 		export PATH=$(HOST_DIR)/bin/:$$PATH && \
 		$(HOST_DIR)/bin/npm ci --production=false && \
+		LIGHTNVR_WEB_LEGACY=false \
+		LIGHTNVR_WEB_LOCALES=en \
 		$(HOST_DIR)/bin/npm run build
 	@echo "Web assets built successfully"
 endef
@@ -52,6 +55,7 @@ define LIGHTNVR_INSTALL_APP_FILES
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/var/lib/lightnvr/web/assets
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/var/lib/lightnvr/web/css
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/var/lib/lightnvr/web/img
+	$(INSTALL) -m 755 -d $(TARGET_DIR)/var/lib/lightnvr/web/locales
 	# Copy only gzip-compressed JS and CSS files (saves ~70% space)
 	cp $(@D)/web/dist/assets/*.gz $(TARGET_DIR)/var/lib/lightnvr/web/assets/
 	cp $(@D)/web/dist/css/*.gz $(TARGET_DIR)/var/lib/lightnvr/web/css/
@@ -60,6 +64,10 @@ define LIGHTNVR_INSTALL_APP_FILES
 	cp $(@D)/web/dist/*.html.gz $(TARGET_DIR)/var/lib/lightnvr/web/
 	# Copy images and other static assets
 	-cp -r $(@D)/web/dist/img/* $(TARGET_DIR)/var/lib/lightnvr/web/img/ 2>/dev/null || true
+	# The embedded web profile retains English and its runtime manifest.
+	cp $(@D)/web/dist/locales/en.json.gz $(TARGET_DIR)/var/lib/lightnvr/web/locales/
+	cp $(@D)/web/dist/locales/en.png $(TARGET_DIR)/var/lib/lightnvr/web/locales/
+	cp $(@D)/web/dist/locales/manifest.json $(TARGET_DIR)/var/lib/lightnvr/web/locales/
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/etc/lightnvr
 	$(INSTALL) -m 755 -d $(TARGET_DIR)/etc/lightnvr/go2rtc
 	$(INSTALL) -m 644 $(LIGHTNVR_PKGDIR)/files/lightnvr.ini $(TARGET_DIR)/etc/lightnvr/lightnvr.ini

--- a/package/thingino-system/Config.in
+++ b/package/thingino-system/Config.in
@@ -33,6 +33,15 @@ config BR2_PACKAGE_THINGINO_SYSTEM_ENTROPY_GENERATOR
 	help
 	  Enables the entropy service for the T40 SoC.
 
+config BR2_PACKAGE_THINGINO_SYSTEM_AUTOMOUNT
+	bool "block device automount"
+	depends on BR2_PACKAGE_THINGINO_SYSTEM
+	default y if BR2_THINGINO_SDCARD
+	help
+	  Install the mdev handler and boot-time scan that mount partitions below
+	  /mnt. SD-card boards select this by default; SATA and USB-storage
+	  appliances can enable it without pulling in the MMC kernel stack.
+
 config BR2_PACKAGE_THINGINO_SYSTEM_SWAP
 	bool "swap"
 	depends on BR2_PACKAGE_THINGINO_SYSTEM

--- a/package/thingino-system/files/automount
+++ b/package/thingino-system/files/automount
@@ -12,6 +12,14 @@ echo -c 240 -e "- Device node: $device_node"
 mount_point="/mnt/$MDEV"
 echo -c 240 -e "- Mount point: $mount_point"
 
+# Camera SD cards favor immediate persistence. SATA and USB block storage are
+# also used by NVRs, where a synchronous mount would serialize every database
+# and recording write and needlessly wear the drive.
+mount_options="noatime,sync"
+case "$MDEV" in
+	sd[a-z][0-9]*) mount_options="noatime" ;;
+esac
+
 diag="$mount_point/.diag"
 run="$mount_point/run.sh"
 run_once="$mount_point/runonce.sh"
@@ -69,7 +77,7 @@ do_mount() {
 		return 1
 	fi
 
-	if mount -t auto -o noatime,sync "$device_node" "$mount_point"; then
+	if mount -t auto -o "$mount_options" "$device_node" "$mount_point"; then
 		echo -c 240 -e "- Mounted $device_node to $mount_point"
 	else
 		echo -c 142 -e "Failed to mount $device_node to $mount_point" >&2

--- a/package/thingino-system/thingino-system.mk
+++ b/package/thingino-system/thingino-system.mk
@@ -38,12 +38,15 @@ define THINGINO_SYSTEM_INSTALL_TARGET_CMDS
 			$(TARGET_DIR)/etc/init.d/S01entropy; \
 	fi
 
-	if [ "$(BR2_THINGINO_SDCARD)" = "y" ]; then \
+	if [ "$(BR2_PACKAGE_THINGINO_SYSTEM_AUTOMOUNT)" = "y" ]; then \
 		mkdir -p $(TARGET_DIR)/usr/lib/mdev; \
 		$(INSTALL) -D -m 0755 $(THINGINO_SYSTEM_PKGDIR)/files/automount \
 			$(TARGET_DIR)/usr/lib/mdev/automount; \
 		$(INSTALL) -D -m 0755 $(THINGINO_SYSTEM_PKGDIR)/files/S30mdev \
 			$(TARGET_DIR)/etc/init.d/S30mdev; \
+	fi
+
+	if [ "$(BR2_THINGINO_SDCARD)" = "y" ]; then \
 		$(INSTALL) -D -m 0755 $(THINGINO_SYSTEM_PKGDIR)/files/formatsd \
 			$(TARGET_DIR)/usr/sbin/formatsd; \
 		$(INSTALL) -D -m 0755 $(THINGINO_SYSTEM_PKGDIR)/files/envfromcard \


### PR DESCRIPTION
## Summary

- update LightNVR to merged embedded-profile commit `1755670975b54c20a0d645253c95b7e2e5deffa8` ([opensensor/lightNVR#544](https://github.com/opensensor/lightNVR/pull/544))
- build the A1 Smart NVR with the embedded profile: 16-stream compile-time ceiling, modern-only web assets, and English-only locale assets
- add an A1-specific kernel fragment that fits the existing 1600 KiB kernel partition without changing the flash layout
- enable generic block-device automount for this SATA NVR without enabling the unused MMC stack
- fix the LightNVR init script so it does not pre-create the application-owned PID file and make LightNVR signal itself
- mount `sdX` recording storage with `noatime` rather than synchronous I/O; SD/MMC cards retain the existing `noatime,sync` behavior
- disable unused GPIO/debugfs, IPv6, and WireGuard support for this fixed IPv4 LAN appliance

## Hardware retained

The kernel fragment explicitly preserves:

- A1 VDE/VGA pinmux and framebuffer/VT console foundation
- USB HID keyboard/mouse input
- SATA/AHCI and USB mass storage
- both Ethernet MACs
- I2C and RTC

The size reduction comes from unused network-root/VPN, debugging, legacy syscall/API, crypto, and filesystem options rather than removing local display or storage paths.

## Validation

Clean build from `themactep/master` (`db7fecd9ae`):

```text
LightNVR profile:       embedded
Compile-time streams:   16
uImage:                 1,602,046 bytes
kernel partition:       1,638,400 bytes (unchanged)
kernel margin:             36,354 bytes
rootfs.squashfs:       11,476,992 bytes
full firmware image:   16,777,216 bytes
SHA-256: f644eb2f464648ad752cb5167bd449af17a2ec52bffca95469f0de84159ab5cf
```

On-device A1 validation:

- complete image written successfully with the legacy Thingino cloner
- firmware booted and exposed Ethernet/SSH at `192.168.52.118`
- SATA detected a Samsung 870 EVO 500 GB; read-only ext4 check completed all five passes cleanly
- diagnosis showed the original boot lacked the automount handler because it was incorrectly gated by the SD-card hardware option
- mounting `/dev/sda1` as ext4 with `noatime` exposed the existing 30.5 GB LightNVR dataset
- launching without `start-stop-daemon -m` produced a stable LightNVR process and application-owned PID file
- SQLite opened the existing database, go2rtc became ready, 11 configured streams registered, and LightNVR listened on port 8080

Additional source checks:

- camera defconfig sort check passes
- shellcheck passes for changed init/automount scripts
- `git diff --check` passes
- final kernel config retains AHCI, framebuffer/VT, HID, USB storage, I2C, and RTC
- final kernel config omits IPv6, NFS root, FOU, and debugfs
- installed LightNVR web tree contains modern compressed assets plus only `locales/en.*` and the locale manifest
