### PR TITLE
uboot: extend NetConsole to USB-Ethernet (OTG) boards (uboot 2013)

### DIFF
--- a/docs/netconsole.md
+++ b/docs/netconsole.md
@@ -43,10 +43,10 @@ Enabling it
 
 Off by default; opt in per camera. Set
 `BR2_PACKAGE_THINGINO_UBOOT_NETCONSOLE=y` in the camera defconfig (it depends
-on wired Ethernet and the 2013.07 U-Boot). That passes `CONFIG_NETCONSOLE=y`
-into the U-Boot build and injects the environment below; every camera that
-does not opt in builds a byte-identical stock bootloader with the stock 1s
-bootdelay.
+on the 2013.07 U-Boot and on the board having either wired Ethernet or a USB
+OTG data port). That passes `CONFIG_NETCONSOLE=y` into the U-Boot build and
+injects the environment below; every camera that does not opt in builds a
+byte-identical stock bootloader with the stock 1s bootdelay.
 `package/all-patches/uboot/2013.07/0006-isvp-enable-NetConsole-behind-a-build-system-guard.patch`
 carries the U-Boot side, guarded by that flag; the driver and its hooks were
 already in the tree.
@@ -86,6 +86,38 @@ the value has to be in `uenv.txt` to reach the board.
   boards without it (wifi-only) keep the stock 1s and boot as fast as before.
 - `ipaddr` must be non-zero or `NetLoop` refuses the protocol. Output is
   broadcast so the value does not affect it; only unicast input depends on it.
+
+USB-Ethernet boards
+-------------------
+
+On a board with no on-chip Ethernet but a USB OTG data port
+(`BR2_PACKAGE_THINGINO_KOPT_DWC2_OTG`), netconsole runs over a USB-Ethernet
+dongle. Nothing extra is compiled: `isvp_common.h` already builds the DWC2
+host controller and the ASIX host-Ethernet drivers on every board but T31LC,
+and `board_usb_init()` puts the OTG in host mode. The injected preboot just
+brings the bus up and selects the dongle before redirecting the console:
+
+    preboot=usb start;setenv ethact ${nc_ethact};setenv stdout serial,nc;setenv stderr serial,nc;setenv stdin serial,nc
+    nc_ethact=asx0
+
+`usb start` enumerates the dongle and registers it as an Ethernet device;
+`ethact` makes it the active device, because the on-chip MAC is still
+registered as device 0 and would otherwise take the traffic. The default
+`nc_ethact=asx0` matches an ASIX AX88772 dongle; for an AX88179 set
+`fw_setenv nc_ethact axg0` (the name comes from the driver: `asx` in
+`drivers/usb/eth/asix.c`, `axg` in `asix88179.c`).
+
+Because `usb start` runs inside preboot, enumeration and link-up finish
+before the autoboot countdown begins, so `bootdelay` only has to overlap a
+keypress from the client and needs no extra margin for USB. Measured on a
+Wyze Cam v3 (T31X) with an AX88772C: the prompt was caught on every boot at
+`bootdelay` 2 and above, and 5 of 6 at 1. The shipped 5 leaves room for a
+cold power-up, which those measurements did not cover.
+
+Cable the dongle to the same segment as the host running `tools/netconsole`;
+from there it behaves exactly like a wired board. To check the selection
+took effect, `printenv ethact` at the prompt should report the dongle
+(`asx0`), not the on-chip MAC.
 
 Security
 --------

--- a/package/thingino-uboot/Config.in
+++ b/package/thingino-uboot/Config.in
@@ -26,13 +26,19 @@ config BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE
 
 config BR2_PACKAGE_THINGINO_UBOOT_NETCONSOLE
 	bool "Enable NetConsole (U-Boot console over UDP)"
-	depends on BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE
+	depends on BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE || BR2_PACKAGE_THINGINO_KOPT_DWC2_OTG
 	depends on BR2_THINGINO_UBOOT_VERSION_2013_07
 	help
 	  Build the bootloader with NetConsole and redirect the console to
 	  it (stdout/stderr/stdin = serial,nc) so U-Boot can be driven over
 	  UDP on a board with no serial port. Also raises bootdelay to 5s so
 	  the autoboot window can be interrupted over the network.
+
+	  Works over the on-chip Ethernet (BR2_ETHERNET boards) or, on boards
+	  with only a USB OTG data port, over a USB-Ethernet dongle: the
+	  injected preboot runs `usb start` and points `ethact` at the dongle
+	  before redirecting the console. The default dongle name is asx0
+	  (ASIX AX88772); for an AX88179 set `fw_setenv nc_ethact axg0`.
 
 	  SECURITY: with ncip unset the board accepts console input from any
 	  host on the L2 segment, so anyone on the subnet can interrupt boot

--- a/package/thingino-uboot/thingino-uboot.mk
+++ b/package/thingino-uboot/thingino-uboot.mk
@@ -33,12 +33,22 @@ endif
 # the make option and the injected environment -- out of non-2013.07 builds.
 # Must be =y, not =1: U-Boot's drivers/net/Makefile selects the object with
 # COBJS-$(CONFIG_NETCONSOLE), and a command-line value overrides autoconf.mk.
-# THINGINO_UBOOT_NETCONSOLE is a single internal flag so a second network
-# transport (e.g. USB-Ethernet on OTG boards) can enable both effects later
-# from one more condition, without duplicating it here and in the env hook.
+# THINGINO_UBOOT_NETCONSOLE is a single internal flag so both effects -- the
+# make option and the injected environment -- follow from one condition.
+# THINGINO_UBOOT_NETCONSOLE_USB additionally marks boards that reach the
+# network over a USB-Ethernet dongle rather than the on-chip MAC: no wired
+# Ethernet, but a USB OTG data port. Their injected preboot runs `usb start`
+# and selects the dongle first (see THINGINO_GENERATE_UBOOT_ENV). The U-Boot
+# side needs nothing extra: isvp_common.h already builds the DWC2 host
+# controller and the ASIX host-Ethernet drivers on every board but T31LC.
 ifeq ($(BR2_PACKAGE_THINGINO_UBOOT_NETCONSOLE),y)
 THINGINO_UBOOT_NETCONSOLE = y
 UBOOT_MAKE_OPTS += CONFIG_NETCONSOLE=y
+ifneq ($(BR2_ETHERNET),y)
+ifeq ($(BR2_PACKAGE_THINGINO_KOPT_DWC2_OTG),y)
+THINGINO_UBOOT_NETCONSOLE_USB = y
+endif
+endif
 endif
 
 ifeq ($(BR2_PACKAGE_THINGINO_UBOOT_PHY_RESET_AFTER_CONFIG),y)
@@ -123,7 +133,7 @@ define THINGINO_GENERATE_UBOOT_ENV
 	@env BR2_PACKAGE_THINGINO_UBOOT_INIT='$(value BR2_PACKAGE_THINGINO_UBOOT_INIT)' sh -c 'grep -q "^init=" $(THINGINO_UENV_TXT) || echo "init=$$BR2_PACKAGE_THINGINO_UBOOT_INIT" | sed "s/=\"/=/;s/\"$$//" >> $(THINGINO_UENV_TXT)'
 	@env BR2_PACKAGE_THINGINO_UBOOT_SD_ENABLE='$(BR2_PACKAGE_THINGINO_UBOOT_SD_ENABLE)' sh -c 'if [ "$$BR2_PACKAGE_THINGINO_UBOOT_SD_ENABLE" = "y" ]; then grep -q "^disable_sd=" $(THINGINO_UENV_TXT) && sed -i "s/^disable_sd=.*/disable_sd=false/" $(THINGINO_UENV_TXT) || echo "disable_sd=false" >> $(THINGINO_UENV_TXT); else grep -q "^disable_sd=" $(THINGINO_UENV_TXT) && sed -i "s/^disable_sd=.*/disable_sd=true/" $(THINGINO_UENV_TXT) || echo "disable_sd=true" >> $(THINGINO_UENV_TXT); fi'
 	@env BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE='$(BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE)' sh -c 'if [ "$$BR2_PACKAGE_THINGINO_UBOOT_ETH_ENABLE" = "y" ]; then grep -q "^disable_eth=" $(THINGINO_UENV_TXT) && sed -i "s/^disable_eth=.*/disable_eth=false/" $(THINGINO_UENV_TXT) || echo "disable_eth=false" >> $(THINGINO_UENV_TXT); else grep -q "^disable_eth=" $(THINGINO_UENV_TXT) && sed -i "s/^disable_eth=.*/disable_eth=true/" $(THINGINO_UENV_TXT) || echo "disable_eth=true" >> $(THINGINO_UENV_TXT); fi'
-	@env THINGINO_UBOOT_NETCONSOLE='$(THINGINO_UBOOT_NETCONSOLE)' sh -c 'if [ "$$THINGINO_UBOOT_NETCONSOLE" = "y" ]; then grep -q "^preboot=" $(THINGINO_UENV_TXT) || echo "preboot=setenv stdout serial,nc;setenv stderr serial,nc;setenv stdin serial,nc" >> $(THINGINO_UENV_TXT); grep -q "^bootdelay=" $(THINGINO_UENV_TXT) || echo "bootdelay=5" >> $(THINGINO_UENV_TXT); grep -q "^ipaddr=" $(THINGINO_UENV_TXT) || echo "ipaddr=192.168.1.10" >> $(THINGINO_UENV_TXT); fi'
+	@env THINGINO_UBOOT_NETCONSOLE='$(THINGINO_UBOOT_NETCONSOLE)' THINGINO_UBOOT_NETCONSOLE_USB='$(THINGINO_UBOOT_NETCONSOLE_USB)' sh -c 'if [ "$$THINGINO_UBOOT_NETCONSOLE" = "y" ]; then if [ "$$THINGINO_UBOOT_NETCONSOLE_USB" = "y" ]; then grep -q "^preboot=" $(THINGINO_UENV_TXT) || echo "preboot=usb start;setenv ethact \$${nc_ethact};setenv stdout serial,nc;setenv stderr serial,nc;setenv stdin serial,nc" >> $(THINGINO_UENV_TXT); grep -q "^nc_ethact=" $(THINGINO_UENV_TXT) || echo "nc_ethact=asx0" >> $(THINGINO_UENV_TXT); else grep -q "^preboot=" $(THINGINO_UENV_TXT) || echo "preboot=setenv stdout serial,nc;setenv stderr serial,nc;setenv stdin serial,nc" >> $(THINGINO_UENV_TXT); fi; grep -q "^bootdelay=" $(THINGINO_UENV_TXT) || echo "bootdelay=5" >> $(THINGINO_UENV_TXT); grep -q "^ipaddr=" $(THINGINO_UENV_TXT) || echo "ipaddr=192.168.1.10" >> $(THINGINO_UENV_TXT); fi'
 	@sed -i "s|\$$(UBOOT_FLASH_CONTROLLER)|$(THINGINO_UBOOT_FLASH_CONTROLLER)|g" $(THINGINO_UENV_TXT)
 	@sh -c '[ "$(SOC_FAMILY)" = "t40" -o "$(SOC_FAMILY)" = "t41" ] && sed -i "s|\$$(UBOOT_NMEM)|nmem=$$\{nmem\} |g" $(THINGINO_UENV_TXT) || sed -i "s|\$$(UBOOT_NMEM)||g" $(THINGINO_UENV_TXT)'
 	@sh -c '[ "$(SOC_FAMILY)" = "t20" -o "$(SOC_FAMILY)" = "t10" ] && sed -i "s|\$$(UBOOT_ISPMEM)| ispmem=$$\{ispmem\} |g" $(THINGINO_UENV_TXT) || sed -i "s|\$$(UBOOT_ISPMEM)| |g" $(THINGINO_UENV_TXT)'


### PR DESCRIPTION
NetConsole currently requires wired Ethernet. This extends it to boards that
have no on-chip Ethernet but do have a USB OTG data port, so they can be driven
over a USB-Ethernet dongle -- the majority of the camera configs, and the ones
most likely to lack a serial header.

## No U-Boot patch needed

The 2013.07 tree already has everything required, it just was not being used:

- `include/configs/isvp_common.h` builds `CONFIG_USB_DWC2`,
  `CONFIG_USB_HOST_ETHER` and the ASIX drivers on every board except
  T31LC/Xiaomi
- `board/ingenic/isvp_t31/usb_init.c:board_usb_init()` puts the OTG in host mode
- `usb start` (`common/cmd_usb.c`) calls `usb_host_eth_scan()`, which registers
  a dongle as an Ethernet device via `eth_register()`

So this is a build-integration change only: three files, no new patch, nothing
added to the bootloader binary beyond what the board already compiled.

## What changed

1. **`Config.in`** -- the opt-in symbol now depends on wired Ethernet **or** a
   USB OTG port (`BR2_PACKAGE_THINGINO_KOPT_DWC2_OTG`), so USB-only cameras can
   select it. Still `default n`, still gated to 2013.07.

2. **`thingino-uboot.mk`** -- boards with no `BR2_ETHERNET` but with OTG are
   marked `THINGINO_UBOOT_NETCONSOLE_USB` and get a USB-flavoured preboot:

   ```
   preboot=usb start;setenv ethact ${nc_ethact};setenv stdout serial,nc;...
   nc_ethact=asx0
   ```

   `usb start` enumerates the dongle; `setenv ethact` selects it, which is
   required because `board_eth_init()` registers the on-chip MAC as device 0 on
   every board -- including boards with no PHY -- and NetConsole would otherwise
   talk to that dead interface. `nc_ethact` is a separate variable so a user can
   retarget it at runtime (`fw_setenv nc_ethact axg0` for an AX88179) without
   rewriting the whole preboot.

3. **`docs/netconsole.md`** -- a "USB-Ethernet boards" section.

Wired boards are unchanged: with `BR2_ETHERNET` set,
`THINGINO_UBOOT_NETCONSOLE_USB` stays unset and the existing wired preboot is
injected exactly as before. Confirmed by rebuilding a wired camera and diffing
the generated `uenv.txt`.

## Enabling it on a camera

One line in the camera defconfig:

```
BR2_PACKAGE_THINGINO_UBOOT_NETCONSOLE=y
```

The transport is chosen automatically from the board's existing flags. Then
flash a full image (the environment has to carry the new `preboot`), plug in a
dongle **with a live cable**, and run `tools/netconsole 255.255.255.255 6666`.

## Testing

Verified end to end on a **Wyze Cam v3**
(`wyze_cam3_t31x_gc2053_rtl8189ftv`: T31X, WiFi + OTG, no wired Ethernet, no
serial header) with an **ASIX AX88772C**:

- Ctrl-C over UDP interrupts autoboot into an interactive prompt; commands
  execute with output returning over UDP
- `printenv ethact` reports `asx0` -- the dongle, not the on-chip MAC
- Both broadcast and unicast input work

Because `usb start` runs inside preboot, enumeration and link-up complete
*before* the countdown starts, so `bootdelay` needs no extra margin for USB.
Across 18 reboots the prompt was caught on every attempt at `bootdelay` 2, 3 and
4, and 5 of 6 at 1. **The injected default stays at 5**, which also covers a
cold power-up -- those runs were warm reboots, so I did not want to ship a lower
value on warm-only evidence.

Wired NetConsole was separately re-verified on a `vanhua_fjz_t31x_gc4653_eth`
after these changes.