### PR TITLE
onvif: advertise rtsp scheme matching Raptor default TLS state

### DIFF
--- a/package/thingino-raptor/files/S96onvif_discovery
+++ b/package/thingino-raptor/files/S96onvif_discovery
@@ -48,7 +48,7 @@ raptor_bool_default() {
 }
 
 raptor_rtsp_scheme() {
-	if [ "$(raptor_bool_default rtsp tls true)" = "true" ]; then
+	if [ "$(raptor_bool_default rtsp tls false)" = "true" ]; then
 		echo "rtsps"
 	else
 		echo "rtsp"


### PR DESCRIPTION
### Problem

ONVIF clients (tinyCam Monitor, and anything else that follows the published profile URIs) discover the camera successfully but cannot connect to the stream. The profile is advertised with an `rtsps://<ip>:322/...` URI while nothing is listening on port 322 — Raptor serves plain RTSP on port 554.

### Root cause

`S96onvif_discovery` decides the scheme to advertise via:

```sh
if [ "$(raptor_bool_default rtsp tls true)" = "true" ]; then
```

That `true` fallback assumes TLS is on by default. But Raptor's actual default is TLS off:

- `rsd_main.c`: `tls_enabled = rss_config_get_bool(dctx.cfg, "rtsp", "tls", false)`
- the `raptor.conf` template ships `# tls = false` commented out
- the RTSP port stays 554 unless explicitly changed

So on a stock install where `tls` is unset, the discovery script publishes `rtsps://<ip>:322` while the server listens on `rtsp://<ip>:554`. The preview-page endpoint list (built by Raptor itself) is correct — only the ONVIF publication is wrong, which is why the mismatch is visible exactly there.

### Fix

One line: flip the fallback from `true` to `false` so the advertised scheme matches the listening server when `tls` is not explicitly configured.

### Verification

- Device (Wyze Cam v3, `wyze_cam3_t31x_gc2053_rtl8189ftv`, master+785447b, reporter C-Walk on Discord): tinyCam ONVIF discovery succeeded, stream connect failed with the `rtsps://...:322` URI from the published profile. Setting `raptorctl config set rtsp tls false` + `config save` + restarting `raptor` and `onvif_discovery` made the profile advertise `rtsp://...:554`, after which tinyCam connected and played. This pins the default mismatch as the root cause (the explicit-set workaround produces the same script state this patch produces on stock configs).
- Tree check: single occurrence of the `tls ... true` fallback in the tree; no other component assumes TLS-on-by-default.

Note: the patched script itself has not been tested on a rebuilt firmware image — only the workaround-equivalent path was device-verified. The change is a single fallback constant in shell logic, reviewed line-by-line.

Reported-and-tested-by: C-Walk (Discord)
