### PR TITLE
package/timps: reapply motors joystick UI over the stock CGI transport

### DIFF
--- a/package/timps/files/www/motors-ui/config-motors.html
+++ b/package/timps/files/www/motors-ui/config-motors.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Pan/Tilt Motors</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+</head>
+
+<body id="page-config-motors">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container" style="min-height:80vh">
+    <div data-app-controls></div>
+
+    <section>
+      <form id="motors-form" class="needs-validation" novalidate autocomplete="off">
+
+        <div class="card mb-3">
+          <div class="card-header">
+            <h2 class="card-title">Pan/Tilt Motors</h2>
+            <small>Match the driver sequence A → B → C → D for both axes. Requires reboot after changes.</small>
+            <span id="motors-type-badge"></span>
+            <span id="motors-version-badge"></span>
+            <button type="button" class="btn btn-outline-secondary" id="motors-reload" title="Reload values from camera">
+              <i class="bi bi-arrow-clockwise"></i> Reload
+            </button>
+          </div><!-- .card-header -->
+          <div class="card-body">
+            <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mb-3">
+              <div class="col">
+                <h4>Pan motor GPIO</h4>
+                <small>Driver pins for horizontal motion</small>
+
+                <div class="row row-cols-2 row-cols-sm-4 g-1">
+                  <p class="col"><label for="gpio_pan_1">GPIO 1</label>
+                    <input type="number" class="form-control" id="gpio_pan_1" name="gpio_pan_1" min="0" placeholder="e.g. 55"></p>
+                  <p class="col"><label for="gpio_pan_2">GPIO 2</label>
+                    <input type="number" class="form-control" id="gpio_pan_2" name="gpio_pan_2" min="0" placeholder="e.g. 56"></p>
+                  <p class="col"><label for="gpio_pan_3">GPIO 3</label>
+                    <input type="number" class="form-control" id="gpio_pan_3" name="gpio_pan_3" min="0" placeholder="e.g. 57"></p>
+                  <p class="col"><label for="gpio_pan_4">GPIO 4</label>
+                    <input type="number" class="form-control" id="gpio_pan_4" name="gpio_pan_4" min="0" placeholder="e.g. 58"></p>
+                </div><!-- .row -->
+                <button type="button" class="btn btn-outline-secondary flip_motor mt-2" data-direction="pan" title="Reverse pin order">
+                  <i class="bi bi-arrow-left-right"></i> Flip
+                </button>
+
+                <p>
+                  <label for="steps_pan">Max steps</label>
+                  <input type="number" class="form-control" id="steps_pan" name="steps_pan" min="1" placeholder="1024">
+                </p>
+                <p>
+                  <label for="speed_pan">Speed</label>
+                  <input type="number" class="form-control" id="speed_pan" name="speed_pan" min="1" placeholder="1200">
+                </p>
+
+              </div><!-- .col -->
+              <div class="col">
+
+                <h4>Tilt motor GPIO</h4>
+                <small>Driver pins for vertical motion</small>
+
+                <div class="row row-cols-2 row-cols-sm-4 g-1">
+                  <p class="col">
+                    <label for="gpio_tilt_1">GPIO 1</label>
+                    <input type="number" class="form-control" id="gpio_tilt_1" name="gpio_tilt_1" min="0" placeholder="e.g. 59">
+                  </p>
+                  <p class="col">
+                    <label for="gpio_tilt_2">GPIO 2</label>
+                    <input type="number" class="form-control" id="gpio_tilt_2" name="gpio_tilt_2" min="0" placeholder="e.g. 60">
+                  </p>
+                  <p class="col">
+                    <label for="gpio_tilt_3">GPIO 3</label>
+                    <input type="number" class="form-control" id="gpio_tilt_3" name="gpio_tilt_3" min="0" placeholder="e.g. 61">
+                  </p>
+                  <p class="col">
+                    <label for="gpio_tilt_4">GPIO 4</label>
+                    <input type="number" class="form-control" id="gpio_tilt_4" name="gpio_tilt_4" min="0" placeholder="e.g. 62">
+                  </p>
+                </div>
+                <button type="button" class="btn btn-outline-secondary flip_motor mt-2" data-direction="tilt" title="Reverse pin order">
+                  <i class="bi bi-arrow-left-right"></i> Flip
+                </button>
+                <p>
+                  <label for="steps_tilt">Max steps</label>
+                  <input type="number" class="form-control" id="steps_tilt" name="steps_tilt" min="1" placeholder="512">
+                </p>
+                <p>
+                  <label for="speed_tilt">Speed</label>
+                  <input type="number" class="form-control" id="speed_tilt" name="speed_tilt" min="1" placeholder="800">
+                </p>
+              </div><!-- .col -->
+              <div class="col">
+                <h4>Behavior</h4>
+                <small>Startup pose and homing logic.</small>
+
+                <p>
+                  <label for="motion_driver">Motion driver</label>
+                  <select class="form-select" id="motion_driver" name="motion_driver">
+                    <option value="legacy">Legacy (kernel-native)</option>
+                    <option value="profiled">Profiled (accel/decel ramping)</option>
+                  </select>
+                </p>
+
+                <p id="motion-driver-help" class="alert alert-secondary small mb-2">
+                  Legacy mode uses the stock kernel movement path. Profiled mode enables acceleration/deceleration ramping in motors-daemon.
+                </p>
+
+                <p>
+                  <label for="preview_control_mode">Preview PTZ controls</label>
+                  <select class="form-select" id="preview_control_mode" name="preview_control_mode">
+                    <option value="step">Step move (click / double-click)</option>
+                    <option value="continuous">Continuous move (press and hold)</option>
+                    <option value="joystick">Analog joystick (drag to steer, further = faster)</option>
+                  </select>
+                  <small class="text-secondary">Applies to motor controls in the preview overlay.</small>
+                </p>
+
+                <div id="joystick-sensitivity-field">
+                  <label for="joystick_sensitivity">Joystick centre sensitivity
+                    <span id="joystick_sensitivity-value" class="text-secondary"></span></label>
+                  <input type="range" class="form-range" id="joystick_sensitivity" name="joystick_sensitivity"
+                    min="0.05" max="4" step="0.05" value="2">
+                  <small class="text-secondary">Below 1.00 reacts faster to small movements near the stick's centre and reaches full speed sooner. Above 1.00 does the opposite - the centre is less sensitive, for finer close-up framing. 1.00 is a straight linear response. Takes effect immediately, no reboot.</small>
+                </div>
+
+                <div id="motion-accel-fields" class="d-flex gap-2">
+                  <p>
+                    <label for="accel_pan">Pan acceleration</label>
+                    <input type="number" class="form-control" id="accel_pan" name="accel_pan" min="0" placeholder="0">
+                  </p>
+                  <p>
+                    <label for="accel_tilt">Tilt acceleration</label>
+                    <input type="number" class="form-control" id="accel_tilt" name="accel_tilt" min="0" placeholder="0">
+                  </p>
+                </div>
+
+                <p class="alert alert-info small">During boot, the camera rotates to its minimum limits and zeroes both axes.</p>
+                <p class="form-switch">
+                  <input type="checkbox" class="form-check-input" id="homing" name="homing" value="true" data-help="Disable only when a fixed pose is required">
+                  <label for="homing">Perform homing on boot</label>
+                </p>
+                <div class="d-flex gap-2">
+                  <p>
+                    <label for="pos_0_x">Initial position X</label>
+                    <input type="number" class="form-control" id="pos_0_x" name="pos_0_x" placeholder="0">
+                  </p>
+                  <p>
+                    <label for="pos_0_y">Initial position Y</label>
+                    <input type="number" class="form-control" id="pos_0_y" name="pos_0_y" placeholder="0">
+                  </p>
+                </div>
+                <p class="alert alert-info small">The initial position is the first PTZ preset. Reorder presets below to change it.</p>
+                <a href="#" class="read-motors mb-3 d-block" title="Use current pose">Pick up the recent position</a>
+              </div><!-- .col -->
+            </div><!-- .row -->
+          </div><!-- .card-body -->
+        </div><!-- .card -->
+
+        <div class="card mb-3">
+          <div class="card-header">
+            <h2 class="card-title">PTZ Presets</h2>
+            <small>Save the current camera position and recall it with one click.</small>
+          </div>
+          <div class="card-body">
+            <div class="d-flex gap-2 mb-3">
+              <input type="text" class="form-control" id="ptz-preset-name" placeholder="Preset description, e.g. Front door" maxlength="64">
+              <button type="button" class="btn btn-outline-primary text-nowrap" id="ptz-preset-save" title="Save current position as a preset">
+                <i class="bi bi-plus-circle me-1"></i>Save position
+              </button>
+            </div>
+            <ul id="ptz-presets-list" class="list-group"></ul>
+            <small id="ptz-presets-empty" class="text-secondary d-block mt-2">No presets yet. Move the camera (preview overlay) and save a position above.</small>
+          </div>
+        </div>
+
+        <button type="submit" id="motors_submit" class="btn btn-primary"><i class="bi bi-save me-1"></i> Save changes</button>
+      </form>
+    </section>
+  </div>
+</main>
+
+<footer data-app-footer></footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="/a/config-motors.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/motors-ui/config-motors.js
+++ b/package/timps/files/www/motors-ui/config-motors.js
@@ -1,0 +1,670 @@
+(function () {
+  "use strict";
+
+  const motorsConfigEndpoint = "/x/json-motors-config.cgi";
+  const alertContainer = $("#motors-alerts");
+  const contentWrap = $("#motors-content");
+  const form = $("#motors-form");
+  const reloadButton = $("#motors-reload");
+  const submitButton = form
+    ? form.querySelector('button[type="submit"]')
+    : null;
+  const submitSpinner = submitButton
+    ? submitButton.querySelector(".spinner-border")
+    : null;
+  const submitLabel = submitButton
+    ? submitButton.querySelector(".label")
+    : null;
+  const submitDefaultText = submitLabel
+    ? submitLabel.textContent
+    : "Save motors";
+  const typeBadge = $("#motors-type-badge");
+  const versionBadge = $("#motors-version-badge");
+  let initialLoadComplete = false;
+  let motorIsSpi = false;
+
+  function normalizeMotionDriver(value) {
+    return value === "profiled" ? "profiled" : "legacy";
+  }
+
+  function escapeHtml(value) {
+    return String(value).replace(/[&<>"']/g, (ch) => ({
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;",
+    })[ch]);
+  }
+
+  function normalizePreviewControlMode(value) {
+    return value === "continuous" || value === "joystick" ? value : "step";
+  }
+
+  function updateMotionDriverInputs() {
+    const motionDriverEl = $("#motion_driver");
+    const accelWrap = $("#motion-accel-fields");
+    const help = $("#motion-driver-help");
+    const accelPan = $("#accel_pan");
+    const accelTilt = $("#accel_tilt");
+    if (!motionDriverEl) return;
+
+    const mode = normalizeMotionDriver(motionDriverEl.value);
+    const profiled = mode === "profiled";
+
+    if (accelWrap) {
+      accelWrap.classList.toggle("opacity-50", !profiled);
+    }
+    if (accelPan) {
+      accelPan.disabled = !profiled;
+      if (!profiled) accelPan.value = "0";
+    }
+    if (accelTilt) {
+      accelTilt.disabled = !profiled;
+      if (!profiled) accelTilt.value = "0";
+    }
+    if (help) {
+      if (profiled) {
+        help.className = "alert alert-info small mb-2";
+        help.textContent =
+          "Profiled mode active: acceleration fields control ramping in motors-daemon.";
+      } else {
+        help.className = "alert alert-secondary small mb-2";
+        help.textContent =
+          "Legacy mode active: acceleration values are ignored and saved as 0.";
+      }
+    }
+  }
+
+  function updateJoystickSensitivityInputs() {
+    const modeEl = $("#preview_control_mode");
+    const wrap = $("#joystick-sensitivity-field");
+    const slider = $("#joystick_sensitivity");
+    const valueLabel = $("#joystick_sensitivity-value");
+    if (!modeEl || !wrap) return;
+
+    const isJoystick = normalizePreviewControlMode(modeEl.value) === "joystick";
+    wrap.classList.toggle("opacity-50", !isJoystick);
+    if (slider) slider.disabled = !isJoystick;
+    if (valueLabel && slider) valueLabel.textContent = slider.value;
+  }
+
+  function showAlert(variant, message, timeout = 6000) {
+    if (!message) return;
+
+    // Use global alert system from main.js
+    if (window.showAlert && typeof window.showAlert === "function") {
+      window.showAlert(variant, message, timeout);
+      return;
+    }
+
+    // Fallback to local alert container if it exists
+    if (!alertContainer) return;
+    const alert = document.createElement("div");
+    alert.className = `alert alert-${variant || "secondary"} alert-dismissible fade show`;
+    alert.setAttribute("role", "alert");
+    alert.innerHTML = message;
+    const dismissBtn = document.createElement("button");
+    dismissBtn.type = "button";
+    dismissBtn.className = "btn-close";
+    dismissBtn.setAttribute("aria-label", "Close");
+    dismissBtn.addEventListener("click", () => alert.remove());
+    alert.appendChild(dismissBtn);
+    alertContainer.appendChild(alert);
+    if (timeout > 0) {
+      setTimeout(() => {
+        alert.classList.remove("show");
+        setTimeout(() => alert.remove(), 200);
+      }, timeout);
+    }
+  }
+
+  function parseMotorPins(raw) {
+    if (typeof raw !== "string") return [];
+    return raw.trim().split(/\s+/).filter(Boolean);
+  }
+
+  function setMotorPins(prefix, pins) {
+    if (!Array.isArray(pins)) return;
+    for (let i = 1; i <= 4; i += 1) {
+      const input = $(`#gpio_${prefix}_${i}`);
+      if (input) input.value = pins[i - 1] || "";
+    }
+  }
+
+  function setMotorFieldValue(id, value) {
+    const input = $(`#${id}`);
+    if (!input) return;
+    input.value = value === undefined || value === null ? "" : value;
+  }
+
+  function setMotorPinInputsEnabled(enabled) {
+    const disablePins = !enabled;
+    $$('#motors-form input[id^="gpio_"]').forEach((input) => {
+      input.disabled = disablePins;
+    });
+    $$(".flip_motor").forEach((btn) => {
+      btn.disabled = disablePins;
+      btn.classList.toggle("disabled", disablePins);
+    });
+  }
+
+  function updateBadge(isSpi) {
+    if (!typeBadge) return;
+    if (isSpi) {
+      typeBadge.textContent = "SPI motor board";
+      typeBadge.className = "badge text-bg-info";
+      typeBadge.title = "Pins are controlled over SPI, GPIO inputs disabled";
+    } else {
+      typeBadge.textContent = "Discrete GPIO driver";
+      typeBadge.className = "badge text-bg-dark";
+      typeBadge.title = "Pins driven directly via GPIO";
+    }
+  }
+
+  function updateHomingInputs() {
+    const homing = $("#homing");
+    const x = $("#pos_0_x");
+    const y = $("#pos_0_y");
+    if (!homing) return;
+    const disabled = !homing.checked;
+    if (x) x.disabled = disabled;
+    if (y) y.disabled = disabled;
+  }
+
+  function applyMotorsConfig(config = {}) {
+    if (typeof config !== "object" || !config) return;
+    setMotorPins("pan", parseMotorPins(config.gpio_pan));
+    setMotorPins("tilt", parseMotorPins(config.gpio_tilt));
+    setMotorFieldValue("steps_pan", config.steps_pan);
+    setMotorFieldValue("steps_tilt", config.steps_tilt);
+    setMotorFieldValue("speed_pan", config.speed_pan);
+    setMotorFieldValue("speed_tilt", config.speed_tilt);
+    setMotorFieldValue("accel_pan", config.accel_pan);
+    setMotorFieldValue("accel_tilt", config.accel_tilt);
+    const motionDriverEl = $("#motion_driver");
+    if (motionDriverEl) {
+      const mode = normalizeMotionDriver(config.motion_driver);
+      motionDriverEl.value = mode;
+    }
+    const previewControlModeEl = $("#preview_control_mode");
+    if (previewControlModeEl) {
+      previewControlModeEl.value = normalizePreviewControlMode(
+        config.preview_control_mode,
+      );
+    }
+    const joystickSensitivityEl = $("#joystick_sensitivity");
+    if (joystickSensitivityEl) {
+      const parsed = parseFloat(config.joystick_sensitivity);
+      joystickSensitivityEl.value =
+        Number.isFinite(parsed) && parsed >= 0.05 && parsed <= 4
+          ? parsed
+          : 2;
+    }
+    updateJoystickSensitivityInputs();
+    const homingEl = $("#homing");
+    if (homingEl) {
+      homingEl.checked = config.homing === true || config.homing === "true";
+    }
+    const firstPreset =
+      Array.isArray(config.presets) && config.presets.length
+        ? config.presets[0]
+        : null;
+    setMotorFieldValue("pos_0_x", firstPreset ? firstPreset.x : "");
+    setMotorFieldValue("pos_0_y", firstPreset ? firstPreset.y : "");
+    updateHomingInputs();
+    motorIsSpi = config.is_spi === true || config.is_spi === "true";
+    setMotorPinInputsEnabled(!motorIsSpi);
+    updateBadge(motorIsSpi);
+    updateMotionDriverInputs();
+  }
+
+  async function loadMotorsConfig(options = {}) {
+    const { silent = false } = options;
+    if (!silent) showBusy("Loading motor settings...");
+    try {
+      const response = await fetch(motorsConfigEndpoint, {
+        headers: { Accept: "application/json" },
+        cache: "no-store",
+      });
+      let payload = null;
+      try {
+        payload = await response.json();
+      } catch (parseErr) {
+        console.error("JSON parse error:", parseErr);
+        payload = null;
+      }
+      if (!response.ok || !payload || payload.result !== "success") {
+        const message = payload && payload.error && payload.error.message;
+        throw new Error(message || `HTTP ${response.status}`);
+      }
+      try {
+        applyMotorsConfig(payload.message || {});
+      } catch (applyErr) {
+        console.error("applyMotorsConfig error:", applyErr);
+        throw applyErr;
+      }
+      if (!initialLoadComplete) {
+        if (contentWrap) contentWrap.classList.remove("d-none");
+        initialLoadComplete = true;
+      }
+      return true;
+    } catch (err) {
+      console.error("Failed to load motors config", err);
+      showAlert(
+        "danger",
+        `Unable to load motor settings: ${err.message || err}`,
+      );
+      return false;
+    } finally {
+      if (!silent) hideBusy();
+    }
+  }
+
+  async function saveMotorsConfig() {
+    const form = $("#motors-form");
+    if (!form) return;
+
+    // Client-side validation to prevent 412 errors
+    const requiredPanFields = [
+      "gpio_pan_1",
+      "gpio_pan_2",
+      "gpio_pan_3",
+      "gpio_pan_4",
+    ];
+    const requiredTiltFields = [
+      "gpio_tilt_1",
+      "gpio_tilt_2",
+      "gpio_tilt_3",
+      "gpio_tilt_4",
+    ];
+
+    const formData = new FormData(form);
+    const errors = [];
+
+    // Check GPIO fields (skip for SPI motor boards where pins are irrelevant)
+    if (!motorIsSpi) {
+      for (const field of requiredPanFields) {
+        const value = formData.get(field);
+        if (!value || value.trim() === "") {
+          errors.push(
+            `${field.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase())} is required`,
+          );
+        }
+      }
+
+      // Detect whether the tilt axis is present: all GPIOs set to -1
+      // means the hardware has no tilt motor and tilt validation should
+      // be skipped entirely.
+      const tiltGpioValues = requiredTiltFields.map((f) =>
+        (formData.get(f) || "").trim(),
+      );
+      const tiltDisabled = tiltGpioValues.every((v) => v === "-1");
+
+      if (!tiltDisabled) {
+        for (const field of requiredTiltFields) {
+          const value = formData.get(field);
+          if (!value || value.trim() === "") {
+            errors.push(
+              `${field.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase())} is required`,
+            );
+          }
+        }
+      }
+    }
+
+    // Check steps fields
+    const stepsPan = formData.get("steps_pan");
+    const stepsTilt = formData.get("steps_tilt");
+    if (!stepsPan || parseInt(stepsPan) <= 0) {
+      errors.push("Pan max steps must be a positive number");
+    }
+
+    // Skip tilt steps validation when the tilt axis is disabled (all GPIOs -1).
+    // Pan-only cameras legitimately have steps_tilt = 0.
+    const tiltGpioVals = requiredTiltFields.map((f) =>
+      (formData.get(f) || "").trim(),
+    );
+    const tiltAxisMissing = tiltGpioVals.every((v) => v === "-1");
+    if (!tiltAxisMissing && (!stepsTilt || parseInt(stepsTilt) <= 0)) {
+      errors.push("Tilt max steps must be a positive number");
+    }
+
+    const accelPan = formData.get("accel_pan");
+    const accelTilt = formData.get("accel_tilt");
+    if (accelPan !== null && accelPan !== "" && parseInt(accelPan) < 0) {
+      errors.push("Pan acceleration must be zero or positive");
+    }
+    if (accelTilt !== null && accelTilt !== "" && parseInt(accelTilt) < 0) {
+      errors.push("Tilt acceleration must be zero or positive");
+    }
+
+    const motionDriver = formData.get("motion_driver");
+    if (motionDriver !== "legacy" && motionDriver !== "profiled") {
+      errors.push("Motion driver must be legacy or profiled");
+    }
+
+    const previewControlMode = formData.get("preview_control_mode");
+    if (normalizePreviewControlMode(previewControlMode) !== previewControlMode) {
+      errors.push("Preview PTZ controls must be step, continuous or joystick");
+    }
+
+    if (motionDriver !== "profiled") {
+      formData.set("accel_pan", "0");
+      formData.set("accel_tilt", "0");
+    }
+
+    // #joystick_sensitivity is disabled outside joystick mode (see
+    // updateJoystickSensitivityInputs()), and FormData silently drops
+    // disabled controls - without this, saving the form in any other mode
+    // would submit no value at all and the CGI's own fallback would reset
+    // whatever sensitivity was previously configured back to its default.
+    // The input's own .value still holds the loaded config value even
+    // while disabled, so re-adding it here just carries it through.
+    const joystickSensitivityEl = $("#joystick_sensitivity");
+    if (joystickSensitivityEl) {
+      formData.set("joystick_sensitivity", joystickSensitivityEl.value);
+    }
+
+    if (errors.length > 0) {
+      showAlert("danger", "Please fix the following errors:", 0);
+      errors.forEach((err) => showAlert("warning", err, 0));
+      return;
+    }
+
+    showBusy("Saving motor settings...");
+    try {
+      const homingEl = $("#homing");
+      const params = new URLSearchParams();
+      params.append("form", "motors");
+      params.append("homing", homingEl && homingEl.checked ? "true" : "false");
+      formData.forEach((value, key) => {
+        if (key !== "form" && key !== "homing") {
+          params.append(key, value == null ? "" : value);
+        }
+      });
+      const response = await fetch(motorsConfigEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: params.toString(),
+        cache: "no-store",
+      });
+      let payload = null;
+      try {
+        payload = await response.json();
+      } catch (_) {
+        payload = null;
+      }
+      if (!response.ok || !payload || payload.result !== "success") {
+        const message = payload && payload.error && payload.error.message;
+        throw new Error(message || `HTTP ${response.status}`);
+      }
+      applyMotorsConfig(payload.message || {});
+      showAlert("success", "Motor settings updated.");
+    } catch (err) {
+      console.error("Failed to save motors config", err);
+      showAlert(
+        "danger",
+        `Failed to save motor settings: ${err.message || err}`,
+      );
+    } finally {
+      hideBusy();
+    }
+  }
+
+  async function readMotorsPosition() {
+    try {
+      const res = await fetch(
+        "/x/json-motor.cgi?" + new URLSearchParams({ d: "j" }).toString(),
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const { message } = await res.json();
+      if (message) {
+        if ($("#pos_0_x")) $("#pos_0_x").value = message.xpos;
+        if ($("#pos_0_y")) $("#pos_0_y").value = message.ypos;
+      }
+      if ($("#homing")) $("#homing").checked = true;
+      updateHomingInputs();
+      showAlert("success", "Captured current position as new reference.", 4000);
+    } catch (err) {
+      console.error("Failed to read motors position", err);
+      showAlert(
+        "danger",
+        `Unable to read current position: ${err.message || err}`,
+      );
+    }
+  }
+
+  if (form) {
+    form.addEventListener("submit", (ev) => {
+      ev.preventDefault();
+      saveMotorsConfig();
+    });
+  }
+
+  if (reloadButton) {
+    reloadButton.addEventListener("click", async () => {
+      try {
+        reloadButton.disabled = true;
+        const success = await loadMotorsConfig({ silent: true });
+        if (success) {
+          showAlert("info", "Motor settings reloaded from camera.", 3000);
+        }
+      } catch (err) {
+        showAlert("danger", "Failed to reload motors settings.");
+      } finally {
+        reloadButton.disabled = false;
+      }
+    });
+  }
+
+  $$(".flip_motor").forEach((el) => {
+    el.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      const dir = el.dataset.direction;
+      if (!dir) return;
+      const base = "#gpio_" + dir + "_";
+      const pins = [1, 2, 3, 4].map((i) => $(base + i)?.value).reverse();
+      [1, 2, 3, 4].forEach((i, idx) => {
+        const field = $(base + i);
+        if (field && pins[idx] !== undefined) field.value = pins[idx];
+      });
+    });
+  });
+
+  $$(".read-motors").forEach((el) => {
+    el.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      readMotorsPosition();
+    });
+  });
+
+  const homingSwitch = $("#homing");
+  if (homingSwitch) {
+    homingSwitch.addEventListener("change", updateHomingInputs);
+    updateHomingInputs();
+  }
+
+  const motionDriverSelect = $("#motion_driver");
+  if (motionDriverSelect) {
+    motionDriverSelect.addEventListener("change", updateMotionDriverInputs);
+  }
+
+  const previewControlModeSelect = $("#preview_control_mode");
+  if (previewControlModeSelect) {
+    previewControlModeSelect.addEventListener(
+      "change",
+      updateJoystickSensitivityInputs,
+    );
+  }
+  const joystickSensitivitySlider = $("#joystick_sensitivity");
+  if (joystickSensitivitySlider) {
+    // "input", not "change": track the thumb while dragging.
+    joystickSensitivitySlider.addEventListener(
+      "input",
+      updateJoystickSensitivityInputs,
+    );
+  }
+
+  // ------------------------------------------------------------------
+  // PTZ presets
+  // ------------------------------------------------------------------
+  const presetNameInput = $("#ptz-preset-name");
+  const presetSaveButton = $("#ptz-preset-save");
+  const presetsList = $("#ptz-presets-list");
+  const presetsEmpty = $("#ptz-presets-empty");
+
+  function renderPresets(presets) {
+    if (!presetsList) return;
+    presetsList.innerHTML = "";
+    if (presetsEmpty) {
+      presetsEmpty.classList.toggle("d-none", presets.length > 0);
+    }
+    presets.forEach((p) => {
+      const li = document.createElement("li");
+      li.className = "list-group-item d-flex align-items-center gap-2";
+
+      const nameInput = document.createElement("input");
+      nameInput.type = "text";
+      nameInput.className = "form-control form-control-sm flex-grow-1 preset-name";
+      nameInput.value = p.description || "";
+      nameInput.maxLength = 64;
+      nameInput.placeholder = `Preset ${p.id}`;
+
+      const xInput = document.createElement("input");
+      xInput.type = "number";
+      xInput.className = "form-control form-control-sm preset-x";
+      xInput.style.width = "4.5rem";
+      xInput.value = p.x;
+      xInput.min = "0";
+
+      const yInput = document.createElement("input");
+      yInput.type = "number";
+      yInput.className = "form-control form-control-sm preset-y";
+      yInput.style.width = "4.5rem";
+      yInput.value = p.y;
+      yInput.min = "0";
+
+      const saveBtn = document.createElement("button");
+      saveBtn.type = "button";
+      saveBtn.className = "btn btn-sm btn-outline-success";
+      saveBtn.title = "Save description and coordinates";
+      saveBtn.innerHTML = '<i class="bi bi-check-lg"></i>';
+      saveBtn.addEventListener("click", () => {
+        const description = nameInput.value.trim();
+        if (!description) {
+          showAlert("warning", "Enter a description for the preset.", 3000);
+          return;
+        }
+        const x = xInput.value.trim();
+        const y = yInput.value.trim();
+        if (!/^\d+$/.test(x) || !/^\d+$/.test(y)) {
+          showAlert("warning", "Coordinates must be whole numbers.", 3000);
+          return;
+        }
+        presetAction("pu", { n: p.id, description, x, y });
+      });
+
+      const moveBtn = document.createElement("button");
+      moveBtn.type = "button";
+      moveBtn.className = "btn btn-sm btn-outline-primary";
+      moveBtn.title = "Move to this preset";
+      moveBtn.innerHTML = '<i class="bi bi-play-fill"></i>';
+      moveBtn.addEventListener("click", () => presetAction("pr", { n: p.id }));
+
+      const delBtn = document.createElement("button");
+      delBtn.type = "button";
+      delBtn.className = "btn btn-sm btn-outline-danger";
+      delBtn.title = "Delete preset";
+      delBtn.innerHTML = '<i class="bi bi-trash"></i>';
+      delBtn.addEventListener("click", () => presetAction("pd", { n: p.id }));
+
+      li.append(nameInput, xInput, yInput, saveBtn, moveBtn, delBtn);
+      presetsList.appendChild(li);
+    });
+  }
+
+  async function loadPresets() {
+    try {
+      const res = await fetch(
+        "/x/json-motor.cgi?" + new URLSearchParams({ d: "pg" }).toString(),
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const payload = await res.json().catch(() => null);
+      if (!payload || payload.result !== "success") {
+        throw new Error(
+          (payload && payload.error && payload.error.message) ||
+            "Failed to load presets",
+        );
+      }
+      renderPresets(
+        payload.message && Array.isArray(payload.message.presets)
+          ? payload.message.presets
+          : [],
+      );
+    } catch (err) {
+      console.error("Failed to load PTZ presets", err);
+    }
+  }
+
+  // The build version rides along in the same `motors -j` status the CGI
+  // already proxies, so no extra endpoint. Stays blank on an older daemon
+  // build that has no "version" field, or when the daemon is down.
+  async function loadMotorsVersion() {
+    if (!versionBadge) return;
+    try {
+      const res = await fetch(
+        "/x/json-motor.cgi?" + new URLSearchParams({ d: "j" }).toString(),
+      );
+      const payload = await res.json();
+      const version = payload && payload.message && payload.message.version;
+      if (!version) return;
+      versionBadge.textContent = "motors " + version;
+      versionBadge.className = "badge text-bg-secondary";
+      versionBadge.title = "motors build version";
+    } catch (err) {
+      console.error("Failed to read motors version", err);
+    }
+  }
+
+  async function presetAction(action, extra) {
+    try {
+      const params = new URLSearchParams({ d: action });
+      Object.entries(extra || {}).forEach(([k, v]) => params.set(k, v));
+      const res = await fetch("/x/json-motor.cgi?" + params.toString());
+      const payload = await res.json().catch(() => null);
+      if (!res.ok || !payload || payload.result !== "success") {
+        const message = payload && payload.error && payload.error.message;
+        throw new Error(message || `HTTP ${res.status}`);
+      }
+      const status =
+        (payload.message && payload.message.status) || "OK";
+      showAlert("success", status, 3000);
+      await loadPresets();
+    } catch (err) {
+      console.error(`Preset action ${action} failed`, err);
+      showAlert(
+        "danger",
+        `Preset action failed: ${err.message || err}`,
+      );
+    }
+  }
+
+  if (presetSaveButton) {
+    presetSaveButton.addEventListener("click", async () => {
+      const description = (presetNameInput ? presetNameInput.value : "").trim();
+      if (!description) {
+        showAlert("warning", "Enter a description for the preset first.", 3000);
+        return;
+      }
+      await presetAction("ps", { description });
+      if (presetNameInput) presetNameInput.value = "";
+    });
+  }
+
+  loadPresets();
+
+  loadMotorsVersion();
+
+  loadMotorsConfig();
+})();

--- a/package/timps/files/www/motors-ui/json-motor-params.cgi
+++ b/package/timps/files/www/motors-ui/json-motor-params.cgi
@@ -1,0 +1,90 @@
+#!/bin/sh
+# shellcheck disable=SC1091,SC2086,SC2154,SC3043
+
+# Check authentication
+. /var/www/x/auth.sh
+require_auth
+
+MOTORS_CONFIG="/etc/thingino.json"
+
+# Get motor config values
+steps_pan_val=$(jct "$MOTORS_CONFIG" get motors.steps_pan 2>/dev/null)
+[ -z "$steps_pan_val" ] && steps_pan_val=0
+steps_tilt_val=$(jct "$MOTORS_CONFIG" get motors.steps_tilt 2>/dev/null)
+[ -z "$steps_tilt_val" ] && steps_tilt_val=0
+speed_pan_val=$(jct "$MOTORS_CONFIG" get motors.speed_pan 2>/dev/null)
+[ -z "$speed_pan_val" ] && speed_pan_val=0
+speed_tilt_val=$(jct "$MOTORS_CONFIG" get motors.speed_tilt 2>/dev/null)
+[ -z "$speed_tilt_val" ] && speed_tilt_val=0
+accel_pan_val=$(jct "$MOTORS_CONFIG" get motors.accel_pan 2>/dev/null)
+[ -z "$accel_pan_val" ] && accel_pan_val=0
+accel_tilt_val=$(jct "$MOTORS_CONFIG" get motors.accel_tilt 2>/dev/null)
+[ -z "$accel_tilt_val" ] && accel_tilt_val=0
+motion_driver_val=$(jct "$MOTORS_CONFIG" get motors.motion_driver 2>/dev/null)
+[ -z "$motion_driver_val" ] && motion_driver_val=legacy
+preview_control_mode_val=$(jct "$MOTORS_CONFIG" get motors.preview_control_mode 2>/dev/null)
+[ -z "$preview_control_mode_val" ] && preview_control_mode_val=step
+pos_0_x_val=$(jct "$MOTORS_CONFIG" get motors.presets.0.x 2>/dev/null)
+[ -z "$pos_0_x_val" ] && pos_0_x_val=0
+pos_0_y_val=$(jct "$MOTORS_CONFIG" get motors.presets.0.y 2>/dev/null)
+[ -z "$pos_0_y_val" ] && pos_0_y_val=0
+
+read_post_data() {
+	if [ -n "$CONTENT_LENGTH" ] && [ "$CONTENT_LENGTH" -gt 0 ]; then
+		body=$(dd bs=1 count="$CONTENT_LENGTH" 2>/dev/null)
+		eval "$(printf '%s' "$body" | awk -F'&' '{
+      for (i=1; i<=NF; i++) {
+        split($i, kv, "=")
+        key = kv[1]
+        value = kv[2]
+        gsub(/\+/, " ", value)
+        gsub(/%([0-9A-Fa-f]{2})/, "\\x\\1", value)
+        printf "POST_%s=\"%s\"\n", key, value
+      }
+    }')"
+	fi
+}
+
+if [ "$REQUEST_METHOD" = "POST" ]; then
+	read_post_data
+
+	changed=0
+
+	case "$POST_preview_control_mode" in
+		step | continuous | joystick)
+			if [ "$POST_preview_control_mode" != "$preview_control_mode_val" ]; then
+				jct "$MOTORS_CONFIG" set motors.preview_control_mode "$POST_preview_control_mode" >/dev/null 2>&1
+				preview_control_mode_val=$POST_preview_control_mode
+				changed=1
+			fi
+			;;
+	esac
+
+	case "$POST_speed_pan" in
+		'' | *[!0-9]*) ;;
+		*)
+			if [ "$POST_speed_pan" != "$speed_pan_val" ]; then
+				jct "$MOTORS_CONFIG" set motors.speed_pan "$POST_speed_pan" >/dev/null 2>&1
+				speed_pan_val=$POST_speed_pan
+				changed=1
+			fi
+			;;
+	esac
+
+	case "$POST_speed_tilt" in
+		'' | *[!0-9]*) ;;
+		*)
+			if [ "$POST_speed_tilt" != "$speed_tilt_val" ]; then
+				jct "$MOTORS_CONFIG" set motors.speed_tilt "$POST_speed_tilt" >/dev/null 2>&1
+				speed_tilt_val=$POST_speed_tilt
+				changed=1
+			fi
+			;;
+	esac
+
+	[ "$changed" = 1 ] && motors -R >/dev/null 2>&1
+fi
+
+printf 'Status: 200 OK\r\nContent-Type: application/json\r\nCache-Control: no-store\r\nConnection: close\r\n\r\n'
+
+printf '{"steps_pan":%s,"steps_tilt":%s,"speed_pan":%s,"speed_tilt":%s,"accel_pan":%s,"accel_tilt":%s,"motion_driver":"%s","preview_control_mode":"%s","pos_0_x":%s,"pos_0_y":%s}' "$steps_pan_val" "$steps_tilt_val" "$speed_pan_val" "$speed_tilt_val" "$accel_pan_val" "$accel_tilt_val" "$motion_driver_val" "$preview_control_mode_val" "$pos_0_x_val" "$pos_0_y_val"

--- a/package/timps/files/www/motors-ui/json-motor.cgi
+++ b/package/timps/files/www/motors-ui/json-motor.cgi
@@ -1,0 +1,186 @@
+#!/bin/sh
+# shellcheck disable=SC1091,SC2046,SC2329,SC3043
+
+# Check authentication
+. /var/www/x/auth.sh
+require_auth
+
+http_200() {
+	printf 'Status: 200 OK\r\n'
+}
+
+http_400() {
+	printf 'Status: 400 Bad Request\r\n'
+}
+
+http_412() {
+	printf 'Status: 412 Precondition Failed\r\n'
+}
+
+json_header() {
+	printf 'Content-Type: application/json\r\n'
+	printf 'Pragma: no-cache\r\n'
+	printf 'Expires: %s\r\n' "$(TZ=GMT0 date +'%a, %d %b %Y %T %Z')"
+	printf 'Etag: "%s"\r\n' "$(cat /proc/sys/kernel/random/uuid)"
+	printf 'Connection: close\r\n'
+	printf '\r\n'
+}
+
+json_error() {
+	http_412
+	json_header
+	printf '{"error":{"code":412,"message":"%s"}}
+' "$1"
+	exit 0
+}
+
+json_ok() {
+	http_200
+	json_header
+	if [ "{" = "$(printf '%.1s' "$1")" ]; then
+		printf '{"code":200,"result":"success","message":%s}
+' "$1"
+	else
+		printf '{"code":200,"result":"success","message":"%s"}
+' "$1"
+	fi
+	exit 0
+}
+
+[ -n "$QUERY_STRING" ] && eval $(echo "$QUERY_STRING" | sed "s/&/;/g")
+
+# URL-decode string params (description, n); the rest are numeric/single char.
+urldecode() {
+	printf '%b' "$(echo "$1" | sed 's/+/ /g; s/%\([0-9A-Fa-f][0-9A-Fa-f]\)/\\x\1/g')"
+}
+[ -n "$description" ] && description=$(urldecode "$description")
+[ -n "$n" ] && n=$(urldecode "$n")
+[ -n "$order" ] && order=$(urldecode "$order")
+
+json_escape() {
+	printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+[ -z "$x" ] && x=0
+[ -z "$y" ] && y=0
+[ -z "$d" ] && d="g"
+
+# Motion commands answer with a bare acknowledgement.
+#
+# They used to fall through to a trailing emit_status that ran `motors -j` and
+# returned the position with every single move. That echo made sense when this
+# CGI was the only way to drive the motors and the page had no other source of
+# position - but it doubled the process cost of the hottest path in the whole
+# UI: a held arrow fired one of these every 90ms, and each one paid for
+# busybox-httpd, this shell, `motors`, and then a SECOND `motors` purely to
+# report a position that was already stale by the time it was read (the move
+# is asynchronous; the daemon has not finished it when the status is sampled).
+#
+# Live control now runs over motors-daemon's WebSocket where position arrives
+# as a server push, and the CGI path that remains is a fallback whose caller
+# (preview-motors.js) only ever console.log()s the echo. Callers that actually
+# want a position ask for one explicitly with d=j.
+motion_ok() {
+	json_ok "$1"
+}
+
+case "$d" in
+	g)
+		# Relative jog. Kept: this is the CGI fallback for the joystick when
+		# the WebSocket listener is off or unreachable, so it has to work.
+		motors -d g -x "$x" -y "$y" >/dev/null
+		motion_ok "moved"
+		;;
+	r)
+		# Homing / recalibration. Kept, and deliberately not moved to the
+		# WebSocket: it is a one-shot maintenance action, not a gesture, and
+		# it runs for tens of seconds - nothing about it benefits from a
+		# persistent socket.
+		motors -r >/dev/null
+		motion_ok "homing"
+		;;
+	h | x)
+		# Absolute move. Kept: used for centring and for the reposition that
+		# follows homing, and it is how ptz_presets-style jumps are issued
+		# from the page. Not a hold gesture, so the WebSocket buys it nothing.
+		motors -d h -x "$x" -y "$y" >/dev/null
+		motion_ok "moved"
+		;;
+	s)
+		# Stop. Kept, and now more load-bearing than before: it is what the
+		# page falls back to when a socket dies mid-hold with the camera still
+		# panning toward its limit.
+		motors -d s >/dev/null
+		motion_ok "stopped"
+		;;
+	b)
+		# Goback. Kept: MOTOR_GOBACK is a distinct driver operation that the
+		# WebSocket protocol deliberately does not expose, so nothing about
+		# the new path makes it redundant. It has no caller in this tree
+		# today, but removing it would be an unrelated dead-code change, not
+		# part of this migration.
+		motors -d b >/dev/null
+		motion_ok "goback"
+		;;
+	j)
+		# Explicit one-shot status. Kept, and NOT redundant: config-motors.js
+		# calls it from the settings page's "capture current position" button,
+		# which has no WebSocket open and no reason to open one for a single
+		# read. (The 'i' case that sat next to it - `motors -i`, an initial-
+		# position echo - had no caller anywhere in this tree and is gone.)
+		payload=$(motors -j 2>/dev/null) || json_error "motors-status-failed"
+		json_ok "$payload"
+		;;
+	pg)
+		# List PTZ presets from the motors.presets array in thingino.json:
+		# [{"id":N,"description":"..","x":N,"y":N}]
+		presets_json=$(jct /etc/thingino.json path '$.motors.presets[*]' --mode values 2>/dev/null)
+		[ -n "$presets_json" ] || presets_json='[]'
+		json_ok "{\"presets\":$presets_json}"
+		;;
+	ps)
+		# Save current motor position as a preset (auto slot)
+		[ -n "$description" ] || json_error "preset-description-required"
+		output=$(ptz_presets -a -1 "$description" 2>&1) || json_error "preset-save-failed"
+		json_ok "{\"status\":\"$output\"}"
+		;;
+	pr)
+		# Move to a preset
+		[ -n "$n" ] || json_error "preset-number-required"
+		output=$(ptz_presets "$n" 2>&1) || json_error "preset-run-failed"
+		json_ok "{\"status\":\"preset $n run\"}"
+		;;
+	pd)
+		# Delete a preset
+		[ -n "$n" ] || json_error "preset-number-required"
+		ptz_presets -r "$n" >/dev/null 2>&1
+		json_ok "{\"status\":\"preset $n deleted\"}"
+		;;
+	pu)
+		# Update an existing preset's description and coordinates
+		[ -n "$n" ] || json_error "preset-number-required"
+		[ -n "$description" ] || json_error "preset-description-required"
+		case "$x" in
+			'' | *[!0-9]*) json_error "preset-x-invalid" ;;
+		esac
+		case "$y" in
+			'' | *[!0-9]*) json_error "preset-y-invalid" ;;
+		esac
+		ptz_presets -a "$n" "$description" "$x" "$y" >/dev/null 2>&1 || json_error "preset-update-failed"
+		json_ok "{\"status\":\"preset $n updated\"}"
+		;;
+	po)
+		# Reorder presets: order is a comma-separated list of preset ids.
+		# Ids are stable; only the array order changes.
+		[ -n "$order" ] || json_error "preset-order-required"
+		output=$(ptz_presets -o "$order" 2>&1) || json_error "preset-reorder-failed"
+		json_ok "{\"status\":\"$output\"}"
+		;;
+	*)
+		json_error "motors-command-unsupported"
+		;;
+esac
+
+# Every case above exits through json_ok or json_error, so nothing reaches
+# here. Reaching it at all would mean a case fell through silently.
+json_error "motors-command-unhandled"

--- a/package/timps/files/www/motors-ui/json-motors-config.cgi
+++ b/package/timps/files/www/motors-ui/json-motors-config.cgi
@@ -1,0 +1,220 @@
+#!/bin/sh
+# shellcheck disable=SC1091,SC2154,SC3043
+
+# Check authentication
+. /var/www/x/auth.sh
+require_auth
+
+motors_domain="motors"
+motors_config_file="/etc/thingino.json"
+
+json_escape() {
+	printf '%s' "$1" | sed \
+		-e 's/\\/\\\\/g' \
+		-e 's/"/\\"/g' \
+		-e "s/\r/\\r/g" \
+		-e "s/\n/\\n/g"
+}
+
+read_post_data() {
+	if [ -n "$CONTENT_LENGTH" ] && [ "$CONTENT_LENGTH" -gt 0 ]; then
+		body=$(dd bs=1 count="$CONTENT_LENGTH" 2>/dev/null)
+		eval "$(printf '%s' "$body" | awk -F'&' '{
+      for (i=1; i<=NF; i++) {
+        split($i, kv, "=")
+        key = kv[1]
+        value = kv[2]
+        gsub(/\+/, " ", value)
+        gsub(/%([0-9A-Fa-f]{2})/, "\\x\\1", value)
+        printf "POST_%s=\"%s\"\n", key, value
+      }
+    }')"
+	fi
+}
+
+http_200() {
+	printf 'Status: 200 OK\r\n'
+}
+
+http_412() {
+	printf 'Status: 412 Precondition Failed\r\n'
+}
+
+json_header() {
+	printf 'Content-Type: application/json\r\n'
+	printf 'Cache-Control: no-store\r\n'
+	printf 'Pragma: no-cache\r\n'
+	printf 'Expires: %s\r\n' "$(TZ=GMT0 date +'%a, %d %b %Y %T %Z')"
+	printf 'Etag: "%s"\r\n' "$(cat /proc/sys/kernel/random/uuid)"
+	printf 'Connection: close\r\n'
+	printf '\r\n'
+}
+
+json_error() {
+	http_412
+	json_header
+	printf '{"error":{"code":412,"message":"%s"}}\n' "$(json_escape "$1")"
+	exit 0
+}
+
+json_ok() {
+	http_200
+	json_header
+	case "$1" in
+		\{*)
+			printf '{"code":200,"result":"success","message":%s}\n' "$1"
+			;;
+		*)
+			printf '{"code":200,"result":"success","message":"%s"}\n' "$(json_escape "$1")"
+			;;
+	esac
+	exit 0
+}
+
+motors_set_value() {
+	jct "$motors_config_file" set "$motors_domain.$1" "$2" >/dev/null 2>&1
+}
+
+motors_get_field() {
+	jct "$motors_config_file" get "$motors_domain.$1" 2>/dev/null
+}
+
+ensure_config_file() {
+	[ -f "$motors_config_file" ] && return
+	umask_old=$(umask)
+	umask 077
+	echo '{}' >"$motors_config_file"
+	umask "$umask_old"
+}
+
+current_config_payload() {
+	local payload
+	payload=$(jct "$motors_config_file" get "$motors_domain" 2>/dev/null)
+	if [ -z "$payload" ] || [ "$payload" = "null" ]; then
+		payload='{}'
+	fi
+	printf '%s' "$payload"
+}
+
+respond_with_config() {
+	ensure_config_file
+	json_ok "$(current_config_payload)"
+}
+
+handle_get() {
+	ensure_config_file
+	respond_with_config
+}
+
+handle_post() {
+	ensure_config_file
+	read_post_data
+	[ "$POST_form" = "motors" ] || json_error "motors-form-missing"
+
+	gpio_pan_1=$POST_gpio_pan_1
+	gpio_pan_2=$POST_gpio_pan_2
+	gpio_pan_3=$POST_gpio_pan_3
+	gpio_pan_4=$POST_gpio_pan_4
+	gpio_tilt_1=$POST_gpio_tilt_1
+	gpio_tilt_2=$POST_gpio_tilt_2
+	gpio_tilt_3=$POST_gpio_tilt_3
+	gpio_tilt_4=$POST_gpio_tilt_4
+	homing_value=${POST_homing:-false}
+	pos_0_x=$POST_pos_0_x
+	pos_0_y=$POST_pos_0_y
+	speed_pan_value=$POST_speed_pan
+	speed_tilt_value=$POST_speed_tilt
+	accel_pan_value=${POST_accel_pan:-0}
+	accel_tilt_value=${POST_accel_tilt:-0}
+	motion_driver_value=${POST_motion_driver:-legacy}
+	preview_control_mode_value=${POST_preview_control_mode:-step}
+	steps_pan_value=$POST_steps_pan
+	steps_tilt_value=$POST_steps_tilt
+	joystick_sensitivity_value=${POST_joystick_sensitivity:-2.00}
+
+	[ "$homing_value" = "true" ] || homing_value="false"
+
+	is_spi_value=$(motors_get_field is_spi)
+
+	if [ "true" != "$is_spi_value" ]; then
+		if [ -z "$gpio_pan_1" ] || [ -z "$gpio_pan_2" ] || [ -z "$gpio_pan_3" ] || [ -z "$gpio_pan_4" ] ||
+			[ -z "$gpio_tilt_1" ] || [ -z "$gpio_tilt_2" ] || [ -z "$gpio_tilt_3" ] || [ -z "$gpio_tilt_4" ]; then
+			json_error "All motor GPIO pins are required"
+		fi
+	fi
+
+	if [ "0$steps_pan_value" -le 0 ] || [ "0$steps_tilt_value" -le 0 ]; then
+		json_error "Motor max steps must be positive"
+	fi
+
+	if [ "0$accel_pan_value" -lt 0 ] || [ "0$accel_tilt_value" -lt 0 ]; then
+		json_error "Motor acceleration must be zero or positive"
+	fi
+
+	case "$motion_driver_value" in
+		legacy | profiled) ;;
+		*)
+			motion_driver_value="legacy"
+			;;
+	esac
+
+	case "$preview_control_mode_value" in
+		step | continuous | joystick) ;;
+		*)
+			preview_control_mode_value="step"
+			;;
+	esac
+
+	# busybox ash's test has no floating point; reject non-numeric, then
+	# clamp via awk into motor-daemon.c's own accepted range.
+	case "$joystick_sensitivity_value" in
+		'' | *[!0-9.]* | *.*.*) joystick_sensitivity_value="2.00" ;;
+	esac
+	joystick_sensitivity_value=$(awk -v v="$joystick_sensitivity_value" \
+		'BEGIN { if (v < 0.05) v = 0.05; if (v > 4) v = 4; printf "%.2f", v }')
+
+	if [ "true" != "$is_spi_value" ]; then
+		motors_set_value gpio_pan "$gpio_pan_1 $gpio_pan_2 $gpio_pan_3 $gpio_pan_4"
+		motors_set_value gpio_tilt "$gpio_tilt_1 $gpio_tilt_2 $gpio_tilt_3 $gpio_tilt_4"
+	fi
+
+	motors_set_value steps_pan "$steps_pan_value"
+	motors_set_value steps_tilt "$steps_tilt_value"
+	motors_set_value speed_pan "$speed_pan_value"
+	motors_set_value speed_tilt "$speed_tilt_value"
+	motors_set_value accel_pan "$accel_pan_value"
+	motors_set_value accel_tilt "$accel_tilt_value"
+	motors_set_value motion_driver "$motion_driver_value"
+	motors_set_value preview_control_mode "$preview_control_mode_value"
+	motors_set_value joystick_sensitivity "$joystick_sensitivity_value"
+	motors_set_value homing "$homing_value"
+
+	if [ -n "$pos_0_x" ] && [ -n "$pos_0_y" ]; then
+		# The initial point is the first preset; create it (id 0, "Home")
+		# when no preset exists yet.
+		if [ -z "$(motors_get_field presets.0.id)" ]; then
+			motors_set_value presets.0.id 0
+			motors_set_value presets.0.name "Home"
+		fi
+		motors_set_value presets.0.x "$pos_0_x"
+		motors_set_value presets.0.y "$pos_0_y"
+	fi
+
+	# Live-reloads the daemon config (see motor_ctl_reload() in
+	# motor-daemon.c for exactly which fields); GPIO still needs a reboot.
+	motors -R >/dev/null 2>&1
+
+	respond_with_config
+}
+
+case "$REQUEST_METHOD" in
+	GET)
+		handle_get
+		;;
+	POST)
+		handle_post
+		;;
+	*)
+		json_error "motors-method-unsupported"
+		;;
+esac

--- a/package/timps/files/www/motors-ui/motors.webui.json
+++ b/package/timps/files/www/motors-ui/motors.webui.json
@@ -1,0 +1,40 @@
+{
+  "name": "motors",
+  "label": "Pan/Tilt Motors",
+  "apiVersion": 1,
+  "nav": [
+    {
+      "section": "ddSettings",
+      "position": "after:GPIO pins",
+      "items": [
+        {
+          "label": "Pan/Tilt motors",
+          "href": "/config-motors.html"
+        }
+      ]
+    }
+  ],
+  "styles": [
+    "/a/preview-motors.css"
+  ],
+  "preview": {
+    "scripts": [
+      "/a/preview-motors.js",
+      "/a/preview-motors-settings.js"
+    ],
+    "html": "<div class=\"position-absolute top-50 start-50 translate-middle\" id=\"motor-overlay\" style=\"display:none\">\n  <div id=\"motor\">\n    <div class=\"jst\">\n      <a class=\"s\" data-dir=\"uc\"></a>\n      <a class=\"s\" data-dir=\"ur\"></a>\n      <a class=\"s\" data-dir=\"cr\"></a>\n      <a class=\"s\" data-dir=\"dr\"></a>\n      <a class=\"s\" data-dir=\"dc\"></a>\n      <a class=\"s\" data-dir=\"dl\"></a>\n      <a class=\"s\" data-dir=\"cl\"></a>\n      <a class=\"s\" data-dir=\"ul\"></a>\n      <a class=\"b\" data-dir=\"h\"></a>\n    </div>\n    <div id=\"motor-stick\"><div id=\"motor-stick-handle\"></div></div>\n    <div id=\"motor-pos\" aria-hidden=\"true\">\n      <span class=\"motor-pos-row motor-pos-pan\"><b>P</b><span class=\"motor-pos-track\"><i id=\"motor-pos-x\"></i></span><span id=\"motor-pos-text\">&#8211;</span></span>\n      <span class=\"motor-pos-row motor-pos-tilt\"><b>T</b><span class=\"motor-pos-track\"><i id=\"motor-pos-y\"></i></span></span>\n    </div>\n  </div>\n</div>"
+  },
+  "featureFlags": {
+    "motors": true,
+    "motorsWs": false
+  },
+  "cgi": [
+    "/x/json-motor.cgi",
+    "/x/json-motor-params.cgi",
+    "/x/json-motor-token.cgi",
+    "/x/json-motors-config.cgi"
+  ],
+  "pages": [
+    "/config-motors.html"
+  ]
+}

--- a/package/timps/files/www/motors-ui/preview-motors-settings.js
+++ b/package/timps/files/www/motors-ui/preview-motors-settings.js
@@ -1,0 +1,418 @@
+/**
+ * Preview-page PTZ settings modal (thingino-motors).
+ *
+ * An icon button in the Live View card header - alongside the motion-grid
+ * and stats toggles - opens a modal with quick settings (preview control
+ * mode, pan/tilt speed) and PTZ presets.
+ *
+ * Settings read/write through /x/json-motor-params.cgi (control mode and
+ * speeds; the CGI reloads the motors-daemon config on save so speed
+ * changes apply without a reboot). Presets read/write through
+ * /x/json-motor.cgi (d=pg / d=ps / d=pr / d=pd / d=pu / d=po).
+ *
+ * Plugin-owned file: registered via motors.webui.json `preview.scripts`,
+ * injected into the preview page at build time.
+ */
+(function () {
+  "use strict";
+
+  const PARAMS_ENDPOINT = "/x/json-motor-params.cgi";
+  const MOTOR_ENDPOINT = "/x/json-motor.cgi";
+
+  function normalizeControlMode(value) {
+    return value === "continuous" || value === "joystick" ? value : "step";
+  }
+
+  async function loadParams() {
+    const res = await fetch(PARAMS_ENDPOINT, { cache: "no-store" });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json();
+  }
+
+  async function saveParams(fields) {
+    const res = await fetch(PARAMS_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(fields).toString(),
+      cache: "no-store",
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json();
+  }
+
+  async function loadPresets() {
+    const res = await fetch(
+      `${MOTOR_ENDPOINT}?${new URLSearchParams({ d: "pg" }).toString()}`,
+      { cache: "no-store" },
+    );
+    const payload = await res.json().catch(() => null);
+    if (!res.ok || !payload || payload.result !== "success") {
+      const message = payload && payload.error && payload.error.message;
+      throw new Error(message || `HTTP ${res.status}`);
+    }
+    return payload.message && Array.isArray(payload.message.presets)
+      ? payload.message.presets
+      : [];
+  }
+
+  async function presetAction(action, extra) {
+    const params = new URLSearchParams({ d: action });
+    Object.entries(extra || {}).forEach(([k, v]) => params.set(k, v));
+    const res = await fetch(`${MOTOR_ENDPOINT}?${params.toString()}`);
+    const payload = await res.json().catch(() => null);
+    if (!res.ok || !payload || payload.result !== "success") {
+      const message = payload && payload.error && payload.error.message;
+      throw new Error(message || `HTTP ${res.status}`);
+    }
+    return (payload.message && payload.message.status) || "OK";
+  }
+
+  // -- modal markup ----------------------------------------------------
+  const MODAL_HTML =
+    '<div class="modal fade" id="ptzModal" tabindex="-1" aria-labelledby="ptzModalLabel" aria-hidden="true">' +
+    '  <div class="modal-dialog modal-lg">' +
+    '    <div class="modal-content">' +
+    '      <div class="modal-header">' +
+    '        <h5 class="modal-title" id="ptzModalLabel">PTZ Settings</h5>' +
+    '        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>' +
+    "      </div>" +
+    '      <div class="modal-body">' +
+    '        <ul class="nav nav-tabs" role="tablist">' +
+    '          <li class="nav-item" role="presentation">' +
+    '            <button class="nav-link active" id="ptz-settings-tab" data-bs-toggle="tab" data-bs-target="#ptz-settings-pane" type="button" role="tab" aria-controls="ptz-settings-pane" aria-selected="true">Movement</button>' +
+    "          </li>" +
+    '          <li class="nav-item" role="presentation">' +
+    '            <button class="nav-link" id="ptz-presets-tab" data-bs-toggle="tab" data-bs-target="#ptz-presets-pane" type="button" role="tab" aria-controls="ptz-presets-pane" aria-selected="false">Presets</button>' +
+    "          </li>" +
+    "        </ul>" +
+    '        <div class="tab-content pt-3">' +
+    '          <div class="tab-pane fade show active" id="ptz-settings-pane" role="tabpanel" aria-labelledby="ptz-settings-tab">' +
+    '            <p class="row">' +
+    '              <label class="form-label col-4" for="ptz-preview-control-mode">Preview controls</label>' +
+    '              <select class="form-select col" id="ptz-preview-control-mode">' +
+    '                <option value="step">Step move (click / double-click)</option>' +
+    '                <option value="continuous">Continuous move (press and hold)</option>' +
+    '                <option value="joystick">Virtual joystick (drag)</option>' +
+    "              </select>" +
+    "            </p>" +
+    '            <p class="row">' +
+    '              <label class="form-label col-4" for="ptz-speed-pan">Pan speed</label>' +
+    '              <input class="form-control col" type="number" id="ptz-speed-pan" min="0" placeholder="900">' +
+    "            </p>" +
+    '            <p class="row">' +
+    '              <label class="form-label col-4" for="ptz-speed-tilt">Tilt speed</label>' +
+    '              <input class="form-control col" type="number" id="ptz-speed-tilt" min="0" placeholder="900">' +
+    "            </p>" +
+    "          </div>" +
+    '          <div class="tab-pane fade" id="ptz-presets-pane" role="tabpanel" aria-labelledby="ptz-presets-tab">' +
+    '            <div class="d-flex gap-2 mb-3">' +
+    '              <input type="text" class="form-control" id="ptz-preset-name" placeholder="Preset description, e.g. Front door" maxlength="64">' +
+    '              <button type="button" class="btn btn-outline-primary text-nowrap" id="ptz-preset-save" title="Save current position as a preset">' +
+    '                <i class="bi bi-plus-circle me-1"></i>Save' +
+    "              </button>" +
+    "            </div>" +
+    '            <ul id="ptz-presets-list" class="list-group"></ul>' +
+    '            <small id="ptz-presets-empty" class="text-secondary d-block mt-2">No presets yet. Move the camera (preview overlay) and save a position above.</small>' +
+    "          </div>" +
+    "        </div>" +
+    "      </div>" +
+    '      <div class="modal-footer">' +
+    '        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>' +
+    '        <button type="button" class="btn btn-primary" id="ptz-save">Save settings</button>' +
+    "      </div>" +
+    "    </div>" +
+    "  </div>" +
+    "</div>";
+
+  // -- presets -----------------------------------------------------------
+  let currentPresets = [];
+
+  function renderPresets(presets) {
+    currentPresets = presets || [];
+    const list = $("#ptz-presets-list");
+    if (!list) return;
+    list.innerHTML = "";
+    const empty = $("#ptz-presets-empty");
+    if (empty) empty.classList.toggle("d-none", currentPresets.length > 0);
+    currentPresets.forEach((p) => list.appendChild(createPresetRow(p)));
+  }
+
+  function createPresetRow(p) {
+    const li = document.createElement("li");
+    li.className = "list-group-item d-flex align-items-center gap-2";
+    li.dataset.id = String(p.id);
+
+    const handle = document.createElement("span");
+    handle.className = "bi bi-grip-vertical drag-handle text-secondary";
+    handle.title = "Drag to reorder";
+    handle.draggable = true;
+    handle.addEventListener("dragstart", (e) => {
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", String(p.id));
+      li.classList.add("dragging");
+    });
+    handle.addEventListener("dragend", () => li.classList.remove("dragging"));
+
+    const nameInput = document.createElement("input");
+    nameInput.type = "text";
+    nameInput.className = "form-control form-control-sm flex-grow-1 preset-name";
+    nameInput.value = p.description || "";
+    nameInput.maxLength = 64;
+    nameInput.placeholder = `Preset ${p.id}`;
+
+    const xInput = document.createElement("input");
+    xInput.type = "number";
+    xInput.className = "form-control form-control-sm preset-x";
+    xInput.style.width = "4.5rem";
+    xInput.value = p.x;
+    xInput.min = "0";
+
+    const yInput = document.createElement("input");
+    yInput.type = "number";
+    yInput.className = "form-control form-control-sm preset-y";
+    yInput.style.width = "4.5rem";
+    yInput.value = p.y;
+    yInput.min = "0";
+
+    const saveBtn = document.createElement("button");
+    saveBtn.type = "button";
+    saveBtn.className = "btn btn-sm btn-outline-success";
+    saveBtn.title = "Save description and coordinates";
+    saveBtn.innerHTML = '<i class="bi bi-check-lg"></i>';
+
+    const moveBtn = document.createElement("button");
+    moveBtn.type = "button";
+    moveBtn.className = "btn btn-sm btn-outline-primary";
+    moveBtn.title = "Move to this preset";
+    moveBtn.innerHTML = '<i class="bi bi-play-fill"></i>';
+
+    const delBtn = document.createElement("button");
+    delBtn.type = "button";
+    delBtn.className = "btn btn-sm btn-outline-danger";
+    delBtn.title = "Delete preset";
+    delBtn.innerHTML = '<i class="bi bi-trash"></i>';
+
+    saveBtn.addEventListener("click", () => {
+      const description = nameInput.value.trim();
+      if (!description) {
+        if (typeof showAlert === "function")
+          showAlert("warning", "Enter a description for the preset.", 3000);
+        return;
+      }
+      const x = xInput.value.trim();
+      const y = yInput.value.trim();
+      if (!/^\d+$/.test(x) || !/^\d+$/.test(y)) {
+        if (typeof showAlert === "function")
+          showAlert("warning", "Coordinates must be whole numbers.", 3000);
+        return;
+      }
+      runPresetAction("pu", { n: p.id, description, x, y });
+    });
+
+    moveBtn.addEventListener("click", () =>
+      runPresetAction("pr", { n: p.id }),
+    );
+    delBtn.addEventListener("click", () =>
+      runPresetAction("pd", { n: p.id }),
+    );
+
+    li.addEventListener("dragover", (e) => {
+      if (e.dataTransfer && e.dataTransfer.types.includes("text/plain")) {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        li.classList.add("drop-target");
+      }
+    });
+    li.addEventListener("dragleave", () => li.classList.remove("drop-target"));
+    li.addEventListener("drop", (e) => {
+      e.preventDefault();
+      li.classList.remove("drop-target");
+      const dragged = e.dataTransfer.getData("text/plain");
+      if (dragged && dragged !== String(p.id)) {
+        reorderPreset(dragged, String(p.id));
+      }
+    });
+
+    li.append(handle, nameInput, xInput, yInput, saveBtn, moveBtn, delBtn);
+    return li;
+  }
+
+  async function reorderPreset(draggedNumber, targetNumber) {
+    const from = currentPresets.findIndex(
+      (p) => String(p.id) === draggedNumber,
+    );
+    const to = currentPresets.findIndex(
+      (p) => String(p.id) === targetNumber,
+    );
+    if (from === -1 || to === -1 || from === to) return;
+
+    const moved = currentPresets.splice(from, 1)[0];
+    currentPresets.splice(to, 0, moved);
+
+    const order = currentPresets.map((p) => p.id).join(",");
+    renderPresets(currentPresets);
+
+    try {
+      await presetAction("po", { order });
+    } catch (err) {
+      console.error("Failed to reorder presets", err);
+      if (typeof showAlert === "function")
+        showAlert("danger", `Reorder failed: ${err.message}`, 5000);
+    }
+    await refreshPresets();
+  }
+
+  async function refreshPresets() {
+    try {
+      renderPresets(await loadPresets());
+    } catch (err) {
+      console.error("Failed to load PTZ presets", err);
+    }
+  }
+
+  async function runPresetAction(action, extra) {
+    try {
+      const status = await presetAction(action, extra);
+      if (typeof showAlert === "function") showAlert("success", status, 3000);
+      await refreshPresets();
+    } catch (err) {
+      console.error(`Preset action ${action} failed`, err);
+      if (typeof showAlert === "function")
+        showAlert("danger", `Preset action failed: ${err.message}`, 5000);
+    }
+  }
+
+  // -- settings -----------------------------------------------------------
+  function populateSettings(data) {
+    const mode = $("#ptz-preview-control-mode");
+    if (mode) mode.value = normalizeControlMode(data.preview_control_mode);
+    const pan = $("#ptz-speed-pan");
+    if (pan) pan.value = data.speed_pan ?? "";
+    const tilt = $("#ptz-speed-tilt");
+    if (tilt) tilt.value = data.speed_tilt ?? "";
+  }
+
+  async function saveSettings() {
+    const btn = $("#ptz-save");
+    if (!btn) return;
+
+    const mode = normalizeControlMode($("#ptz-preview-control-mode").value);
+    const pan = $("#ptz-speed-pan").value.trim();
+    const tilt = $("#ptz-speed-tilt").value.trim();
+
+    if (pan !== "" && !/^\d+$/.test(pan)) {
+      if (typeof showAlert === "function")
+        showAlert("warning", "Pan speed must be a whole number.", 4000);
+      return;
+    }
+    if (tilt !== "" && !/^\d+$/.test(tilt)) {
+      if (typeof showAlert === "function")
+        showAlert("warning", "Tilt speed must be a whole number.", 4000);
+      return;
+    }
+
+    const fields = { preview_control_mode: mode };
+    if (pan !== "") fields.speed_pan = pan;
+    if (tilt !== "") fields.speed_tilt = tilt;
+
+    btn.disabled = true;
+    try {
+      const data = await saveParams(fields);
+      if (window.motorParams) {
+        if (data.preview_control_mode !== undefined)
+          window.motorParams.preview_control_mode = data.preview_control_mode;
+        if (data.speed_pan !== undefined)
+          window.motorParams.speed_pan = data.speed_pan;
+        if (data.speed_tilt !== undefined)
+          window.motorParams.speed_tilt = data.speed_tilt;
+      }
+      // tell preview-motors.js to rebind so the saved mode applies live
+      const savedMode = normalizeControlMode(
+        data.preview_control_mode !== undefined
+          ? data.preview_control_mode
+          : mode,
+      );
+      document.dispatchEvent(
+        new CustomEvent("preview-motors:control-mode", {
+          detail: { mode: savedMode },
+        }),
+      );
+
+      if (typeof showAlert === "function")
+        showAlert("success", "PTZ settings saved.", 4000);
+      const modal = bootstrap.Modal.getInstance($("#ptzModal"));
+      if (modal) modal.hide();
+    } catch (err) {
+      console.error("Failed to save PTZ settings", err);
+      if (typeof showAlert === "function")
+        showAlert("danger", `Failed: ${err.message}`, 6000);
+    } finally {
+      btn.disabled = false;
+    }
+  }
+
+  // -- bootstrap ----------------------------------------------------------
+  function init() {
+    const style = document.createElement("style");
+    style.textContent =
+      "#ptz-presets-list .drag-handle{cursor:grab;user-select:none}" +
+      "#ptz-presets-list .drag-handle:active{cursor:grabbing}" +
+      "#ptz-presets-list li.dragging{opacity:.5}" +
+      "#ptz-presets-list li.drop-target{outline:2px dashed var(--bs-primary)}";
+    document.head.appendChild(style);
+
+    document.body.insertAdjacentHTML("beforeend", MODAL_HTML);
+
+    // anchor off #ms-stats-toggle's parent (that row has no class of its
+    // own); the old ".preview-header-actions" selector matched nothing
+    const frame = $("#frame");
+    const img = $("#preview");
+    const statsBtn = $("#ms-stats-toggle");
+    const connectBtn = $("#ms-connect");
+    const row =
+      (statsBtn && statsBtn.parentNode) || (connectBtn && connectBtn.parentNode);
+    const host = row || frame || (img && img.parentNode) || document.body;
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "btn btn-outline-secondary";
+    btn.id = "preview-ptz";
+    btn.title = "PTZ settings"; // icon-only button, so this carries the name
+    btn.setAttribute("aria-label", "PTZ settings");
+    btn.innerHTML = '<i class="bi bi-arrows-move"></i>';
+    if (row && connectBtn && connectBtn.parentNode === row)
+      row.insertBefore(btn, connectBtn);
+    else host.appendChild(btn);
+
+    btn.addEventListener("click", async () => {
+      try {
+        populateSettings(await loadParams());
+      } catch (err) {
+        console.error("Failed to load PTZ settings", err);
+      }
+      await refreshPresets();
+      new bootstrap.Modal($("#ptzModal")).show();
+    });
+
+    $("#ptz-save").addEventListener("click", saveSettings);
+
+    const presetSave = $("#ptz-preset-save");
+    if (presetSave) {
+      presetSave.addEventListener("click", async () => {
+        const description = $("#ptz-preset-name").value.trim();
+        if (!description) {
+          if (typeof showAlert === "function")
+            showAlert("warning", "Enter a description for the preset first.", 3000);
+          return;
+        }
+        await runPresetAction("ps", { description });
+        $("#ptz-preset-name").value = "";
+      });
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/package/timps/files/www/motors-ui/preview-motors.css
+++ b/package/timps/files/www/motors-ui/preview-motors.css
@@ -1,0 +1,184 @@
+/* Virtual analog stick for the preview PTZ overlay, used when
+ * motors.preview_control_mode is "joystick". Plugin stylesheet rather than
+ * more rules in main.css: markup comes from this plugin's own manifest.
+ */
+
+#motor {
+  position: relative;
+  /* --motor-stick-size is written here at runtime (sizeStick() in
+   * preview-motors.js), not on #motor-stick: the readout rows are the
+   * ring's siblings and custom properties only inherit downward. */
+}
+
+#motor-stick,
+#motor-pos {
+  display: none;
+}
+
+#motor.stick-mode #motor-stick,
+#motor.stick-mode #motor-pos {
+  display: block;
+}
+
+/* The eight direction sectors would otherwise swallow every pointerdown. */
+#motor.stick-mode .jst a.s {
+  display: none;
+}
+
+#motor-stick {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  /* transform, not a margin hack: --motor-stick-size changes at runtime. */
+  transform: translate(-50%, -50%);
+  width: var(--motor-stick-size, 450px);
+  height: var(--motor-stick-size, 450px);
+  border-radius: 50%;
+  background: transparent; /* no fill - would cover most of the video */
+  border: 2px solid #ffffff59;
+  opacity: 0; /* hover/drag only, see below */
+  transition: opacity 220ms ease;
+  pointer-events: auto; /* re-enables over #motor-overlay's pointer-events:none */
+  touch-action: none; /* else the browser claims the gesture for scrolling */
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* .dragging too: pointer capture can carry a drag outside the ring. */
+#motor-stick:hover,
+#motor-stick.dragging {
+  opacity: 1;
+}
+
+#motor-stick::after {
+  content: ""; /* centre pip, marks the dead zone */
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 6px;
+  height: 6px;
+  margin: -3px 0 0 -3px;
+  border-radius: 50%;
+  background: #ffffff59;
+}
+
+#motor-stick-handle {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 50px;
+  height: 50px;
+  margin: -25px 0 0 -25px;
+  border-radius: 50%;
+  background: #ff8800cc;
+  border: 3px solid #fffffff2;
+  box-shadow: 0 2px 8px #000000a6;
+  cursor: grab;
+  transition: transform 120ms ease-out; /* snap-back only, off during drag */
+}
+
+#motor-stick.dragging {
+  border-color: #ff8800a6;
+}
+
+#motor-stick.dragging #motor-stick-handle {
+  cursor: grabbing;
+  transition: none;
+}
+
+/* Live position readout: pan (left/right) as a horizontal bar under the
+ * ring, tilt (up/down) as a vertical one beside it - both positioned off
+ * --motor-stick-size, hidden individually by sizeStick() when they don't
+ * fit next to the ring. */
+#motor-pos {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  font-size: 11px;
+  font-weight: 500;
+  color: #fff;
+  text-shadow: 0 1px 2px #000000cc;
+  pointer-events: none;
+}
+
+.motor-pos-row {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.motor-pos-row b {
+  width: 9px;
+  font-weight: 600;
+  opacity: 0.75;
+  flex: none;
+}
+
+.motor-pos-track {
+  display: block;
+  border-radius: 2px;
+  background: #ffffff40;
+  overflow: hidden;
+}
+
+.motor-pos-track i {
+  display: block;
+  background: #ff8800;
+}
+
+.motor-pos-pan {
+  top: calc(var(--motor-stick-size, 450px) / 2 + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 176px;
+}
+
+.motor-pos-pan .motor-pos-track {
+  flex: 1;
+  height: 4px;
+}
+
+.motor-pos-pan .motor-pos-track i {
+  width: 0;
+  height: 100%;
+  transition: width 220ms linear;
+}
+
+/* Beside the ring, not stacked under the pan bar - two rows under a short
+ * (portrait-phone) ring is what overran the frame before. Label rotates via
+ * writing-mode (simpler than rotating the whole flex row + fill direction). */
+.motor-pos-tilt {
+  left: calc(var(--motor-stick-size, 450px) / 2 + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  flex-direction: column;
+  height: 90px;
+}
+
+.motor-pos-tilt b {
+  width: auto;
+  writing-mode: vertical-rl;
+}
+
+.motor-pos-tilt .motor-pos-track {
+  flex: 1;
+  width: 4px;
+  display: flex;
+  align-items: flex-end;
+}
+
+.motor-pos-tilt .motor-pos-track i {
+  width: 100%;
+  height: 0;
+  transition: height 220ms linear;
+}
+
+/* Fixed width: changing digits next to a flex track would jog it otherwise. */
+#motor-pos-text {
+  flex: none;
+  width: 62px;
+  text-align: right;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}

--- a/package/timps/files/www/motors-ui/preview-motors.js
+++ b/package/timps/files/www/motors-ui/preview-motors.js
@@ -1,0 +1,772 @@
+/* PTZ joystick for the preview page.
+ *
+ * Two transports: CGI (/x/json-motor.cgi, always available) and WS
+ * (motors-daemon, only when built with BR2_PACKAGE_THINGINO_MOTORS_WS -
+ * window.thinginoUIConfig.device.motorsWs). The build flag alone doesn't
+ * guarantee a usable socket (daemon config, https mixed-content), so
+ * everything here checks "is the socket open right now" and falls back
+ * to CGI per call.
+ */
+
+function runMotorCmd(args) {
+  return fetch(`/x/json-motor.cgi?${args}`)
+    .then((res) => res.json())
+    .then(({ message }) => {
+      const { xpos, ypos } = message || {};
+      updatePositionDisplay(xpos, ypos);
+      return message;
+    });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// WebSocket transport. Token via query string, not a header: the WebSocket
+// constructor can't set request headers on the handshake (same as timps's
+// EventSource); motors-daemon accepts ?token= for that reason.
+const MOTOR_WS_TOKEN_URL = "/x/json-motor-token.cgi";
+const MOTOR_WS_CONNECT_TIMEOUT_MS = 4000;
+// After this many failed attempts, stay on CGI for the rest of the page's life.
+const MOTOR_WS_MAX_ATTEMPTS = 3;
+
+const motorWs = (function () {
+  let socket = null;
+  let connecting = null;
+  let attempts = 0;
+  let seq = 1;
+  let frameListener = null;
+  let pushIntervalMs = 0;
+  const limits = { x: 0, y: 0 };
+
+  function buildFlagSet() {
+    const cfg = window.thinginoUIConfig || {};
+    return !!(cfg.device && cfg.device.motorsWs === true);
+  }
+
+  function usable() {
+    if (!buildFlagSet()) return false;
+    if (attempts >= MOTOR_WS_MAX_ATTEMPTS) return false;
+    return true; // https:// vs wss:// is decided later, in openSocket()
+  }
+
+  // https:// page must use wss:// (mixed content) or not connect at all -
+  // never ws:// even if the daemon offers it, since an untrusted self-signed
+  // wss:// cert has no browser prompt to fall back on.
+  function socketScheme(info) {
+    if (location.protocol !== "https:") return "ws";
+    return info && info.tls === true ? "wss" : null;
+  }
+
+  function onMessage(ev) {
+    let frame;
+    try {
+      frame = JSON.parse(ev.data);
+    } catch (err) {
+      return;
+    }
+    if (frame.type === "hello" || frame.type === "status") {
+      // Daemon's own travel limits; 0 means unknown, fall back to fixed steps.
+      if (typeof frame.x_max === "number") limits.x = frame.x_max;
+      if (typeof frame.y_max === "number") limits.y = frame.y_max;
+    }
+    // Keep window.motorPosition current from every WS push too, not just
+    // the CGI one-shot path - see updatePositionDisplay()'s own comment.
+    if (typeof frame.x === "number" && typeof frame.y === "number") {
+      updatePositionDisplay(frame.x, frame.y);
+    }
+    // Errors included - "unknown_cmd" is how a daemon older than the
+    // vector command is detected.
+    if (frameListener) frameListener(frame);
+  }
+
+  function openSocket(info) {
+    const port = parseInt(info.port, 10) || 8089;
+    const scheme = socketScheme(info);
+    if (!scheme) {
+      // https:// page, daemon has no cert: fall back to the CGI path
+      return Promise.reject(new Error("no wss:// on an https:// page"));
+    }
+    // Bracket a raw IPv6 literal, the same way preview.html does when it
+    // builds timps's base URL - location.hostname hands it back unbracketed.
+    let host = location.hostname;
+    if (host.indexOf(":") >= 0 && host[0] !== "[") host = "[" + host + "]";
+    const url =
+      scheme +
+      "://" +
+      host +
+      ":" +
+      port +
+      "/ws?token=" +
+      encodeURIComponent(info.token);
+
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(url);
+      const timer = setTimeout(() => {
+        try {
+          ws.close();
+        } catch (err) {
+          /* already gone */
+        }
+        reject(new Error("connect timeout"));
+      }, MOTOR_WS_CONNECT_TIMEOUT_MS);
+
+      ws.onopen = () => {
+        clearTimeout(timer);
+        socket = ws;
+        attempts = 0;
+        console.info("motors: PTZ control over " + scheme + "://");
+        // Position pushes only subscribed when something draws them (see
+        // subscribe()) - travel limits arrive unprompted in "hello" either way.
+        if (pushIntervalMs) {
+          try {
+            ws.send(
+              JSON.stringify({
+                cmd: "subscribe",
+                interval_ms: pushIntervalMs,
+              }),
+            );
+          } catch (err) {
+            /* the send below will report it */
+          }
+        }
+        resolve(ws);
+      };
+      ws.onerror = () => {
+        clearTimeout(timer);
+        reject(new Error("socket error"));
+      };
+      ws.onclose = () => {
+        if (socket === ws) socket = null;
+      };
+      ws.onmessage = onMessage;
+    });
+  }
+
+  function connect() {
+    if (!usable()) return Promise.resolve(null);
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      return Promise.resolve(socket);
+    }
+    if (connecting) return connecting;
+
+    attempts += 1;
+    connecting = fetch(MOTOR_WS_TOKEN_URL, { cache: "no-store" })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((info) => {
+        if (!info || info.enabled === false || !info.token) {
+          throw new Error("listener not available");
+        }
+        return openSocket(info);
+      })
+      .catch((err) => {
+        console.warn(
+          "motors: WebSocket control unavailable, using the CGI path",
+          err,
+        );
+        socket = null;
+        return null;
+      })
+      .then((ws) => {
+        connecting = null;
+        return ws;
+      });
+
+    return connecting;
+  }
+
+  // Synchronous: returns 0 (falsy) on failure so a half-open socket can't
+  // swallow a stop; returns the stamped id on success (seq starts at 1, so
+  // callers can treat it as a boolean too) for matching error frames back.
+  function trySend(obj) {
+    if (!socket || socket.readyState !== WebSocket.OPEN) return 0;
+    try {
+      obj.id = seq++;
+      socket.send(JSON.stringify(obj));
+      return obj.id;
+    } catch (err) {
+      console.warn("motors: WebSocket send failed", err);
+      return 0;
+    }
+  }
+
+  return {
+    connect,
+    trySend,
+    isOpen: () => !!socket && socket.readyState === WebSocket.OPEN,
+    limits,
+    enabledAtBuild: buildFlagSet,
+    setFrameListener: (fn) => {
+      frameListener = fn;
+    },
+    // Safe before or after the socket opens; whichever is second sends it.
+    subscribe: (intervalMs) => {
+      pushIntervalMs = intervalMs;
+      trySend({ cmd: "subscribe", interval_ms: intervalMs });
+    },
+  };
+})();
+
+function normalizePreviewControlMode(value) {
+  return value === "continuous" || value === "joystick" ? value : "step";
+}
+
+function getPreviewControlMode() {
+  const motorParams = window.motorParams || {};
+  return normalizePreviewControlMode(motorParams.preview_control_mode);
+}
+
+async function ensureMotorParams() {
+  if (window.motorParams) {
+    return window.motorParams;
+  }
+  try {
+    const response = await fetch("/x/json-motor-params.cgi", {
+      cache: "no-store",
+    });
+    const motorParams = await response.json();
+    window.motorParams = motorParams;
+    return motorParams;
+  } catch (error) {
+    console.error("Failed to load motor parameters:", error);
+    window.motorParams = {
+      steps_pan: 0,
+      steps_tilt: 0,
+      pos_0_x: 0,
+      pos_0_y: 0,
+      preview_control_mode: "step",
+    };
+    return window.motorParams;
+  }
+}
+
+// Axis sign from data-dir ("ul", "cr", "dc", ...); shared by step and hold mode.
+function motorDirSigns(dir) {
+  return {
+    x: dir.includes("l") ? -1 : dir.includes("r") ? 1 : 0,
+    y: dir.includes("d") ? -1 : dir.includes("u") ? 1 : 0,
+  };
+}
+
+async function moveMotor(dir, steps = 100, d = "g") {
+  // Use motor parameters loaded from backend
+  const motorParams = window.motorParams || {
+    steps_pan: 0,
+    steps_tilt: 0,
+    pos_0_x: 0,
+    pos_0_y: 0,
+  };
+  const x_max = motorParams.steps_pan;
+  const y_max = motorParams.steps_tilt;
+  const x0 = Number(motorParams.pos_0_x);
+  const y0 = Number(motorParams.pos_0_y);
+  const step = x_max / steps;
+  if (dir === "homing") {
+    // Stays on CGI regardless of transport: one-shot, not a gesture.
+    await runMotorCmd("d=r");
+    if (Number.isFinite(x0) && Number.isFinite(y0)) {
+      await sleep(800);
+      await runMotorCmd("d=x&x=" + x0 + "&y=" + y0);
+    }
+  } else if (dir === "cc") {
+    const cx = x_max / 2;
+    const cy = y_max / 2;
+    if (!motorWs.trySend({ cmd: "move", mode: "abs", x: cx, y: cy })) {
+      runMotorCmd("d=x&x=" + cx + "&y=" + cy);
+    }
+  } else {
+    const sign = motorDirSigns(dir);
+    const x = sign.x * step;
+    const y = sign.y * step;
+    if (!motorWs.trySend({ cmd: "move", mode: "rel", x: x, y: y })) {
+      runMotorCmd("d=g&x=" + x + "&y=" + y);
+    }
+  }
+}
+
+function updatePositionDisplay(xpos, ypos) {
+  if (xpos === undefined) return;
+  // Expose for other plugins/view models (e.g. the settings modal's
+  // "capture current position" button) - kept in sync from BOTH transports
+  // below (the CGI one-shot response and every WS position push), so a
+  // reader always gets the latest value without polling json-motor.cgi d=j
+  // itself. bindPositionReadout()'s own DOM bars are separate and unaffected.
+  window.motorPosition = { xpos, ypos };
+}
+
+// upstream's keyboard-jog (Shift+arrow) feature is deliberately not ported
+// here, same decision as this morning's merge: it depends on a
+// `currentStepName` module-level variable (and the step-size UI that sets
+// it) that this fork's own preview-motors.js never adopted, so pulling in
+// just this commit's refinement of it would reference an undeclared
+// variable. Revisit as one deliberate piece of work if this fork ever wants
+// keyboard PTZ, not as a side effect of a routine upstream sync.
+
+// --- initialization ----------------------------------------------------
+document.addEventListener("DOMContentLoaded", async function () {
+  const uiConfig = window.thinginoUIConfig || {};
+  const hasMotors = uiConfig.device && uiConfig.device.motors === true;
+
+  if (!hasMotors) {
+    return;
+  }
+  await ensureMotorParams();
+
+  const motorOverlay = $("#motor-overlay");
+  if (motorOverlay) {
+    motorOverlay.style.display = "";
+  }
+
+  // Not awaited: a slow/absent listener must not delay binding the controls.
+  motorWs.connect();
+
+  let timer;
+
+  let renderPosition = null; // joystick mode's live pan/tilt readout, or null
+  let activeControlMode = null;
+  let modeAbort = null; // owns every listener the active mode registered
+
+  function bindStepControls() {
+    $$(".jst a.s").forEach((el) => {
+      el.onclick = (ev) => {
+        if (ev.detail === 1) {
+          timer = setTimeout(() => {
+            moveMotor(ev.target.dataset.dir, 100);
+          }, 200);
+        }
+      };
+      el.ondblclick = (ev) => {
+        if (ev.detail === 2) {
+          clearTimeout(timer);
+          moveMotor(ev.target.dataset.dir, 10);
+        }
+      };
+    });
+  }
+
+  function bindContinuousControls(signal) {
+    let holdInterval = null;
+    let wsHolding = false;
+    const intervalMs = 90;
+
+    // Hold-to-move over the socket: one command down, one stop up. The delta
+    // is the full axis travel - motor_ctl_relative() clamps to the limit and
+    // recomputes, so this means "go until the far end"; no limit (x_max 0)
+    // falls back to nudges below.
+    const startWsHold = (dir) => {
+      const sign = motorDirSigns(dir);
+      const params = window.motorParams || {};
+      const xTravel = motorWs.limits.x || Number(params.steps_pan) || 0;
+      const yTravel = motorWs.limits.y || Number(params.steps_tilt) || 0;
+      if ((sign.x && !xTravel) || (sign.y && !yTravel)) return false;
+
+      if (
+        !motorWs.trySend({
+          cmd: "move",
+          mode: "rel",
+          x: sign.x * xTravel,
+          y: sign.y * yTravel,
+        })
+      ) {
+        return false;
+      }
+      wsHolding = true;
+      return true;
+    };
+
+    // Re-issue a small nudge every 90ms; ceasing to send them IS the stop.
+    const stopCgiMove = () => {
+      if (holdInterval) {
+        clearInterval(holdInterval);
+        holdInterval = null;
+      }
+    };
+
+    const startCgiMove = (dir) => {
+      stopCgiMove();
+      moveMotor(dir, 100);
+      holdInterval = setInterval(() => {
+        moveMotor(dir, 100);
+      }, intervalMs);
+    };
+
+    const startContinuousMove = (dir) => {
+      if (!dir) return;
+      stopContinuousMove();
+      if (motorWs.isOpen() && startWsHold(dir)) return;
+      startCgiMove(dir);
+    };
+
+    // Bound to every way a press can end - a missed release leaves the
+    // camera panning to its limit. Idempotent.
+    function stopContinuousMove() {
+      stopCgiMove();
+      if (wsHolding) {
+        wsHolding = false;
+        if (!motorWs.trySend({ cmd: "stop" })) {
+          runMotorCmd("d=s"); // socket died mid-gesture, still moving
+        }
+      }
+    }
+
+    $$(".jst a.s").forEach((el) => {
+      const stopHandler = () => stopContinuousMove();
+      el.addEventListener("pointerdown", (ev) => {
+        ev.preventDefault();
+        if (el.setPointerCapture && ev.pointerId !== undefined) {
+          el.setPointerCapture(ev.pointerId);
+        }
+        startContinuousMove(el.dataset.dir);
+      }, { signal });
+      el.addEventListener("pointerup", stopHandler, { signal });
+      el.addEventListener("pointerleave", stopHandler, { signal });
+      el.addEventListener("pointercancel", stopHandler, { signal });
+      el.addEventListener("lostpointercapture", stopHandler, { signal });
+      el.addEventListener("contextmenu", (ev) => ev.preventDefault(), { signal });
+    });
+
+    // A backgrounded tab gets no pointer event; catch it here too.
+    window.addEventListener("blur", stopContinuousMove, { signal });
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) stopContinuousMove();
+    }, { signal });
+
+    // Switching mode mid-press must not leave the camera panning to its limit.
+    if (signal) signal.addEventListener("abort", stopContinuousMove);
+  }
+
+  // Live pan/tilt readout, joystick mode only - a held stick runs toward a
+  // limit the video gives no warning of. 200ms cadence (matches the
+  // socket's own); the CSS transition smooths it further for free.
+  function bindPositionReadout() {
+    const wrap = $("#motor-pos");
+    const barX = $("#motor-pos-x");
+    const barY = $("#motor-pos-y");
+    const text = $("#motor-pos-text");
+    if (!wrap) return null;
+
+    motorWs.subscribe(200);
+
+    return function render(frame) {
+      if (typeof frame.x !== "number" || typeof frame.y !== "number") return;
+      const xMax = frame.x_max || motorWs.limits.x;
+      const yMax = frame.y_max || motorWs.limits.y;
+      if (barX) barX.style.width = xMax ? (frame.x / xMax) * 100 + "%" : "0";
+      // tilt's bar is vertical (preview-motors.css), filled by height
+      if (barY) barY.style.height = yMax ? (frame.y / yMax) * 100 + "%" : "0";
+      if (text) text.textContent = frame.x + " / " + frame.y;
+    };
+  }
+
+  // Virtual analog stick. The drag deflection goes over the wire as a
+  // per-mille value, not a distance/speed - only the daemon knows travel
+  // limits, speed cap, and (motor_ctl_vector) per-axis speed support.
+  function bindJoystickControls(signal) {
+    const stick = $("#motor-stick");
+    const handle = $("#motor-stick-handle");
+    if (!stick || !handle) {
+      // stale manifest asset; degrade rather than nothing
+      bindContinuousControls(signal);
+      return;
+    }
+
+    $("#motor").classList.add("stick-mode");
+
+    // Ring size: measured from the real preview box (timps's
+    // ".ms-video-wrap" or the stock "#frame"), not a vw/vh guess, since
+    // neither can know the stream's aspect ratio. --motor-stick-size lives
+    // on #motor (not the ring): the readout rows are the ring's siblings
+    // and custom properties only inherit downward.
+    const GAP = 8; // matches the +8px offsets in preview-motors.css
+    const MIN_RING = 110; // below this the ring stops being drag-able
+    const motorEl = $("#motor");
+    const panEl = $(".motor-pos-pan");
+    const tiltEl = $(".motor-pos-tilt");
+    function sizeStick() {
+      const frame = $(".ms-video-wrap") || $("#frame");
+      if (!frame) return;
+      const box = frame.getBoundingClientRect();
+      if (!box.width || !box.height) return;
+
+      // Un-hide before measuring, or a row hidden on a previous run reports
+      // a zero box and stays hidden forever.
+      if (panEl) panEl.style.display = "";
+      if (tiltEl) tiltEl.style.display = "";
+      const panReach = panEl
+        ? GAP + panEl.getBoundingClientRect().height
+        : 0;
+      const tiltReach = tiltEl ? GAP + tiltEl.getBoundingClientRect().width : 0;
+
+      // Reserve the readout, then size the ring in what's left (92% for
+      // a small margin) - has room for the readout by construction.
+      const reserved = Math.min(
+        box.width - 2 * tiltReach,
+        box.height - 2 * panReach,
+      );
+      let size = Math.min(450, reserved * 0.92);
+      let panFits = true;
+      let tiltFits = true;
+
+      if (size < MIN_RING) {
+        // Too small for both: ring gets the frame, readout rows that don't
+        // fit are dropped rather than left to overflow:hidden-clip.
+        size = Math.max(
+          MIN_RING,
+          Math.min(450, Math.min(box.width, box.height) * 0.92),
+        );
+        panFits = size / 2 + panReach <= box.height / 2;
+        tiltFits = size / 2 + tiltReach <= box.width / 2;
+      }
+
+      motorEl.style.setProperty("--motor-stick-size", size.toFixed(0) + "px");
+      if (panEl) panEl.style.display = panFits ? "" : "none";
+      if (tiltEl) tiltEl.style.display = tiltFits ? "" : "none";
+    }
+    sizeStick();
+    window.addEventListener("resize", sizeStick, { signal });
+    // img-fluid markup only reaches its real aspect ratio once the first
+    // frame loads; timps's markup has no #preview, so this is a no-op there.
+    const previewImg = $("#preview");
+    if (previewImg) previewImg.addEventListener("load", sizeStick, { signal });
+
+    const SEND_INTERVAL_MS = 90; // matches the CGI hold loop's cadence
+    const DEAD_ZONE = 0.12; // felt dead zone; daemon's own is a smaller backstop
+
+    let dragging = false;
+    let radius = 1;
+    let centre = { x: 0, y: 0 };
+    let vector = { x: 0, y: 0 };
+    let overSocket = false;
+    let vectorRejected = false;
+    let lastVectorId = 0;
+    let lastSentAt = 0;
+    let flushTimer = null;
+    let cgiInterval = null;
+
+    motorWs.setFrameListener((frame) => {
+      if (renderPosition && (frame.type === "status" || frame.type === "hello"))
+        renderPosition(frame);
+      // Daemon predates the vector command: give up on the socket
+      // permanently (not per-press) and finish the gesture on the CGI.
+      if (
+        frame.type === "error" &&
+        frame.id === lastVectorId &&
+        (frame.code === "unknown_cmd" || frame.code === "no_limits")
+      ) {
+        console.warn("motors: daemon rejected the vector command", frame.code);
+        vectorRejected = true;
+        if (dragging && overSocket) {
+          motorWs.trySend({ cmd: "stop" });
+          overSocket = false;
+          startCgiNudges();
+        }
+      }
+    });
+
+    // CGI fallback: no speed field, so proportionality comes from nudge size
+    // scaled by deflection, on the classic 90ms tick.
+    function startCgiNudges() {
+      stopCgiNudges();
+      const params = window.motorParams || {};
+      const stepX = Number(params.steps_pan) / 100 || 0;
+      const stepY = Number(params.steps_tilt) / 100 || 0;
+      cgiInterval = setInterval(() => {
+        const x = Math.round((stepX * vector.x) / 1000);
+        const y = Math.round((stepY * vector.y) / 1000);
+        if (x || y) runMotorCmd("d=g&x=" + x + "&y=" + y);
+      }, SEND_INTERVAL_MS);
+    }
+
+    function stopCgiNudges() {
+      if (cgiInterval) {
+        clearInterval(cgiInterval);
+        cgiInterval = null;
+      }
+    }
+
+    function sendVector() {
+      lastSentAt = performance.now();
+      lastVectorId = motorWs.trySend({
+        cmd: "vector",
+        x: vector.x,
+        y: vector.y,
+      });
+      if (!lastVectorId) {
+        // Socket died mid-drag, still moving: switch transports.
+        overSocket = false;
+        runMotorCmd("d=s");
+        startCgiNudges();
+      }
+    }
+
+    // Trailing-edge throttle: a leading-only one would drop the last sample
+    // of a gesture, which is the one that says how fast to keep going.
+    function queueVector() {
+      const wait = SEND_INTERVAL_MS - (performance.now() - lastSentAt);
+      if (wait <= 0) {
+        if (flushTimer) {
+          clearTimeout(flushTimer);
+          flushTimer = null;
+        }
+        sendVector();
+        return;
+      }
+      if (!flushTimer) {
+        flushTimer = setTimeout(() => {
+          flushTimer = null;
+          // overSocket too: transport may have switched to CGI since queued
+          if (dragging && overSocket) sendVector();
+        }, wait);
+      }
+    }
+
+    function updateFromPointer(ev) {
+      let dx = ev.clientX - centre.x;
+      let dy = ev.clientY - centre.y;
+      const dist = Math.hypot(dx, dy);
+
+      // Clamp to the ring, or the deflection has no upper bound.
+      if (dist > radius) {
+        dx = (dx / dist) * radius;
+        dy = (dy / dist) * radius;
+      }
+
+      handle.style.transform = "translate(" + dx + "px," + dy + "px)";
+
+      const norm = Math.min(dist, radius) / radius;
+      if (norm < DEAD_ZONE) {
+        vector = { x: 0, y: 0 };
+        return;
+      }
+      // Rescale so the throw starts at the dead-zone edge, not 12% deflection.
+      const scale = ((norm - DEAD_ZONE) / (1 - DEAD_ZONE)) * 1000;
+      vector = {
+        x: Math.round((dx / (dist || 1)) * scale),
+        y: Math.round((-dy / (dist || 1)) * scale), // screen y is inverted vs logical y
+      };
+    }
+
+    function endDrag() {
+      if (!dragging) return;
+      dragging = false;
+      stick.classList.remove("dragging");
+      handle.style.transform = "";
+      if (flushTimer) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+      }
+      vector = { x: 0, y: 0 };
+      stopCgiNudges();
+      if (overSocket) {
+        overSocket = false;
+        if (!motorWs.trySend({ cmd: "stop" })) runMotorCmd("d=s");
+      }
+    }
+
+    stick.addEventListener("pointerdown", (ev) => {
+      ev.preventDefault();
+      const box = stick.getBoundingClientRect();
+      radius = box.width / 2;
+      centre = { x: box.left + radius, y: box.top + box.height / 2 };
+      dragging = true;
+      stick.classList.add("dragging");
+      // Guarded: setPointerCapture can throw NotFoundError, which would
+      // otherwise skip binding the rest of the gesture entirely.
+      try {
+        if (stick.setPointerCapture && ev.pointerId !== undefined) {
+          stick.setPointerCapture(ev.pointerId);
+        }
+      } catch (err) {
+        // no capture; blur/visibilitychange below still catch a runaway drag
+      }
+      overSocket = motorWs.isOpen() && !vectorRejected;
+      updateFromPointer(ev);
+      if (overSocket) sendVector();
+      else startCgiNudges();
+    }, { signal });
+
+    stick.addEventListener("pointermove", (ev) => {
+      if (!dragging) return;
+      ev.preventDefault();
+      updateFromPointer(ev);
+      if (overSocket) queueVector();
+    }, { signal });
+
+    // Every way a drag can end has to land here, same reasoning as the arrows.
+    ["pointerup", "pointercancel", "lostpointercapture"].forEach((name) =>
+      stick.addEventListener(name, endDrag, { signal }),
+    );
+    stick.addEventListener("contextmenu", (ev) => ev.preventDefault(), { signal });
+
+    window.addEventListener("blur", endDrag, { signal });
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) endDrag();
+    }, { signal });
+
+    // leaving mid-drag must stop the motor and the position-readout listener
+    if (signal)
+      signal.addEventListener("abort", () => {
+        endDrag();
+        motorWs.setFrameListener(null);
+      });
+  }
+
+  // (Re-)bind the widget to one control mode; safe to call repeatedly since
+  // aborting modeAbort tears down the previous mode's listeners first.
+  function applyControlMode(mode) {
+    mode = normalizePreviewControlMode(mode);
+    if (mode === activeControlMode) return;
+
+    if (modeAbort) modeAbort.abort();
+    modeAbort = new AbortController();
+    const signal = modeAbort.signal;
+
+    // step mode's onclick/ondblclick aren't covered by the signal
+    $$(".jst a.s").forEach((el) => {
+      el.onclick = null;
+      el.ondblclick = null;
+    });
+    const motorEl = $("#motor");
+    if (motorEl) motorEl.classList.remove("stick-mode");
+
+    activeControlMode = mode;
+    renderPosition = mode === "joystick" ? bindPositionReadout() : null;
+
+    if (mode === "joystick") {
+      bindJoystickControls(signal);
+    } else if (mode === "continuous") {
+      bindContinuousControls(signal);
+    } else {
+      bindStepControls();
+    }
+  }
+
+  applyControlMode(getPreviewControlMode());
+
+  // re-render hook: preview-motors-settings.js fires this after a save
+  window.previewMotors = window.previewMotors || {};
+  window.previewMotors.applyControlMode = applyControlMode;
+  document.addEventListener("preview-motors:control-mode", (ev) => {
+    applyControlMode(
+      (ev.detail && ev.detail.mode) || getPreviewControlMode(),
+    );
+  });
+
+  $(".jst a.b").onclick = (ev) => {
+    if (ev.detail === 1) {
+      timer = setTimeout(() => {
+        moveMotor("cc");
+      }, 200);
+    }
+  };
+
+  $(".jst a.b").ondblclick = (ev) => {
+    clearTimeout(timer);
+    moveMotor("homing");
+  };
+
+  // Over the socket this arrives unprompted in "hello"; only CGI needs to ask.
+  if (!motorWs.enabledAtBuild()) {
+    runMotorCmd("d=j");
+  }
+});

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -636,6 +636,35 @@ endef
 TARGET_FINALIZE_HOOKS := TIMPS_REAPPLY_WEBUI_OVERLAY $(TARGET_FINALIZE_HOOKS)
 TARGET_FINALIZE_HOOKS += TIMPS_PURGE_STOCK_WEBUI
 
+# Same prepend trick as TIMPS_REAPPLY_WEBUI_OVERLAY, for thingino-motors'
+# own www files instead of thingino-webui's: reapplied before assemble_plugins
+# runs, so a plain (non-fork) thingino-motors build still gets the full
+# joystick/CSS/CGIs over CGI transport. motorsWs stays false in the shipped
+# manifest - WS itself still needs the fork; this only carries the UI.
+ifeq ($(BR2_PACKAGE_THINGINO_MOTORS),y)
+define TIMPS_REAPPLY_MOTORS_UI
+	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/config-motors.html \
+		$(TARGET_DIR)/var/www/config-motors.html
+	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/preview-motors.js \
+		$(TARGET_DIR)/var/www/a/preview-motors.js
+	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/preview-motors-settings.js \
+		$(TARGET_DIR)/var/www/a/preview-motors-settings.js
+	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/preview-motors.css \
+		$(TARGET_DIR)/var/www/a/preview-motors.css
+	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/config-motors.js \
+		$(TARGET_DIR)/var/www/a/config-motors.js
+	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/www/motors-ui/json-motor.cgi \
+		$(TARGET_DIR)/var/www/x/json-motor.cgi
+	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/www/motors-ui/json-motor-params.cgi \
+		$(TARGET_DIR)/var/www/x/json-motor-params.cgi
+	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/www/motors-ui/json-motors-config.cgi \
+		$(TARGET_DIR)/var/www/x/json-motors-config.cgi
+	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/motors.webui.json \
+		$(TARGET_DIR)/var/www/a/plugins/motors.webui.json
+endef
+TARGET_FINALIZE_HOOKS := TIMPS_REAPPLY_MOTORS_UI $(TARGET_FINALIZE_HOOKS)
+endif
+
 # libstdc++.so is 2130 KB and, once timps links the C++ runtime statically and
 # libaudioprocess-neo replaces the proprietary (C++) libaudioProcess.so, has no
 # consumer left. Verify that before removing: NEEDED scan only, so this cannot


### PR DESCRIPTION
## Summary
- Reapplies thingino-motors' joystick UI (preview overlay, CSS, sensitivity slider, CGIs, manifest) from `package/timps` at target-finalize, before `thingino-webui`'s plugin assembly runs — same prepend-onto-`TARGET_FINALIZE_HOOKS` trick `TIMPS_REAPPLY_WEBUI_OVERLAY` already uses for timps's own preview page.
- Only takes effect when `BR2_PACKAGE_THINGINO_MOTORS` is on. `motorsWs` stays `false` in the shipped manifest — this carries the UI over the existing CGI transport only, no new daemon behavior.
- No change to `package/thingino-motors` itself.

## Why
A WebSocket PTZ control path exists on a fork (not part of this PR) and needs its own separate proposal. Independently of that, the joystick UI/CSS/sensitivity-slider work that ships with it is generic - it works fine over the plain CGI path `thingino-motors` already has, and shouldn't wait on the WS discussion to reach users. This PR carries just that part, self-contained inside `package/timps`.

## Test plan
- [x] `make ... -n timps-build` dry-run clean
- [x] `printvars VARS="TARGET_FINALIZE_HOOKS"` confirms `TIMPS_REAPPLY_MOTORS_UI` runs ahead of `THINGINO_WEBUI_ASSEMBLE_PLUGINS`
- [ ] Full build + flash test on a PTZ camera (pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)