### PR TITLE
uboot: enable NetConsole (2026.07)

### DIFF
--- a/docs/firmware/netconsole.md
+++ b/docs/firmware/netconsole.md
@@ -1,0 +1,229 @@
+NetConsole
+==========
+
+The U-Boot console over UDP: an interactive bootloader prompt on a camera
+with no serial port attached.
+
+Covers the U-Boot phase only. Booting the kernel halts the network, so
+output stops at the handoff; kernel messages go to the serial port and need
+Linux-side netconsole instead. Anything printed before the main loop (TPL,
+SPL, DDR init, the U-Boot banner) is also out of reach, because the network
+is not up that early.
+
+Quick start
+-----------
+
+On a camera already carrying the shipped defaults:
+
+    U=<output-dir>/build/uboot-2026.07
+    gcc -o $U/tools/ncb $U/tools/ncb.c            # once
+    $U/tools/netconsole 255.255.255.255 6666      # broadcast: no ARP, any subnet
+
+Broadcast is the default here because it makes no assumption about the
+board's `ipaddr` or your subnet. Unicast to the board's address is quieter
+(your own keystrokes do not echo back) and works once `ipaddr` is an unused
+address on your subnet -- see "Shipped defaults" and "Reaching the board for
+input".
+
+Reboot the camera and keep pressing Enter until the `=>` prompt appears --
+autoboot aborts on any key. Type commands; `boot` resumes, `reset` reboots,
+Ctrl-T exits the client.
+
+If the interrupt never lands, check `bootdelay`: a saved environment keeps
+whatever value it already has, so a camera that only had its bootloader
+reflashed may still carry the old one -- and a 1s window closes before the
+link is up. Set it once (persistent):
+
+    ssh root@<camera> fw_setenv bootdelay 5
+
+If keystrokes never arrive, or stop arriving while output still flows,
+switch to broadcast -- it needs no ARP or routing (see "Troubleshooting" for
+the switch-side failure it sidesteps):
+
+    $U/tools/netconsole 255.255.255.255 6666
+
+With broadcast, characters may display twice -- your own keystroke loops
+back to the listener on top of the board's echo -- which is cosmetic.
+
+Enabling it
+-----------
+
+Off by default; opt in per camera. Set
+`BR2_PACKAGE_THINGINO_UBOOT_NETCONSOLE=y` in the camera defconfig. The symbol
+needs a wired network (U-Boot has no Wi-Fi driver) -- either the on-chip MAC
+or a USB-Ethernet dongle on an OTG board, see "USB-Ethernet boards" -- and a
+U-Boot version configured through Kconfig; the 2013.07 tree uses a patch
+instead and is handled on the ciao branch. Cameras that do not opt in build a
+stock console and keep the stock one-second bootdelay.
+
+A pre-build hook in `package/thingino-uboot/thingino-uboot.mk` switches on the
+Kconfig options:
+
+| Symbol | Purpose |
+|---|---|
+| `CONFIG_NETCONSOLE` | the console-over-UDP driver |
+| `CONFIG_CONSOLE_MUX` | device lists, so serial is kept alongside `nc` instead of replaced |
+| `CONFIG_USE_PREBOOT` | runs the environment's `preboot` before the autoboot window, the only point early enough to redirect the console and still interrupt boot |
+
+Costs a few KB in the boot partition and does not change the partition
+layout.
+
+Shipped defaults
+----------------
+
+Injected into the generated `uenv.txt` (`thingino-uboot.mk`), each line only
+when no camera or user uenv file has set that variable already:
+
+    preboot=setenv stdout serial,nc;setenv stderr serial,nc;setenv stdin serial,nc
+    bootdelay=5
+    ipaddr=192.168.1.10
+
+`uenv.txt` is both the compiled-in default environment
+(`CONFIG_ENV_DEFAULT_ENV_TEXT_FILE`) and the source of the flashed env
+partition image, so a full-image flash carries these from the first boot.
+
+- `preboot` performs the console redirect. `serial` stays first in each
+  list, so an attached serial console is unaffected.
+- `bootdelay` must leave usable time after the link comes up: interrupting
+  autoboot over the network from a cold power-up does not work inside 1
+  second, and 5 is verified sufficient. It rides with netconsole, so boards
+  without it (wifi-only) keep the stock 1s.
+- `ipaddr` must be non-zero or `net_loop()` refuses NETCONS outright
+  (`*** ERROR: 'ipaddr' not set`), so some value has to be present. Output is
+  broadcast, so the value does not affect it; only unicast input depends on it.
+
+  The value is taken from the address the image was built for. `make ... IP=`
+  is already the per-camera address used to reach the board, and the build
+  injects it here, so a camera built with `IP=192.168.88.139` carries its own
+  unique, on-subnet address into the bootloader -- the same one `make ota
+  IP=...` uses. A value that is not a dotted quad (a hostname, say) is ignored
+  in favour of the fallback, because U-Boot cannot parse it.
+
+  192.168.1.10 is only the fallback for builds that pass no `IP=`, not a fleet
+  policy. Precedence, lowest to highest: that fallback, then the `IP=` the
+  image was built with, then `ipaddr=` in the camera's `uenv.txt` or in
+  `user/<camera>/local.uenv.txt`. `fw_setenv ipaddr` overrides all of it on an
+  already-flashed board.
+
+  On any other subnet, unicast input cannot reach the board: your host ARPs
+  for an off-subnet address and hands the packet to its gateway instead of
+  the camera's port. Use broadcast, or set an unused address on your subnet.
+
+  Enabling netconsole on more than one camera without a per-camera `ipaddr`
+  is worse than a wrong subnet. Every such camera answers an ARP for the same
+  address (`net/arp.c`), so unicast reaches whichever MAC your host cached
+  last and you cannot address one camera in particular. With `ncip` unset each
+  accepts input from any source (`drivers/net/netconsole.c`), so a single
+  broadcast `reset` reboots all of them at once. Their output is broadcast
+  too, so the consoles interleave on one listener. Building each camera with its own
+  `IP=` gives them unique addresses without any hand-written override; pin
+  `ncip` to your host as well -- `ncip` disambiguates input, but the ARP reply
+  still needs the address to be unique.
+
+USB-Ethernet boards
+-------------------
+
+On a board with no on-chip Ethernet but a USB OTG data port
+(`BR2_PACKAGE_THINGINO_KOPT_DWC2_OTG`), netconsole runs over a USB-Ethernet
+dongle instead. Nothing extra is compiled: the isvp defconfigs already set
+`CONFIG_USB_DWC2`, `CONFIG_USB_HOST_ETHER` and the ASIX host drivers
+(`CONFIG_USB_ETHER_ASIX`, `CONFIG_USB_ETHER_ASIX88179`). It is
+`THINGINO_UBOOT_DISABLE_USB_ETH` that strips them from boards with no OTG
+port -- exactly the boards this mode excludes. The only difference is one
+extra command at the head of the injected preboot:
+
+    preboot=usb start;setenv stdout serial,nc;setenv stderr serial,nc;setenv stdin serial,nc
+
+`usb start` enumerates the dongle and registers it as an Ethernet device.
+
+No `ethact` selection is needed on this tree, unlike the 2013.07 one. Two
+reasons: `THINGINO_UBOOT_DISABLE_WIRED_ETH` drops the on-chip MAC driver on
+the same `!BR2_ETHERNET` condition, so the dongle is the only `UCLASS_ETH`
+device; and under `CONFIG_DM_ETH` `eth_init()` only consults `ethact` when
+`ethrotate=no`, otherwise taking the current device and rotating on failure.
+Note also that the driver-model device names are `asix_eth` and
+`ax88179_eth` (the `U_BOOT_DRIVER` names), not the `asx0`/`axg0` of the
+legacy stack -- so a hand-written `setenv ethact asx0` would find nothing.
+
+Because `usb start` runs inside preboot, enumeration and link-up finish
+before the autoboot countdown begins, so `bootdelay` only has to overlap a
+keypress from the client and needs no extra margin for USB.
+
+Cable the dongle to the same segment as the host running `tools/netconsole`;
+from there it behaves exactly like a wired board. To confirm which device
+carried the traffic, `printenv ethact` at the prompt reports the dongle.
+
+Reaching the board for input
+----------------------------
+
+Output is broadcast and always arrives. Input can be sent two ways:
+
+- **Unicast** (send to `ipaddr`, the quick start default): requires your
+  host to address that IP on the wire -- same subnet, or a seeded neighbour
+  entry (`ip neigh replace <ipaddr> lladdr <ethaddr> dev <iface>`).
+- **Broadcast** (send to `255.255.255.255`): needs no ARP entry and works
+  regardless of whether `ipaddr` is on your subnet.
+
+Use `ncb`, not netcat, for receiving -- netcat cannot listen to broadcast.
+`tools/netconsole` drives both directions and needs `ncb` beside it or in
+`PATH`.
+
+Troubleshooting
+---------------
+
+- **Nothing arrives.** Using netcat instead of `ncb`? It cannot receive
+  broadcast.
+- **`Connection refused`.** ICMP port-unreachable: the board is in Linux,
+  where nothing listens on UDP 6666. You missed the window.
+- **Output stops when the kernel boots.** By design; the network is halted
+  at the OS handoff.
+- **Commands abort on their own.** A key sender is still running.
+- **Different L2 segment.** Broadcast does not cross routers.
+- **Unicast input freezes; output keeps flowing.** Seen with a MikroTik
+  CRS112 (QCA-8511): the switch's dynamic unicast FDB entry for the quiet
+  board evaporates and unicast stops reaching the port, while broadcast
+  still arrives -- and any transmit from the board revives it. The
+  mechanism is entirely switch-side, so any board idling at the prompt is
+  exposed. Remedies, best first:
+  1. Send input to 255.255.255.255 (the broadcast alternative in the quick
+     start). Immune by construction.
+  2. Pin the board's MAC on the switch. On RouterOS:
+     `/interface ethernet switch unicast-fdb add mac-address=<ethaddr> port=<port> svl=yes`
+  3. Ad hoc: anything broadcast that makes the board transmit. A freshly
+     started `arping <ipaddr>` punches through (its first probe is
+     broadcast), but goes deaf once it switches to unicast probes.
+     `ping -b 255.255.255.255` keeps working, because every probe stays
+     broadcast.
+
+Security
+--------
+
+NetConsole has no authentication. With `ncip` unset the board runs in
+broadcast mode and accepts console input from any host on the L2 segment, so
+while autoboot counts down anyone on the subnet can interrupt boot and reach
+an interactive U-Boot prompt: full access to flash, the environment, and boot.
+
+That is why the build option is off by default and opt-in per camera. To
+narrow it, pin one client with `fw_setenv ncip <host-ip>`; the board then only
+accepts input from that host, and sends its output there as unicast rather
+than broadcasting. That is address-based, not real authentication.
+
+Removing it
+-----------
+
+    fw_setenv preboot        # back to stock behaviour
+    fw_setenv bootdelay 1
+
+Serial is not at risk from the environment here. The build pins
+`CONFIG_SYS_CONSOLE_IS_IN_ENV=n`, so `console_init_r()` builds the console
+from the real stdio devices every boot and never reads `stdout`/`stdin` from
+the environment -- a saved `stdout=nc` is inert at boot, because the callback
+that reassigns a console is a no-op until `GD_FLG_DEVINIT` is set. On top of
+that, the injected `preboot` re-asserts `serial,nc` on every boot, so a
+runtime redirect does not survive a reset either.
+
+Both properties come from this build's configuration, not from netconsole
+itself. `SYS_CONSOLE_IS_IN_ENV` is `default y if CONSOLE_MUX` in
+`common/Kconfig`, and a build that leaves it at that default does take the
+console from the environment -- there, `fw_setenv stdout nc` together with a
+cleared `preboot` would leave no console on the serial port.

--- a/package/thingino-uboot/Config.in
+++ b/package/thingino-uboot/Config.in
@@ -24,6 +24,33 @@ config BR2_PACKAGE_THINGINO_UBOOT_SD_ENABLE
 config BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE
 	bool
 
+config BR2_PACKAGE_THINGINO_UBOOT_NETCONSOLE
+	bool "Enable NetConsole (U-Boot console over UDP)"
+	depends on BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE || BR2_PACKAGE_THINGINO_KOPT_DWC2_OTG
+	depends on !BR2_THINGINO_UBOOT_VERSION_2013_07
+	help
+	  Build the bootloader with NetConsole and redirect the console to
+	  it (stdout/stderr/stdin = serial,nc) so U-Boot can be driven over
+	  UDP on a camera whose serial port is not exposed. Also raises
+	  bootdelay to 5s so the autoboot window can be interrupted over the
+	  network.
+
+	  Needs a wired network: U-Boot has no Wi-Fi driver. That is either
+	  the on-chip MAC, or -- on a board with no wired Ethernet but a USB
+	  OTG data port -- a USB-Ethernet dongle, for which the injected
+	  preboot runs `usb start` before redirecting the console. The ASIX
+	  host drivers are already in the isvp defconfigs, so nothing extra
+	  is compiled.
+
+	  The 2013.07 tree configures NetConsole through a patch instead and
+	  is handled on the ciao branch, hence the version dependency here.
+
+	  SECURITY: with ncip unset the board accepts console input from any
+	  host on the L2 segment, so anyone on the subnet can interrupt boot
+	  and reach an unauthenticated U-Boot prompt during the boot window.
+	  Enable only on trusted networks, or pin a single client with
+	  `fw_setenv ncip <host>`. Off by default; opt in per camera.
+
 config BR2_PACKAGE_THINGINO_UBOOT_ENABLE_BAR
 	bool "Enable SPI Flash BAR"
 	help

--- a/package/thingino-uboot/thingino-uboot.mk
+++ b/package/thingino-uboot/thingino-uboot.mk
@@ -24,6 +24,50 @@ ifeq ($(BR2_PACKAGE_THINGINO_UBOOT_EXTERNAL_ENV_ENABLE),y)
 UBOOT_MAKE_OPTS += CONFIG_BOOTARGS_EXTERNAL=1
 endif
 
+# NetConsole (U-Boot console over UDP), opt-in per camera via
+# BR2_PACKAGE_THINGINO_UBOOT_NETCONSOLE. That symbol is default n and gated in
+# Kconfig to the versions configured through Kconfig, because the 2013.07 tree
+# needs a patch instead. CONSOLE_MUX keeps serial alongside nc rather than
+# replacing it, and USE_PREBOOT runs the environment's preboot before the
+# autoboot window -- the only point early enough to redirect the console and
+# still interrupt boot. SYS_CONSOLE_IS_IN_ENV is pinned off: common/Kconfig makes
+# it default y whenever CONSOLE_MUX is set, and with it on, console_init_r()
+# takes stdin/stdout/stderr from the environment instead of the real stdio
+# devices -- so a saved stdout=nc would survive a reset and, with preboot also
+# cleared, leave no console on a camera whose serial header is not exposed. It
+# happens to resolve to n today only because buildroot expands the defconfig
+# before this hook runs and olddefconfig keeps the recorded value; pinning makes
+# that a property of the build rather than of the ordering. The environment that
+# makes netconsole reachable is injected in THINGINO_GENERATE_UBOOT_ENV below.
+# THINGINO_UBOOT_NETCONSOLE is a single internal flag so both effects -- the
+# Kconfig options and the injected environment -- follow from one condition.
+# THINGINO_UBOOT_NETCONSOLE_USB additionally marks boards that reach the
+# network over a USB-Ethernet dongle rather than the on-chip MAC: no wired
+# Ethernet, but a USB OTG data port. Their injected preboot runs `usb start`
+# first (see THINGINO_GENERATE_UBOOT_ENV). Nothing extra is compiled: the isvp
+# defconfigs already set USB_DWC2, USB_HOST_ETHER and the ASIX host drivers,
+# and it is THINGINO_UBOOT_DISABLE_USB_ETH below that strips them from boards
+# without an OTG port -- exactly the boards this flag excludes. No ethact is
+# selected either: THINGINO_UBOOT_DISABLE_WIRED_ETH drops the on-chip MAC
+# driver on the same !BR2_ETHERNET condition, so the dongle is the only
+# UCLASS_ETH device and eth_init() picks it up on its own.
+ifeq ($(BR2_PACKAGE_THINGINO_UBOOT_NETCONSOLE),y)
+THINGINO_UBOOT_NETCONSOLE = y
+ifneq ($(BR2_ETHERNET),y)
+ifeq ($(BR2_PACKAGE_THINGINO_KOPT_DWC2_OTG),y)
+THINGINO_UBOOT_NETCONSOLE_USB = y
+endif
+endif
+define THINGINO_UBOOT_ENABLE_NETCONSOLE
+	$(call KCONFIG_ENABLE_OPT,CONFIG_NETCONSOLE,$(@D)/.config)
+	$(call KCONFIG_ENABLE_OPT,CONFIG_CONSOLE_MUX,$(@D)/.config)
+	$(call KCONFIG_ENABLE_OPT,CONFIG_USE_PREBOOT,$(@D)/.config)
+	$(call KCONFIG_DISABLE_OPT,CONFIG_SYS_CONSOLE_IS_IN_ENV,$(@D)/.config)
+	$(UBOOT_KCONFIG_MAKE) olddefconfig
+endef
+UBOOT_PRE_BUILD_HOOKS += THINGINO_UBOOT_ENABLE_NETCONSOLE
+endif
+
 ifeq ($(BR2_PACKAGE_THINGINO_UBOOT_PHY_RESET_AFTER_CONFIG),y)
 UBOOT_MAKE_OPTS += CONFIG_PHY_RESET_AFTER_CONFIG=1
 UBOOT_MAKE_OPTS += CONFIG_GPIO_PHY_RESET=$(call qstrip,$(BR2_PACKAGE_THINGINO_UBOOT_GPIO_PHY_RESET))
@@ -118,6 +162,7 @@ define THINGINO_GENERATE_UBOOT_ENV
 	@env BR2_PACKAGE_THINGINO_UBOOT_INIT='$(value BR2_PACKAGE_THINGINO_UBOOT_INIT)' sh -c 'grep -q "^init=" $(THINGINO_UENV_TXT) || echo "init=$$BR2_PACKAGE_THINGINO_UBOOT_INIT" | sed "s/=\"/=/;s/\"$$//" >> $(THINGINO_UENV_TXT)'
 	@env BR2_PACKAGE_THINGINO_UBOOT_SD_ENABLE='$(BR2_PACKAGE_THINGINO_UBOOT_SD_ENABLE)' sh -c 'if [ "$$BR2_PACKAGE_THINGINO_UBOOT_SD_ENABLE" = "y" ]; then grep -q "^disable_sd=" $(THINGINO_UENV_TXT) && sed -i "s/^disable_sd=.*/disable_sd=false/" $(THINGINO_UENV_TXT) || echo "disable_sd=false" >> $(THINGINO_UENV_TXT); else grep -q "^disable_sd=" $(THINGINO_UENV_TXT) && sed -i "s/^disable_sd=.*/disable_sd=true/" $(THINGINO_UENV_TXT) || echo "disable_sd=true" >> $(THINGINO_UENV_TXT); fi'
 	@env BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE='$(BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE)' sh -c 'if [ "$$BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE" = "y" ]; then grep -q "^disable_eth=" $(THINGINO_UENV_TXT) && sed -i "s/^disable_eth=.*/disable_eth=false/" $(THINGINO_UENV_TXT) || echo "disable_eth=false" >> $(THINGINO_UENV_TXT); else grep -q "^disable_eth=" $(THINGINO_UENV_TXT) && sed -i "s/^disable_eth=.*/disable_eth=true/" $(THINGINO_UENV_TXT) || echo "disable_eth=true" >> $(THINGINO_UENV_TXT); fi'
+	@env THINGINO_UBOOT_NETCONSOLE='$(THINGINO_UBOOT_NETCONSOLE)' THINGINO_UBOOT_NETCONSOLE_USB='$(THINGINO_UBOOT_NETCONSOLE_USB)' IP='$(strip $(IP))' sh -c 'if [ "$$THINGINO_UBOOT_NETCONSOLE" = "y" ]; then if [ "$$THINGINO_UBOOT_NETCONSOLE_USB" = "y" ]; then NC_PREBOOT="usb start;setenv stdout serial,nc;setenv stderr serial,nc;setenv stdin serial,nc"; else NC_PREBOOT="setenv stdout serial,nc;setenv stderr serial,nc;setenv stdin serial,nc"; fi; case "$$IP" in [0-9]*.[0-9]*.[0-9]*.[0-9]*) NC_IPADDR="$$IP" ;; *) NC_IPADDR=192.168.1.10 ;; esac; grep -q "^preboot=" $(THINGINO_UENV_TXT) || echo "preboot=$$NC_PREBOOT" >> $(THINGINO_UENV_TXT); grep -q "^bootdelay=" $(THINGINO_UENV_TXT) || echo "bootdelay=5" >> $(THINGINO_UENV_TXT); grep -q "^ipaddr=" $(THINGINO_UENV_TXT) || echo "ipaddr=$$NC_IPADDR" >> $(THINGINO_UENV_TXT); fi'
 	@sed -i "s|\$$(UBOOT_FLASH_CONTROLLER)|$(THINGINO_UBOOT_FLASH_CONTROLLER)|g" $(THINGINO_UENV_TXT)
 	@sh -c '[ "$(SOC_FAMILY)" = "t40" -o "$(SOC_FAMILY)" = "t41" ] && sed -i "s|\$$(UBOOT_NMEM)|nmem=$$\{nmem\} |g" $(THINGINO_UENV_TXT) || sed -i "s|\$$(UBOOT_NMEM)||g" $(THINGINO_UENV_TXT)'
 	@sh -c '[ "$(SOC_FAMILY)" = "t20" -o "$(SOC_FAMILY)" = "t10" ] && sed -i "s|\$$(UBOOT_ISPMEM)| ispmem=$$\{ispmem\} |g" $(THINGINO_UENV_TXT) || sed -i "s|\$$(UBOOT_ISPMEM)| |g" $(THINGINO_UENV_TXT)'


### PR DESCRIPTION
NetConsole gives an interactive U-Boot prompt over UDP. On a camera whose serial
header is not exposed outside the case, that is the only way into the
bootloader. This adds it as an opt-in build option for the U-Boot versions
configured through Kconfig, over either the on-chip MAC or a USB-Ethernet
dongle.

Off by default. A camera opts in with one defconfig line; every camera that does
not builds a byte-identical bootloader with the stock 1s bootdelay.

## What changed

Three files, no new U-Boot patch.

1. **`package/thingino-uboot/Config.in`** -- new `default n` symbol
   `BR2_PACKAGE_THINGINO_UBOOT_NETCONSOLE`, gated to the Kconfig-configured
   U-Boot versions and to boards that have a wired network:
   `BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE || BR2_PACKAGE_THINGINO_KOPT_DWC2_OTG`.

2. **`package/thingino-uboot/thingino-uboot.mk`** -- a pre-build hook enables the
   U-Boot options, and the env hook injects the environment that makes the board
   reachable.

3. **`docs/firmware/netconsole.md`** -- usage, the shipped defaults, the
   USB-Ethernet section, troubleshooting and the security note.

### U-Boot options

| Symbol | Why |
|---|---|
| `CONFIG_NETCONSOLE` | the console-over-UDP driver |
| `CONFIG_CONSOLE_MUX` | device lists, so serial is kept alongside `nc` instead of replaced. Also why `stdin=serial,nc` cannot hang on a dead network: the mux only enters a `getc` after that device's `tstc` reported data |
| `CONFIG_USE_PREBOOT` | runs the environment's `preboot` before the autoboot window -- the only point early enough to redirect the console and still interrupt boot |

### Injected environment

Written into the generated `uenv.txt`, each line only when no camera or user
uenv file has already set that variable:

```
preboot=setenv stdout serial,nc;setenv stderr serial,nc;setenv stdin serial,nc
bootdelay=5
ipaddr=192.168.1.10
```

- `bootdelay` has to leave usable time after the link comes up. The stock 1s
  window closes before that on a cold power-up; 5 is measured sufficient. It
  rides with the option, so boards without it keep the stock 1s.
- `ipaddr` must be non-zero or `NetLoop` refuses the protocol. It has to be in
  `uenv.txt` rather than relying on `CONFIG_IPADDR`, because a flashed camera
  has a valid saved environment that replaces the compiled default wholesale.

## USB-Ethernet boards

A board with no on-chip Ethernet but a USB OTG data port runs netconsole over a
USB-Ethernet dongle. Such boards (no `BR2_ETHERNET`, but
`BR2_PACKAGE_THINGINO_KOPT_DWC2_OTG`) are marked internally with
`THINGINO_UBOOT_NETCONSOLE_USB` and get one extra command at the head of the
injected preboot:

```
preboot=usb start;setenv stdout serial,nc;setenv stderr serial,nc;setenv stdin serial,nc
```

`usb start` enumerates the dongle and registers it as an Ethernet device.

Nothing extra is compiled for this: the isvp defconfigs already set
`CONFIG_USB_DWC2`, `CONFIG_CMD_USB`, `CONFIG_USB_HOST_ETHER` and the ASIX host
drivers. It is the existing `THINGINO_UBOOT_DISABLE_USB_ETH` hook that strips
them from boards with no OTG port -- exactly the boards this mode excludes.

**No `ethact` selection is needed on this tree**, unlike the 2013.07 lane, for
two reasons:

- `THINGINO_UBOOT_DISABLE_WIRED_ETH` drops the on-chip MAC driver on the same
  `!BR2_ETHERNET` condition, so the dongle is the only `UCLASS_ETH` device.
- Under `CONFIG_DM_ETH`, `eth_init()` only consults `ethact` when
  `ethrotate=no`; otherwise it takes the current device and rotates on failure.

Worth recording because it is an easy mistake to carry across branches: under
driver model the device names come from `U_BOOT_DRIVER`, so they are `asix_eth`
and `ax88179_eth`. The legacy stack's `asx0`/`axg0` names match nothing here,
and `ASIX_BASE_NAME` is dead code on this tree. The docs say so.

## Security

With `ncip` unset the board accepts console input from any host on the L2
segment, so during the boot window anyone on the subnet can interrupt autoboot
and reach an unauthenticated U-Boot prompt. This is inherent to netconsole. The
symbol's help text and the docs both say so, and a single client can be pinned
with `fw_setenv ncip <host>`. Keeping it opt-in limits the exposure to boards
someone deliberately enabled.



## Testing

Build-verified both ways with the 2026.07 tree.

*Wired* (`vanhua_fjz_t31x_gc4653_eth`): without the option, the U-Boot config
has no netconsole symbols and `uenv.txt` gets no injected variables. With it,
the three options are set, `netconsole.o` is compiled, the DesignWare MAC is
still built, the USB-Ethernet drivers are still stripped, and the injected
preboot has no `usb start`.

*USB-only* (`wyze_cam3_t31x_gc2053_rtl8189ftv`, T31X, WiFi + OTG, no wired
Ethernet, no serial header): the symbol is accepted with `BR2_ETHERNET` unset;
`netconsole.o`, `asix.o`, `usb_ether.o` and `dwc2.o` are compiled; the wired MAC
driver is dropped; and the `usb start` preboot reaches the linked `u-boot`
through the default environment.

### Hardware

Both transports verified on real cameras with no serial port attached, at the
shipped `bootdelay` of 5. Each trial was a fresh reboot, and counted as a pass
only if an `echo` round-tripped through the prompt -- receiving console output
alone was not treated as success.

**USB-Ethernet** (`wyze_cam3_t31x_gc2053_rtl8189ftv` + ASIX AX88772C dongle) --
5 of 5. Ctrl-C over UDP interrupts autoboot into an interactive prompt and
commands execute with output returning over UDP:

```
=> usb tree
  |+-2  Vendor specific (480 Mb/s, 200mA)
       ASIX Elec. Corp. AX88772C A7C737
=> printenv ethact
## Error: "ethact" not defined
```

**Wired on-chip MAC** (`vanhua_fjz_t31x_gc4653_eth`) -- 5 of 5:

```
=> version
U-Boot 2026.10-rc1 (Sep 02 2026 - 01:00:56 +0200)
=> printenv ethact
ethact=ethernet@134b0000
=> printenv preboot
preboot=setenv stdout serial,nc;setenv stderr serial,nc;setenv stdin serial,nc
```

The wired camera was also tested on its previous 2013.07 build immediately
before flashing, as a control that the test rig itself was sound.

`ethact` across the three lanes, which is what the design note above rests on:

| Lane | `ethact` | Why |
|---|---|---|
| 2013.07 wired (ciao) | `Jz4775-9161` | legacy stack registers the on-chip MAC as device 0 |
| 2026.07 wired | `ethernet@134b0000` | driver-model device name, set by `eth_init()` after use |
| 2026.07 USB dongle | not defined | the dongle is the only `UCLASS_ETH` device, so there is nothing to select |