### PR TITLE
uboot: enable NetConsole with working defaults

### DIFF
--- a/package/all-patches/uboot/2013.07/0006-isvp-enable-NetConsole-behind-a-build-system-guard.patch
+++ b/package/all-patches/uboot/2013.07/0006-isvp-enable-NetConsole-behind-a-build-system-guard.patch
@@ -1,0 +1,111 @@
+From 4d6b86869147c5391c0e179d05778f51bb7ffd10 Mon Sep 17 00:00:00 2001
+From: spamcop <5637111+spamcop@users.noreply.github.com>
+Date: Wed, 26 Aug 2026 12:21:10 +0200
+Subject: [PATCH] isvp: enable NetConsole behind a build-system guard
+
+The driver and all its hooks are already in the 2013.07 tree; what is
+missing is configuration. isvp_common.h gains, guarded by
+CONFIG_NETCONSOLE:
+
+  CONFIG_CONSOLE_MUX  device lists, so serial stays alongside nc rather
+                      than being replaced, and stdin=serial,nc cannot hang
+                      on a dead network (the mux only enters a getc after
+                      that device's tstc reported data)
+  CONFIG_PREBOOT      empty by default; preboot runs before the autoboot
+                      abort window, the only point early enough to
+                      redirect the console and still interrupt boot
+
+CONFIG_NETCONSOLE itself is never defined in the header: it comes from
+the build system (make ... CONFIG_NETCONSOLE=y), bridged to the
+preprocessor in config.mk exactly like CONFIG_SPI_FLASH_BAR and
+CONFIG_BOOTARGS_EXTERNAL. Boards built without the flag get a
+byte-identical stock console; netconsole.o is not even compiled, since
+drivers/net/Makefile selects it with COBJS-$(CONFIG_NETCONSOLE). The
+value must be y, not 1, because a command-line variable overrides
+autoconf.mk in every sub-make.
+---
+ config.mk                     |  8 ++++++
+ include/configs/isvp_common.h | 48 +++++++++++++++++++++++++++++++++++
+ 2 files changed, 56 insertions(+)
+
+diff --git a/config.mk b/config.mk
+index 5d7f04b..ae0b0b5 100644
+--- a/config.mk
++++ b/config.mk
+@@ -210,6 +210,14 @@ ifdef CONFIG_BOOTARGS_EXTERNAL
+ CPPFLAGS += -DCONFIG_BOOTARGS_EXTERNAL
+ endif
+ 
++# Enable NetConsole (console over UDP), typically from buildroot on boards
++# with Ethernet. Pass CONFIG_NETCONSOLE=y, not =1: drivers/net/Makefile
++# selects the object with COBJS-$(CONFIG_NETCONSOLE), and a command-line
++# value overrides autoconf.mk.
++ifdef CONFIG_NETCONSOLE
++CPPFLAGS += -DCONFIG_NETCONSOLE
++endif
++
+ ifneq ($(CONFIG_SYS_TEXT_BASE),)
+ CPPFLAGS += -DCONFIG_SYS_TEXT_BASE=$(CONFIG_SYS_TEXT_BASE)
+ endif
+diff --git a/include/configs/isvp_common.h b/include/configs/isvp_common.h
+index 546b6c1..597c3d0 100644
+--- a/include/configs/isvp_common.h
++++ b/include/configs/isvp_common.h
+@@ -605,6 +605,54 @@
+ 
+ #define CONFIG_NET_GMAC
+ 
++/*
++ * NetConsole: the U-Boot console over UDP.
++ *
++ * Guarded: CONFIG_NETCONSOLE is not defined here. It arrives from the build
++ * system (make ... CONFIG_NETCONSOLE=y, bridged to the preprocessor in
++ * config.mk) only when the build opts in; everything else builds a stock
++ * console. It must be =y on the make command line, because
++ * drivers/net/Makefile selects the object with COBJS-$(CONFIG_NETCONSOLE)
++ * and a command-line value overrides autoconf.mk.
++ *
++ * The eth device is registered at boot without help: board_r.c calls
++ * eth_initialize() -> board_eth_init() (board/ingenic/isvp_t31/board.c) ->
++ * jz_net_initialize(). NetLoop refuses NETCONS unless `ipaddr' is non-zero
++ * (net/net.c); CONFIG_IPADDR below supplies the default, so netconsole needs
++ * no ipaddr injected into the environment.
++ *
++ * CONFIG_CONSOLE_MUX accepts a device list, so serial is kept as a fallback
++ * alongside the network console rather than being replaced by it:
++ *   setenv stdout serial,nc
++ *   setenv stderr serial,nc
++ *   setenv stdin  serial,nc
++ *
++ * The mux also makes stdin=serial,nc safe: its getc() only calls a device's
++ * getc() after that device's tstc() reported data (common/console.c), so
++ * netconsole's unbounded nc_getc() is never entered speculatively. A bare
++ * stdin=nc without the mux can hang forever on a dead network.
++ *
++ * CONFIG_PREBOOT is a feature gate only. env_default.h expands it as
++ * "preboot=" CONFIG_PREBOOT, so the bare form leaves the variable empty and
++ * boot behaviour unchanged until someone sets it. It matters because preboot
++ * runs BEFORE the bootdelay abort window (common/main.c), the only point early
++ * enough to redirect the console and still interrupt autoboot over the network
++ * -- abortboot polls tstc(), which under the mux includes the nc device.
++ * Redirecting from bootcmd is too late: console_init_r has already reset
++ * stdin/stdout/stderr and the keypress window has closed. For an interactive
++ * U-Boot prompt with no serial port attached, from the running system:
++ *   fw_setenv preboot 'setenv stdout serial,nc;setenv stderr serial,nc;setenv stdin serial,nc'
++ *   fw_setenv bootdelay 5
++ *
++ * CONFIG_NETCONSOLE_BUFFER_SIZE is left at its 512-byte default to match the
++ * 512-byte recvfrom() buffer in tools/ncb.c. Raising it would make U-Boot emit
++ * datagrams that the host-side receiver silently truncates.
++ */
++#ifdef CONFIG_NETCONSOLE
++#define CONFIG_CONSOLE_MUX
++#define CONFIG_PREBOOT
++#endif
++
+ /**
+  * Environment
+  */
+-- 
+2.55.0
+

--- a/package/thingino-uboot/Config.in
+++ b/package/thingino-uboot/Config.in
@@ -24,6 +24,22 @@ config BR2_PACKAGE_THINGINO_UBOOT_SD_ENABLE
 config BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE
 	bool
 
+config BR2_PACKAGE_THINGINO_UBOOT_NETCONSOLE
+	bool "Enable NetConsole (U-Boot console over UDP)"
+	depends on BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE
+	depends on BR2_THINGINO_UBOOT_VERSION_2013_07
+	help
+	  Build the bootloader with NetConsole and redirect the console to
+	  it (stdout/stderr/stdin = serial,nc) so U-Boot can be driven over
+	  UDP on a board with no serial port. Also raises bootdelay to 5s so
+	  the autoboot window can be interrupted over the network.
+
+	  SECURITY: with ncip unset the board accepts console input from any
+	  host on the L2 segment, so anyone on the subnet can interrupt boot
+	  and reach an unauthenticated U-Boot prompt during the boot window.
+	  Enable only on trusted networks, or pin a single client with
+	  `fw_setenv ncip <host>`. Off by default; opt in per camera.
+
 config BR2_PACKAGE_THINGINO_UBOOT_ENABLE_BAR
 	bool "Enable SPI Flash BAR"
 	help

--- a/package/thingino-uboot/thingino-uboot.mk
+++ b/package/thingino-uboot/thingino-uboot.mk
@@ -24,6 +24,23 @@ ifeq ($(BR2_PACKAGE_THINGINO_UBOOT_EXTERNAL_ENV_ENABLE),y)
 UBOOT_MAKE_OPTS += CONFIG_BOOTARGS_EXTERNAL=1
 endif
 
+# NetConsole (U-Boot console over UDP), opt-in per camera via
+# BR2_PACKAGE_THINGINO_UBOOT_NETCONSOLE. That symbol is default n and gated
+# in Kconfig to 2013.07, because patch 0006 provides the plumbing only for
+# that tree; 2026.07 enables netconsole through Kconfig on its own. Keying
+# off the symbol (not BR2_ETHERNET) keeps it off for the ethernet cameras
+# that never asked for it, and the Kconfig gate keeps both effects below --
+# the make option and the injected environment -- out of non-2013.07 builds.
+# Must be =y, not =1: U-Boot's drivers/net/Makefile selects the object with
+# COBJS-$(CONFIG_NETCONSOLE), and a command-line value overrides autoconf.mk.
+# THINGINO_UBOOT_NETCONSOLE is a single internal flag so a second network
+# transport (e.g. USB-Ethernet on OTG boards) can enable both effects later
+# from one more condition, without duplicating it here and in the env hook.
+ifeq ($(BR2_PACKAGE_THINGINO_UBOOT_NETCONSOLE),y)
+THINGINO_UBOOT_NETCONSOLE = y
+UBOOT_MAKE_OPTS += CONFIG_NETCONSOLE=y
+endif
+
 ifeq ($(BR2_PACKAGE_THINGINO_UBOOT_PHY_RESET_AFTER_CONFIG),y)
 UBOOT_MAKE_OPTS += CONFIG_PHY_RESET_AFTER_CONFIG=1
 UBOOT_MAKE_OPTS += CONFIG_GPIO_PHY_RESET=$(call qstrip,$(BR2_PACKAGE_THINGINO_UBOOT_GPIO_PHY_RESET))
@@ -106,6 +123,7 @@ define THINGINO_GENERATE_UBOOT_ENV
 	@env BR2_PACKAGE_THINGINO_UBOOT_INIT='$(value BR2_PACKAGE_THINGINO_UBOOT_INIT)' sh -c 'grep -q "^init=" $(THINGINO_UENV_TXT) || echo "init=$$BR2_PACKAGE_THINGINO_UBOOT_INIT" | sed "s/=\"/=/;s/\"$$//" >> $(THINGINO_UENV_TXT)'
 	@env BR2_PACKAGE_THINGINO_UBOOT_SD_ENABLE='$(BR2_PACKAGE_THINGINO_UBOOT_SD_ENABLE)' sh -c 'if [ "$$BR2_PACKAGE_THINGINO_UBOOT_SD_ENABLE" = "y" ]; then grep -q "^disable_sd=" $(THINGINO_UENV_TXT) && sed -i "s/^disable_sd=.*/disable_sd=false/" $(THINGINO_UENV_TXT) || echo "disable_sd=false" >> $(THINGINO_UENV_TXT); else grep -q "^disable_sd=" $(THINGINO_UENV_TXT) && sed -i "s/^disable_sd=.*/disable_sd=true/" $(THINGINO_UENV_TXT) || echo "disable_sd=true" >> $(THINGINO_UENV_TXT); fi'
 	@env BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE='$(BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE)' sh -c 'if [ "$$BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE" = "y" ]; then grep -q "^disable_eth=" $(THINGINO_UENV_TXT) && sed -i "s/^disable_eth=.*/disable_eth=false/" $(THINGINO_UENV_TXT) || echo "disable_eth=false" >> $(THINGINO_UENV_TXT); else grep -q "^disable_eth=" $(THINGINO_UENV_TXT) && sed -i "s/^disable_eth=.*/disable_eth=true/" $(THINGINO_UENV_TXT) || echo "disable_eth=true" >> $(THINGINO_UENV_TXT); fi'
+	@env THINGINO_UBOOT_NETCONSOLE='$(THINGINO_UBOOT_NETCONSOLE)' sh -c 'if [ "$$THINGINO_UBOOT_NETCONSOLE" = "y" ]; then grep -q "^preboot=" $(THINGINO_UENV_TXT) || echo "preboot=setenv stdout serial,nc;setenv stderr serial,nc;setenv stdin serial,nc" >> $(THINGINO_UENV_TXT); grep -q "^bootdelay=" $(THINGINO_UENV_TXT) || echo "bootdelay=5" >> $(THINGINO_UENV_TXT); fi'
 	@sed -i "s|\$$(UBOOT_FLASH_CONTROLLER)|$(THINGINO_UBOOT_FLASH_CONTROLLER)|g" $(THINGINO_UENV_TXT)
 	@sh -c '[ "$(SOC_FAMILY)" = "t40" -o "$(SOC_FAMILY)" = "t41" ] && sed -i "s|\$$(UBOOT_NMEM)|nmem=$$\{nmem\} |g" $(THINGINO_UENV_TXT) || sed -i "s|\$$(UBOOT_NMEM)||g" $(THINGINO_UENV_TXT)'
 	@sh -c '[ "$(SOC_FAMILY)" = "t20" -o "$(SOC_FAMILY)" = "t10" ] && sed -i "s|\$$(UBOOT_ISPMEM)| ispmem=$$\{ispmem\} |g" $(THINGINO_UENV_TXT) || sed -i "s|\$$(UBOOT_ISPMEM)| |g" $(THINGINO_UENV_TXT)'


### PR DESCRIPTION
The driver and all its hooks are already in the 2013.07 tree; patch 0006 adds the three missing config symbols to isvp_common.h:

  CONFIG_NETCONSOLE   the console-over-UDP driver
  CONFIG_CONSOLE_MUX  device lists, so serial stays alongside nc rather
                      than being replaced, and stdin=serial,nc cannot hang
                      on a dead network (the mux only enters a getc after
                      that device's tstc reported data)
  CONFIG_PREBOOT      empty by default; preboot runs before the autoboot
                      abort window, the only point early enough to
                      redirect the console and still interrupt boot

environment that makes it usable out of the box:
injected from thingino-uboot.mk via THINGINO_GENERATE_UBOOT_ENV

  preboot=setenv stdout serial,nc;setenv stderr serial,nc;setenv stdin serial,nc
  bootdelay=5
  ipaddr=192.168.1.10

bootdelay 5 is verified sufficient from a cold power-up; the stock 1s window is not. ipaddr must be non-zero or NetLoop refuses the protocol. Serial stays first in every list, so an attached serial console is unaffected.

Verified end to end on a vanhua_fjz_t31x_gc4653_eth with no serial port: Ctrl-C over UDP into an interactive prompt, commands executing with output returning over UDP. Costs a few KB in the boot partition; the partition layout is unchanged.