### PR TITLE
uboot: align 2013.07 SFC-NOR env offset with the boot partition

### DIFF
--- a/package/thingino-uboot/thingino-uboot.mk
+++ b/package/thingino-uboot/thingino-uboot.mk
@@ -130,6 +130,14 @@ define THINGINO_GENERATE_UBOOT_ENV
 endef
 UBOOT_PRE_BUILD_HOOKS += THINGINO_GENERATE_UBOOT_ENV
 
+# The 2013.07 header hardcodes CONFIG_ENV_OFFSET 0x40000 for SFC-NOR, which
+# only matches a 256k boot partition. U_BOOT_SIZE_KB drives the actual boot
+# size (and thus the env partition offset) in the generated mtdparts, so a
+# larger boot region leaves the bootloader reading/writing its env at the
+# wrong offset -- inside the boot partition, not the env partition. Rewrite
+# CONFIG_ENV_OFFSET to U_BOOT_PARTITION_SIZE so it always tracks the boot
+# size. (Kconfig fragments cannot reach this legacy header; the 2026.07 tree
+# gets its env offset from configs/uboot/layout/sfcnor.config instead.)
 define THINGINO_PATCH_DEV_ENV
 	@if [ -f $(@D)/include/configs/isvp_common.h ] && [ -f $(THINGINO_BINARIES_DIR)/uImage ] && [ -f $(THINGINO_BINARIES_DIR)/rootfs.squashfs ]; then \
 		KERNEL_OFFSET=$$(( $(U_BOOT_PARTITION_SIZE) + $(UB_ENV_PARTITION_SIZE) + $(BACKUP_PARTITION_SIZE) )); \
@@ -144,6 +152,7 @@ define THINGINO_PATCH_DEV_ENV
 		MTDPARTS="$(THINGINO_UBOOT_FLASH_CONTROLLER):$(U_BOOT_SIZE_KB)k(boot),$(UB_ENV_SIZE_KB)k(env),$(BACKUP_SIZE_KB)k(backup),$(KERNEL_SIZE_KB)k(kernel),$${ROOTFS_SIZE_KB}k(rootfs),$${DATA_SIZE_KB}k(data),$${FLASH_SIZE_KB}k@0(all)"; \
 		echo "Compiling U-Boot with mtdparts=$$MTDPARTS"; \
 		sed -i "s|CONFIG_MTDPARTS_DEFAULT=.*|CONFIG_MTDPARTS_DEFAULT=\"$$MTDPARTS\"|" $(@D)/include/configs/isvp_common.h; \
+		sed -i "s|^\(#define CONFIG_ENV_OFFSET[ \t]*\)0x40000|\1$(U_BOOT_PARTITION_SIZE)|" $(@D)/include/configs/isvp_common.h; \
 		$(BR2_EXTERNAL_THINGINO_PATH)/scripts/uboot-device-env.sh $(THINGINO_UENV_TXT) \
 			$(@D)/include/configs/isvp_common.h; \
 	fi


### PR DESCRIPTION
The 2013.07 header hardcodes CONFIG_ENV_OFFSET 0x40000 (isvp_common.h, CONFIG_ENV_IS_IN_SPI_FLASH branch), which is correct only for a 256k boot partition. U_BOOT_SIZE_KB drives the real boot size and thus the env partition offset in the generated mtdparts, so after the boot partition grew to 320k the env partition moved to 0x50000 while the bootloader kept reading and writing its environment at 0x40000 -- inside the boot partition, past the U-Boot binary, not the env partition.

Effect on a 320k build: U-Boot finds a blank/invalid env at 0x40000 and falls back to the compiled-in default env, while Linux (fw_env.config, /dev/mtd1) uses the real env partition at 0x50000. The two disagree: fw_setenv from Linux never reaches the bootloader, and a U-Boot saveenv writes into the boot region.

Rewrite CONFIG_ENV_OFFSET to U_BOOT_PARTITION_SIZE in THINGINO_PATCH_DEV_ENV, next to where the mtdparts are already stamped, so the env offset always tracks the boot size (0x40000 for 256k, 0x50000 for 320k, ...). Kconfig fragments cannot reach this legacy header; the 2026.07 tree gets its env offset from configs/uboot/layout/sfcnor.config instead, which the 320k change already updated.

Verified: with U_BOOT_SIZE_KB=320 the built isvp_common.h now has CONFIG_ENV_OFFSET 327680 (0x50000), matching the env partition; the MMC and NAND env-offset defines are untouched.