### PR TITLE
package/timps: sync package to current state

### DIFF
--- a/package/thingino-motors/files/www/x/json-motor.cgi
+++ b/package/thingino-motors/files/www/x/json-motor.cgi
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck disable=SC1091,SC2046,SC2329,SC3043
+# shellcheck disable=SC1091,SC2046,SC2317,SC2329,SC3043
 
 # Check authentication
 . /var/www/x/auth.sh

--- a/package/thingino-motors/files/www/x/json-motor.cgi
+++ b/package/thingino-motors/files/www/x/json-motor.cgi
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck disable=SC1091,SC2046,SC2317,SC2329,SC3043
+# shellcheck disable=SC1091,SC2046,SC2329,SC3043
 
 # Check authentication
 . /var/www/x/auth.sh

--- a/package/timps/Config.in
+++ b/package/timps/Config.in
@@ -99,8 +99,14 @@ config BR2_PACKAGE_TIMPS_TLS
 	select BR2_PACKAGE_MBEDTLS
 	help
 	  Enable mbedTLS for HTTPS (HTTP preview port) and RTSPS (RTSP
-	  over TLS on port 322). Requires TLS certificates at
-	  /etc/ssl/certs/httpd.crt and /etc/ssl/private/httpd.key.
+	  over TLS on port 322). Certificates come from the paths in
+	  timps.conf (http.tls_cert / http.tls_key, default
+	  /etc/ssl/certs/timps.crt and /etc/ssl/private/timps.key).
+	  S95timps sets them up before timpsd starts: on an image with
+	  the web UI it symlinks them to uhttpd's own certificate, so
+	  :443 and the preview port present the same cert to the browser
+	  (self-signed trust is per host+PORT); otherwise it generates a
+	  self-signed pair.
 
 config BR2_PACKAGE_TIMPS_SRT
 	bool "SRT output (libsrt)"
@@ -112,7 +118,7 @@ config BR2_PACKAGE_TIMPS_SRT
 
 config BR2_PACKAGE_TIMPS_OSD_HINTING
 	bool "OSD text autohinting (geometric stem snapping)"
-	default y
+	default n
 	help
 	  Enable the opt-in geometric autohinting pass in the TTF rasterizer
 	  (msttf.c), which snaps long, near-vertical/near-horizontal glyph
@@ -182,6 +188,58 @@ config BR2_PACKAGE_TIMPS_BC_AAC
 	  libhelix-aac (the same decoder prudynt uses). Better audio quality
 	  than G.711 but higher latency and an extra dependency. Leave off
 	  for a G.711-only, dependency-light backchannel.
+
+config BR2_PACKAGE_TIMPS_BC_WS
+	bool "Browser-microphone backchannel (WebSocket talk endpoint)"
+	depends on BR2_PACKAGE_TIMPS_BACKCHANNEL
+	depends on BR2_PACKAGE_TIMPS_TLS
+	depends on BR2_PACKAGE_TIMPS_CONTROL
+	default n
+	help
+	  Serve the audio backchannel to a browser over a WebSocket at
+	  wss://<camera>:<http_port>/talk, in addition to the ONVIF/RTSP
+	  path the backchannel already offers. The page captures the
+	  visitor's microphone with getUserMedia(), encodes G.711 mu-law
+	  in an AudioWorklet and sends 20 ms binary frames; timps decodes
+	  them with the G.711 decoder it already has and hands the PCM to
+	  the same IMP_AO speaker path the RTSP backchannel uses.
+
+	  A browser cannot speak RTSP/RTP, so without this the backchannel
+	  is reachable only from an ONVIF client or an NVR.
+
+	  Enabling this compiles three extra source files into timpsd (the
+	  RFC 6455 framing, SHA-1, and the talk endpoint itself) and costs
+	  roughly 8KB of text. No new library: the framing rides on the
+	  connection httpd.c has already TLS-terminated, and mu-law decode
+	  is the pure-C g711.c that the backchannel already builds.
+
+	  TLS is a hard requirement, not a preference: getUserMedia() is
+	  refused outside a secure context, so a plain-http:// preview page
+	  can never obtain a microphone to send. Hence "depends on
+	  BR2_PACKAGE_TIMPS_TLS" rather than a runtime warning.
+
+	  The control endpoint is an equally hard requirement, for the
+	  auth story: a browser's WebSocket constructor cannot set request
+	  headers, so the ONLY credential it can present is the per-boot
+	  ?token= that /events already relies on - and the whole token
+	  machinery (http_header, http_check_token, http_cors, and the
+	  tok_ok that unlocks the global auth gate) is compiled only under
+	  the control endpoint. Without it this endpoint still builds, but
+	  every browser reaching it on a camera that HAS credentials
+	  configured gets a 401 demanding Digest or Basic, which a
+	  WebSocket cannot answer. Hence "depends on
+	  BR2_PACKAGE_TIMPS_CONTROL" rather than a silently unreachable
+	  endpoint.
+
+	  mbedTLS is NOT selected here. BR2_PACKAGE_TIMPS_TLS already
+	  carries "select BR2_PACKAGE_MBEDTLS", so depending on that symbol
+	  transitively guarantees the library; adding a second select for
+	  the same package is what produced the "recursive dependency
+	  detected" breakage documented in thingino-motors' WS_TLS option,
+	  where kconfig responded by silently ignoring defaults.
+
+	  Gated at runtime by audio.talk_ws in timps.conf (default 0,
+	  restart-required), so turning this on is not a one-way door.
 
 config BR2_PACKAGE_TIMPS_PLAY
 	bool "System-sound play queue (/usr/sbin/play)"

--- a/package/timps/README.md
+++ b/package/timps/README.md
@@ -120,6 +120,14 @@ and `/a/preview-motors.js` are contributed by `thingino-motors`' own manifest
 via the marker above (no hand-copied markup in this package), so PTZ via
 `/x/json-motor.cgi` keeps working.
 
+**WebSocket PTZ:** a timps build with PTZ hardware also has the option of
+a WebSocket-based control path for `thingino-motors` (`ws://`/`wss://`,
+replacing per-move CGI round trips with a persistent socket) instead of
+the CGI-only path above. That daemon and its Kconfig option
+(`BR2_PACKAGE_THINGINO_MOTORS_WS`) live only on
+<https://github.com/Lu-Fi/thingino-firmware> (branch `ciao`) for now, not
+in this tree — build from there if you want it.
+
 The motion-grid overlay (`/a/preview-motion.js`) gets the per-boot token
 from `/x/timps-token.cgi`, probes `GET /control` once (feature detection +
 initial state) and then **subscribes** to

--- a/package/timps/files/S95timps
+++ b/package/timps/files/S95timps
@@ -14,14 +14,52 @@ conf_get() {
 		head -n1
 }
 
-# If TLS is requested but the cert/key are missing, generate a self-signed pair
-# so timpsd doesn't fail to bind the HTTPS/RTSPS listener on first boot.
+# The WebUI's own cert, written by thingino-uhttpd's S02ssl (which runs long
+# before this script). Absent on images built without the WebUI.
+UHTTPD_CRT=/etc/ssl/certs/uhttpd.crt
+UHTTPD_KEY=/etc/ssl/private/uhttpd.key
+
+# Make sure a usable cert/key pair exists before timpsd starts, so it can bind
+# the HTTPS/RTSPS listener on first boot. Priority:
+#
+#   1. whatever http.tls_cert/http.tls_key already point at, if both are
+#      non-empty - an operator-supplied cert is never second-guessed;
+#   2. else the WebUI's certificate, by symlink;
+#   3. else a freshly generated self-signed pair at the configured path.
+#
+# Step 2 is the important one and it is not cosmetic. A browser tracks trust
+# for a self-signed cert per ORIGIN - scheme+host+PORT - so the WebUI on :443
+# and timps on :8880 are two separate trust decisions even on the same camera.
+# The WebUI's cert gets trusted implicitly the first time someone clicks
+# through the warning on a top-level navigation; timps' never does, because the
+# preview reaches :8880 from JavaScript, and Safari (iOS especially) offers no
+# click-through for a fetch()/XHR failure at all - the preview just reports
+# "Load failed" with nothing the user can do about it. Presenting the IDENTICAL
+# certificate on both ports makes the one trust decision cover both.
+#
+# Symlink rather than copy: S02ssl regenerates uhttpd's cert whenever it is
+# missing (e.g. after a flash), and a copy taken once would silently go stale
+# and desynchronise the two ports again - which is the exact bug this avoids.
 ensure_tls_certs() {
 	[ "$(conf_get http.https)" = "1" ] || [ "$(conf_get rtsp.tls)" = "1" ] || return 0
 	crt=$(conf_get http.tls_cert)
 	key=$(conf_get http.tls_key)
 	[ -n "$crt" ] && [ -n "$key" ] || return 0
 	[ -s "$crt" ] && [ -s "$key" ] && return 0
+
+	# `-s` follows symlinks, so this also re-links a dangling one.
+	if [ "$crt" != "$UHTTPD_CRT" ] && [ "$key" != "$UHTTPD_KEY" ] &&
+		[ -s "$UHTTPD_CRT" ] && [ -s "$UHTTPD_KEY" ]; then
+		mkdir -p "$(dirname "$crt")" "$(dirname "$key")"
+		if ln -sf "$UHTTPD_CRT" "$crt" && ln -sf "$UHTTPD_KEY" "$key"; then
+			logger -t timps "TLS: sharing the web UI certificate ($UHTTPD_CRT)"
+			return 0
+		fi
+		# a half-made link would leave timpsd with a cert and no key
+		rm -f "$crt" "$key"
+		logger -t timps "TLS: could not link $UHTTPD_CRT, generating our own"
+	fi
+
 	[ -x /usr/bin/generate-timps-tls-certs.sh ] || return 0
 	# a failure must reach syslog: without the cert every TLS bind fails
 	out=$(/usr/bin/generate-timps-tls-certs.sh "$crt" "$key" 2>&1) ||

--- a/package/timps/files/generate-tls-certs.sh
+++ b/package/timps/files/generate-tls-certs.sh
@@ -4,9 +4,16 @@
 #
 # Usage: generate-timps-tls-certs.sh [cert_path] [key_path]
 # Defaults match timps.conf (http.tls_cert / http.tls_key).
+#
+# This is a plain generator; it does NOT decide WHICH certificate timps should
+# use. S95timps' ensure_tls_certs() owns that policy and prefers the thingino
+# web UI's own /etc/ssl/certs/uhttpd.crt where it exists (so :443 and :8880
+# present the identical cert to the browser), calling this script only for
+# images that have no web UI - hence the timps-own default paths below rather
+# than a uhttpd-named one, which would be a lie on exactly those images.
 
-CERT="${1:-/etc/ssl/certs/httpd.crt}"
-KEY="${2:-/etc/ssl/private/httpd.key}"
+CERT="${1:-/etc/ssl/certs/timps.crt}"
+KEY="${2:-/etc/ssl/private/timps.key}"
 
 mkdir -p "$(dirname "$CERT")" "$(dirname "$KEY")"
 

--- a/package/timps/files/timps.conf
+++ b/package/timps/files/timps.conf
@@ -70,9 +70,19 @@ http.token       =
 http.token_file  = /run/timps.token
 
 # ---- optional TLS: HTTPS + RTSPS (USE_TLS builds, mbedTLS) ----
+# S95timps makes sure this pair exists before timpsd starts. On an image with
+# the thingino web UI it SYMLINKS both to the web UI's own certificate
+# (/etc/ssl/certs/uhttpd.crt, from thingino-uhttpd's S02ssl) so that :443 and
+# this port present the IDENTICAL certificate: a browser trusts a self-signed
+# cert per origin (host+PORT), and Safari gives fetch()/XHR no click-through
+# at all, so a second cert here makes the WebUI preview fail with a bare
+# "Load failed" for anyone who only ever trusted the web UI's. Without a web UI
+# in the image, a timps-own self-signed pair is generated at these paths
+# instead. Point them at a real cert to use your own - an existing, non-empty
+# pair is always left alone.
 # http.https    = 1                       # serve the HTTP port over TLS
-http.tls_cert   = /etc/ssl/certs/httpd.crt
-http.tls_key    = /etc/ssl/private/httpd.key
+http.tls_cert   = /etc/ssl/certs/timps.crt
+http.tls_key    = /etc/ssl/private/timps.key
 # rtsp.tls      = 1                       # additionally run an RTSPS listener
 # rtsp.tls_port = 322                     # RTSPS port
 

--- a/package/timps/files/timps.webui.json
+++ b/package/timps/files/timps.webui.json
@@ -82,7 +82,15 @@
           "label": "Restart streamer",
           "href": "/x/restart-prudynt.cgi",
           "className": "text-danger confirm",
-          "trackActive": false
+          "trackActive": false,
+          "action": true,
+          "confirm": {
+            "title": "Restart streamer",
+            "message": "Restart the timps streamer? The video stream will be interrupted for a few seconds.",
+            "confirmLabel": "Restart"
+          },
+          "actionPendingMessage": "Restarting streamer…",
+          "actionMessage": "Streamer restart initiated"
         }
       ]
     },

--- a/package/timps/files/www/a/preview-motion.js
+++ b/package/timps/files/www/a/preview-motion.js
@@ -13,6 +13,8 @@
   "use strict";
 
   const POLL_MS = 250; // fallback poll rate, ~4 Hz
+  const POLL_MAX_BACKOFF_MS = 8000;  // ceiling once polls start failing
+  const PROBE_MAX_BACKOFF_MS = 30000; // ceiling for the initial capability probe
   const ES_MAX_ERRORS = 4; // consecutive EventSource errors before fallback
   const video = document.getElementById("ms-video");
   const canvas = document.getElementById("motion-overlay");
@@ -28,19 +30,37 @@
   let busy = false;
   let last = null;   // last motion status object (or null)
   let on = sessionStorage.getItem("ms.motionOverlay") !== "0";
+  let pollFails = 0;    // consecutive failed polls, drives the poll backoff
+  let nextPollAt = 0;   // performance.now() before which tick() stays quiet
+  let btnShown = null;  // null = never applied, so the first call always runs
+  let stopped = false;  // set on pagehide; stops the probe retry loop
 
   function setBtn() {
     btn.classList.toggle("active", on);
     btn.title = on ? "Hide motion grid overlay" : "Show motion grid overlay";
   }
 
-  /* displayed content rect of the object-fit:contain video inside its box */
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  // gate on available && enabled; timps pushes a motion event on both the
+  // enable and disable transition, so this stays live off the open stream.
+  function applyAvailability(st) {
+    const usable = !!(st && st.available && st.enabled);
+    if (usable === btnShown) return;
+    btnShown = usable;
+    btn.style.display = usable ? "" : "none";
+    if (usable) setBtn();
+    else clear();
+  }
+
+  // displayed content rect of the object-fit:contain video inside its box;
+  // real-time mode's <video> has no metadata, so fall back to window.msPreviewSize
   function contentRect() {
-    // measure the display box from the (always-visible) video, falling back to
-    // the canvas; never rely on the canvas alone (it may still be display:none)
     const bw = video.clientWidth || canvas.clientWidth;
     const bh = video.clientHeight || canvas.clientHeight;
-    const vw = video.videoWidth, vh = video.videoHeight;
+    const rt = window.msPreviewSize;
+    const vw = video.videoWidth || (rt ? rt.w : 0);
+    const vh = video.videoHeight || (rt ? rt.h : 0);
     if (!bw || !bh) return null;
     if (!vw || !vh) return { x: 0, y: 0, w: bw, h: bh }; // no metadata yet
     const scale = Math.min(bw / vw, bh / vh);
@@ -53,10 +73,7 @@
     if (rafId != null) { cancelAnimationFrame(rafId); rafId = null; }
   }
 
-  /* motion "afterglow": timps reports a cell active only on the frame it moved,
-   * then clears it, so raw highlights just flicker. Remember when each cell was
-   * last active and keep drawing it - fading out over HOLD_MS - so movement is
-   * actually visible. A rAF loop animates the fade between motion events. */
+  // afterglow: a cell is only reported active for one frame, so hold and fade it
   const HOLD_MS = 1200;
   let holds = null;   // Float64Array: last-active timestamp per cell
   let holdN = 0;
@@ -166,13 +183,22 @@
     if (document.hidden) return;
     if (!on) { clear(); return; }
     if (busy) return;
+    // honour the backoff set by a previous failure
+    if (performance.now() < nextPollAt) return;
     busy = true;
     try {
       last = await poll();
+      pollFails = 0;
+      nextPollAt = 0;
     } catch (e) {
-      last = null; // endpoint gone (streamer restart?): hide, keep trying
+      // back off instead of hammering a failing endpoint at a flat 4Hz
+      pollFails++;
+      nextPollAt = performance.now() +
+        Math.min(POLL_MAX_BACKOFF_MS, POLL_MS * Math.pow(2, pollFails));
+      last = null;
     }
     busy = false;
+    applyAvailability(last);
     noteActive(last);
     ensureAnim();
   }
@@ -203,14 +229,14 @@
       } catch (err) {
         last = null;
       }
+      // carries available/enabled: a live motion on/off lands here
+      applyAvailability(last);
       noteActive(last);
       ensureAnim();
     });
     es.onopen = () => { esErrors = 0; };
     es.onerror = () => {
-      // EventSource reconnects on its own (server retry: 3000); only give
-      // up for good - old timpsd without /events, events.enabled=0 - after
-      // several consecutive failures without a single event in between
+      // give up for good only after several consecutive failures
       esErrors++;
       if (esErrors >= ES_MAX_ERRORS || (es && es.readyState === EventSource.CLOSED)) {
         fellBack = true;
@@ -251,18 +277,29 @@
     if (host.indexOf(":") >= 0 && host[0] !== "[") host = "[" + host + "]"; // raw IPv6
     base = (info.tls ? "https" : "http") + "://" + host + ":" + (info.port || 8880);
 
-    // probe once: only offer the overlay when this build HAS motion support
-    let st;
-    try {
-      st = await poll();
-    } catch (e) {
-      return; // :8880 unreachable (HTTPS mixed content?) -> stay hidden
+    // Bind teardown before the probe below can start waiting on the network.
+    window.addEventListener("pagehide", () => {
+      stopped = true;
+      stopPush();
+      stopPoll();
+    });
+
+    // probe for motion support, retrying with backoff instead of giving up
+    // forever on one transient failure (pool full, cert not yet trusted)
+    let st = null;
+    for (let delay = 1000; !stopped; delay = Math.min(PROBE_MAX_BACKOFF_MS, delay * 2)) {
+      try {
+        st = await poll();
+        break;
+      } catch (e) {
+        await sleep(delay);
+      }
     }
-    if (!st || !st.available) return;
+    if (stopped || !st) return;
+    if (!st.available) return; // build-time property, permanent if absent
     last = st;
 
-    btn.style.display = "";
-    setBtn();
+    applyAvailability(last);
     draw(last);
     btn.addEventListener("click", () => {
       on = !on;
@@ -281,10 +318,7 @@
       if (document.hidden) pause();
       else resume();
     });
-    window.addEventListener("pagehide", () => {
-      stopPush();
-      stopPoll();
-    });
+    // teardown is already bound above, before the probe
   }
 
   init();

--- a/package/timps/files/www/a/preview-talk.js
+++ b/package/timps/files/www/a/preview-talk.js
@@ -1,0 +1,345 @@
+/* preview-talk.js - push-to-talk (browser microphone -> camera speaker) for the
+ * timps preview page.
+ *
+ * Captures the visitor's microphone, encodes it as G.711 mu-law and streams
+ * 20 ms binary frames over a WebSocket to timps' /talk endpoint, which decodes
+ * them straight into the same IMP_AO speaker path the ONVIF/RTSP backchannel
+ * uses. A browser cannot speak RTSP/RTP, which is the whole reason this
+ * transport exists.
+ *
+ * Fails soft throughout, exactly like preview-motion.js: no token, no HTTPS, or
+ * a build without the endpoint just leaves the button hidden. The button is
+ * HIDDEN rather than disabled - a greyed control invites "why doesn't this
+ * work", a missing one asks nothing.
+ *
+ * Requires all four of:
+ *   - caps.backchannel.talk_ws == 1 from GET /control (feature compiled AND
+ *     audio.talk_ws set AND the backchannel pipeline up at boot)
+ *   - a TLS timps listener: getUserMedia() is refused outside a secure
+ *     context, and a wss:// URL is the only thing an https:// page may open
+ *   - navigator.mediaDevices.getUserMedia
+ *   - AudioContext with createScriptProcessor
+ *
+ * ScriptProcessorNode is deprecated in favour of AudioWorklet and runs on the
+ * main thread, so it can glitch under heavy page load. That is a deliberate
+ * first-cut choice: a worklet processor's exceptions are swallowed on the
+ * audio render thread with no console trace, which is a poor place to be while
+ * the C side of this protocol is also new. Revisit once /talk has real miles.
+ */
+(function () {
+  "use strict";
+
+  const btn = document.getElementById("ms-talk");
+  const statusEl = document.getElementById("ms-talk-status");
+  if (!btn) return;
+
+  const FRAME_MS = 20;
+  /* Must not exceed WS_MAX_PAYLOAD in timps' src/ws.h. One mu-law byte per
+   * sample, so 20 ms at 48 kHz = 960 bytes is the largest frame we can emit
+   * and still fit. Every rate in RATES_OK stays under this. */
+  const WS_MAX_PAYLOAD = 1024;
+  /* Sample rates timps' talk_ws.c accepts via ?rate= (TALK_RATES there). Kept
+   * in sync by hand; an unlisted rate is refused with 400 by the server, so
+   * checking here just turns a mystery failure into a readable message. */
+  const RATES_OK = [8000, 16000, 24000, 32000, 44100, 48000];
+  /* Client-side backpressure. The server has its own drop-if-behind guard, but
+   * there is no point handing the socket audio it cannot drain: past this much
+   * queued, drop frames here instead. ~10 frames = 200 ms. */
+  const MAX_BUFFERED = 10 * WS_MAX_PAYLOAD;
+  const PROBE_MAX_BACKOFF_MS = 30000;
+
+  let base = null;    // https://<host>:<port>
+  let wsBase = null;  // wss://<host>:<port>
+  let token = null;
+  let stopped = false; // set on pagehide; stops the probe retry loop
+
+  // live session state, all null/idle between presses
+  let ws = null, ctx = null, spn = null, src = null, sink = null, mic = null;
+  let state = "idle"; // idle | connecting | talking | error
+  let pending = null, pendN = 0, frameSamples = 0;
+  let errTimer = null;
+
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+  function say(msg, isErr) {
+    if (!statusEl) { if (isErr) console.warn("[talk] " + msg); return; }
+    if (errTimer) { clearTimeout(errTimer); errTimer = null; }
+    statusEl.textContent = msg || "";
+    statusEl.style.display = msg ? "" : "none";
+    statusEl.classList.toggle("text-danger", !!isErr);
+    // errors are transient notices, not a permanent banner
+    if (msg && isErr) errTimer = setTimeout(() => say(""), 6000);
+  }
+
+  function setBtn() {
+    const on = state === "talking" || state === "connecting";
+    btn.classList.toggle("active", on);
+    btn.classList.toggle("btn-danger", state === "talking");
+    btn.classList.toggle("btn-outline-secondary", state !== "talking");
+    btn.disabled = state === "connecting";
+    btn.title = state === "talking" ? "Stop talking"
+              : state === "connecting" ? "Connecting the talk channel..."
+              : "Talk to the camera (microphone -> camera speaker)";
+  }
+
+  /* Reveal the control. Unlike preview-motion.js this is one-way: motion can be
+   * switched on and off live, so that module re-hides its button off the event
+   * stream, but audio.talk_ws is restart-only - once /control says the endpoint
+   * is being served, it is served for the life of this page. */
+  function showBtn() {
+    btn.style.display = "";
+    setBtn();
+  }
+
+  /* float [-1,1] -> G.711 mu-law byte. The exact inverse of g711_ulaw_decode()
+   * in timps' src/codec/g711.c (Sun/CCITT), so what the camera reconstructs is
+   * what we sampled. No table: ~10 integer ops per sample is cheaper than the
+   * cache miss, and this runs on the main thread. */
+  function ulawEncode(f) {
+    let s = (f < -1 ? -1 : f > 1 ? 1 : f) * 32767 | 0;
+    const sign = (s >> 8) & 0x80;
+    if (sign) s = -s;
+    if (s > 32635) s = 32635;      // CLIP
+    s += 132;                      // BIAS 0x84
+    let exp = 7;
+    for (let m = 0x4000; (s & m) === 0 && exp > 0; m >>= 1) exp--;
+    const mant = (s >> (exp + 3)) & 0x0F;
+    return ~(sign | (exp << 4) | mant) & 0xFF;
+  }
+
+  /* ScriptProcessorNode wants a power-of-two buffer (256..16384). Target ~30 ms
+   * so latency stays low without making main-thread glitches likely: 256 at
+   * 8 kHz (32 ms), 1024 at 48 kHz (21 ms). */
+  function bufSizeFor(rate) {
+    let n = 256;
+    while (n < 16384 && n * 2 <= rate * 0.03) n *= 2;
+    return n;
+  }
+
+  function teardown() {
+    // stop producing before closing the socket, so no frame races the close
+    if (spn) { try { spn.disconnect(); } catch (e) {} spn.onaudioprocess = null; spn = null; }
+    if (src) { try { src.disconnect(); } catch (e) {} src = null; }
+    if (sink) { try { sink.disconnect(); } catch (e) {} sink = null; }
+    if (mic) { try { mic.getTracks().forEach((t) => t.stop()); } catch (e) {} mic = null; }
+    if (ctx) { try { ctx.close(); } catch (e) {} ctx = null; }
+    pending = null; pendN = 0; frameSamples = 0;
+  }
+
+  /* Always the client-initiated path: a real close frame (1000) makes timps'
+   * ws_read_message() return WS_CLOSED immediately, so talk_ws.c runs
+   * bc_release() and drops the speaker now instead of after its 10 s
+   * stale-owner timeout. Abandoning the socket would "work" but leave the
+   * camera's speaker owned by a session that is already gone. */
+  function stop(msg, isErr) {
+    teardown();
+    if (ws) {
+      const w = ws;
+      ws = null;
+      w.onopen = w.onmessage = w.onerror = w.onclose = null;
+      try {
+        if (w.readyState === WebSocket.OPEN || w.readyState === WebSocket.CONNECTING)
+          w.close(1000, "bye");
+      } catch (e) {}
+    }
+    // Errors are surfaced by say() as transient red text, not by a stuck
+    // button: the control goes straight back to idle so it can be retried.
+    state = "idle";
+    setBtn();
+    say(msg || "", isErr);
+  }
+
+  function flushFrames() {
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    while (pendN >= frameSamples) {
+      if (ws.bufferedAmount > MAX_BUFFERED) {
+        // socket is not draining: drop everything queued rather than grow a
+        // backlog the listener would hear as ever-increasing delay
+        pendN = 0;
+        return;
+      }
+      ws.send(pending.subarray(0, frameSamples));
+      pending.copyWithin(0, frameSamples, pendN);
+      pendN -= frameSamples;
+    }
+  }
+
+  async function start() {
+    state = "connecting";
+    setBtn();
+    say("Requesting microphone...");
+
+    try {
+      mic = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          // The camera has its own AEC (audio.aec / IMP_AI_EnableAec) for the
+          // far end; this is the near-end half - it stops the camera's own
+          // audio, playing out of these speakers, from being sent back.
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+          channelCount: 1,
+        },
+      });
+    } catch (e) {
+      stop("Microphone denied or unavailable.", true);
+      return;
+    }
+    if (stopped) { stop(""); return; }
+
+    // Ask for 8 kHz (mu-law's native rate, 64 kbit/s on the wire). Browsers may
+    // decline and impose the hardware rate - iOS Safari commonly forces 48 kHz
+    // - so the requested value is never assumed: read it back and tell the
+    // server what we actually got. timps resamples whatever it is handed.
+    const AC = window.AudioContext || window.webkitAudioContext;
+    try {
+      ctx = new AC({ sampleRate: 8000 });
+    } catch (e) {
+      try { ctx = new AC(); } catch (e2) { stop("No Web Audio support.", true); return; }
+    }
+    if (!ctx.createScriptProcessor) { stop("No Web Audio support.", true); return; }
+    // iOS starts contexts suspended; we are inside a click handler, so this is
+    // the one moment resuming is allowed.
+    try { await ctx.resume(); } catch (e) {}
+
+    const rate = Math.round(ctx.sampleRate);
+    if (RATES_OK.indexOf(rate) < 0) {
+      stop("Browser audio rate " + rate + " Hz is not supported by the camera.", true);
+      return;
+    }
+    frameSamples = Math.round((rate * FRAME_MS) / 1000);
+    if (frameSamples > WS_MAX_PAYLOAD) frameSamples = WS_MAX_PAYLOAD;
+    pending = new Uint8Array(frameSamples * 4);
+    pendN = 0;
+
+    const url = wsBase + "/talk?token=" + encodeURIComponent(token) + "&rate=" + rate;
+    try {
+      ws = new WebSocket(url);
+    } catch (e) {
+      stop("Cannot open the talk channel.", true);
+      return;
+    }
+    ws.binaryType = "arraybuffer";
+
+    ws.onopen = () => {
+      if (!ws) return;
+      state = "talking";
+      setBtn();
+      say("Talking - " + rate + " Hz");
+
+      const n = bufSizeFor(rate);
+      spn = ctx.createScriptProcessor(n, 1, 1);
+      src = ctx.createMediaStreamSource(mic);
+      // A ScriptProcessorNode only runs while it is connected to a
+      // destination, but routing the microphone to these speakers would be an
+      // instant feedback loop - so terminate it in a muted gain node.
+      sink = ctx.createGain();
+      sink.gain.value = 0;
+
+      spn.onaudioprocess = (ev) => {
+        if (!ws || ws.readyState !== WebSocket.OPEN) return;
+        const inBuf = ev.inputBuffer.getChannelData(0);
+        if (pendN + inBuf.length > pending.length) {
+          const grown = new Uint8Array((pendN + inBuf.length) * 2);
+          grown.set(pending.subarray(0, pendN));
+          pending = grown;
+        }
+        for (let i = 0; i < inBuf.length; i++) pending[pendN++] = ulawEncode(inBuf[i]);
+        flushFrames();
+      };
+
+      src.connect(spn);
+      spn.connect(sink);
+      sink.connect(ctx.destination);
+    };
+
+    ws.onmessage = (ev) => {
+      // talk_ws.c sends one hello: {"ok":1,"codec":"pcmu","rate":N}. Purely
+      // informational - it turns "no audio" into something diagnosable.
+      if (typeof ev.data !== "string") return;
+      try {
+        const j = JSON.parse(ev.data);
+        if (j && j.rate && j.rate !== rate)
+          console.warn("[talk] server negotiated " + j.rate + " Hz, we sent " + rate);
+      } catch (e) {}
+    };
+
+    ws.onerror = () => { if (ws) stop("Talk channel failed.", true); };
+
+    ws.onclose = (ev) => {
+      if (!ws) return; // our own stop() already cleaned up
+      // 1000 from the server side still means it ended this, not us
+      const why = ev.code === 1008 ? "Another talker holds the camera speaker."
+                : ev.code === 1001 ? "Talk channel timed out."
+                : "Talk channel closed (" + ev.code + ").";
+      stop(why, ev.code !== 1000);
+    };
+  }
+
+  function toggle() {
+    if (state === "connecting") return;
+    if (state === "talking") stop("");
+    else start();
+  }
+
+  async function probe() {
+    const res = await fetch(base + "/control", {
+      headers: { "X-Timps-Token": token },
+      cache: "no-store",
+    });
+    if (!res.ok) throw new Error("HTTP " + res.status);
+    const data = await res.json();
+    return !!(data && data.caps && data.caps.backchannel &&
+              data.caps.backchannel.talk_ws);
+  }
+
+  async function init() {
+    let info;
+    if (window.timpsTokenInfo) {
+      info = await window.timpsTokenInfo;   // shared single fetch (preview.html)
+    } else {
+      try {
+        const res = await fetch("/x/timps-token.cgi", { cache: "no-store" });
+        if (!res.ok) return;                // no bridge -> feature silently off
+        info = await res.json();
+      } catch (e) {
+        return;
+      }
+    }
+    if (!info || !info.token) return;
+    token = info.token;
+    let host = location.hostname || "127.0.0.1";
+    if (host.indexOf(":") >= 0 && host[0] !== "[") host = "[" + host + "]"; // raw IPv6
+    const port = info.port || 8880;
+    base = (info.tls ? "https" : "http") + "://" + host + ":" + port;
+    wsBase = "wss://" + host + ":" + port;
+
+    window.addEventListener("pagehide", () => { stopped = true; stop(""); });
+
+    // Hard gates, all permanent for this page load - no point probing without
+    // them. /talk answers 426 on a plaintext listener, and getUserMedia is
+    // undefined outside a secure context, so either one means "never".
+    if (!info.tls) return;
+    if (!window.WebSocket) return;
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) return;
+    if (!(window.AudioContext || window.webkitAudioContext)) return;
+
+    // Retry the capability probe with backoff rather than giving up forever on
+    // one transient failure (client pool full, cert not yet trusted).
+    let usable = false;
+    for (let delay = 1000; !stopped; delay = Math.min(PROBE_MAX_BACKOFF_MS, delay * 2)) {
+      try {
+        usable = await probe();
+        break;
+      } catch (e) {
+        await sleep(delay);
+      }
+    }
+    if (stopped || !usable) return;
+
+    showBtn();
+    btn.addEventListener("click", toggle);
+  }
+
+  init();
+})();

--- a/package/timps/files/www/motors-ui/config-motors.html
+++ b/package/timps/files/www/motors-ui/config-motors.html
@@ -1,0 +1,204 @@
+<!DOCTYPE html>
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Pan/Tilt Motors</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+</head>
+
+<body id="page-config-motors">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container" style="min-height:80vh">
+    <div data-app-controls></div>
+
+    <section>
+      <form id="motors-form" class="needs-validation" novalidate autocomplete="off">
+
+        <div class="card mb-3">
+          <div class="card-header">
+            <h2 class="card-title">Pan/Tilt Motors</h2>
+            <small>Match the driver sequence A → B → C → D for both axes. Requires reboot after changes.</small>
+            <span id="motors-type-badge"></span>
+            <span id="motors-version-badge"></span>
+            <button type="button" class="btn btn-outline-secondary" id="motors-reload" title="Reload values from camera">
+              <i class="bi bi-arrow-clockwise"></i> Reload
+            </button>
+          </div><!-- .card-header -->
+          <div class="card-body">
+            <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-4 mb-3">
+              <div class="col">
+                <h4>Pan motor GPIO</h4>
+                <small>Driver pins for horizontal motion</small>
+
+                <div class="row row-cols-2 row-cols-sm-4 g-1">
+                  <p class="col"><label for="gpio_pan_1">GPIO 1</label>
+                    <input type="number" class="form-control" id="gpio_pan_1" name="gpio_pan_1" min="0" placeholder="e.g. 55"></p>
+                  <p class="col"><label for="gpio_pan_2">GPIO 2</label>
+                    <input type="number" class="form-control" id="gpio_pan_2" name="gpio_pan_2" min="0" placeholder="e.g. 56"></p>
+                  <p class="col"><label for="gpio_pan_3">GPIO 3</label>
+                    <input type="number" class="form-control" id="gpio_pan_3" name="gpio_pan_3" min="0" placeholder="e.g. 57"></p>
+                  <p class="col"><label for="gpio_pan_4">GPIO 4</label>
+                    <input type="number" class="form-control" id="gpio_pan_4" name="gpio_pan_4" min="0" placeholder="e.g. 58"></p>
+                </div><!-- .row -->
+                <button type="button" class="btn btn-outline-secondary flip_motor mt-2" data-direction="pan" title="Reverse pin order">
+                  <i class="bi bi-arrow-left-right"></i> Flip
+                </button>
+
+                <p>
+                  <label for="steps_pan">Max steps</label>
+                  <input type="number" class="form-control" id="steps_pan" name="steps_pan" min="1" placeholder="1024">
+                </p>
+                <p>
+                  <label for="speed_pan">Speed</label>
+                  <input type="number" class="form-control" id="speed_pan" name="speed_pan" min="1" placeholder="1200">
+                </p>
+
+              </div><!-- .col -->
+              <div class="col">
+
+                <h4>Tilt motor GPIO</h4>
+                <small>Driver pins for vertical motion</small>
+
+                <div class="row row-cols-2 row-cols-sm-4 g-1">
+                  <p class="col">
+                    <label for="gpio_tilt_1">GPIO 1</label>
+                    <input type="number" class="form-control" id="gpio_tilt_1" name="gpio_tilt_1" min="0" placeholder="e.g. 59">
+                  </p>
+                  <p class="col">
+                    <label for="gpio_tilt_2">GPIO 2</label>
+                    <input type="number" class="form-control" id="gpio_tilt_2" name="gpio_tilt_2" min="0" placeholder="e.g. 60">
+                  </p>
+                  <p class="col">
+                    <label for="gpio_tilt_3">GPIO 3</label>
+                    <input type="number" class="form-control" id="gpio_tilt_3" name="gpio_tilt_3" min="0" placeholder="e.g. 61">
+                  </p>
+                  <p class="col">
+                    <label for="gpio_tilt_4">GPIO 4</label>
+                    <input type="number" class="form-control" id="gpio_tilt_4" name="gpio_tilt_4" min="0" placeholder="e.g. 62">
+                  </p>
+                </div>
+                <button type="button" class="btn btn-outline-secondary flip_motor mt-2" data-direction="tilt" title="Reverse pin order">
+                  <i class="bi bi-arrow-left-right"></i> Flip
+                </button>
+                <p>
+                  <label for="steps_tilt">Max steps</label>
+                  <input type="number" class="form-control" id="steps_tilt" name="steps_tilt" min="1" placeholder="512">
+                </p>
+                <p>
+                  <label for="speed_tilt">Speed</label>
+                  <input type="number" class="form-control" id="speed_tilt" name="speed_tilt" min="1" placeholder="800">
+                </p>
+              </div><!-- .col -->
+              <div class="col">
+                <h4>Behavior</h4>
+                <small>Startup pose and homing logic.</small>
+
+                <p>
+                  <label for="motion_driver">Motion driver</label>
+                  <select class="form-select" id="motion_driver" name="motion_driver">
+                    <option value="legacy">Legacy (kernel-native)</option>
+                    <option value="profiled">Profiled (accel/decel ramping)</option>
+                  </select>
+                </p>
+
+                <p id="motion-driver-help" class="alert alert-secondary small mb-2">
+                  Legacy mode uses the stock kernel movement path. Profiled mode enables acceleration/deceleration ramping in motors-daemon.
+                </p>
+
+                <p>
+                  <label for="preview_control_mode">Preview PTZ controls</label>
+                  <select class="form-select" id="preview_control_mode" name="preview_control_mode">
+                    <option value="step">Step move (click / double-click)</option>
+                    <option value="continuous">Continuous move (press and hold)</option>
+                    <option value="joystick">Analog joystick (drag to steer, further = faster)</option>
+                  </select>
+                  <small class="text-secondary">Applies to motor controls in the preview overlay.</small>
+                </p>
+
+                <div id="joystick-sensitivity-field">
+                  <label for="joystick_sensitivity">Joystick centre sensitivity
+                    <span id="joystick_sensitivity-value" class="text-secondary"></span></label>
+                  <input type="range" class="form-range" id="joystick_sensitivity" name="joystick_sensitivity"
+                    min="0.05" max="4" step="0.05" value="2">
+                  <small class="text-secondary">Below 1.00 reacts faster to small movements near the stick's centre and reaches full speed sooner. Above 1.00 does the opposite - the centre is less sensitive, for finer close-up framing. 1.00 is a straight linear response. Takes effect immediately, no reboot.</small>
+                </div>
+
+                <div id="motion-accel-fields" class="d-flex gap-2">
+                  <p>
+                    <label for="accel_pan">Pan acceleration</label>
+                    <input type="number" class="form-control" id="accel_pan" name="accel_pan" min="0" placeholder="0">
+                  </p>
+                  <p>
+                    <label for="accel_tilt">Tilt acceleration</label>
+                    <input type="number" class="form-control" id="accel_tilt" name="accel_tilt" min="0" placeholder="0">
+                  </p>
+                </div>
+
+                <p class="alert alert-info small">During boot, the camera rotates to its minimum limits and zeroes both axes.</p>
+                <p class="form-switch">
+                  <input type="checkbox" class="form-check-input" id="homing" name="homing" value="true" data-help="Disable only when a fixed pose is required">
+                  <label for="homing">Perform homing on boot</label>
+                </p>
+                <div class="d-flex gap-2">
+                  <p>
+                    <label for="pos_0_x">Initial position X</label>
+                    <input type="number" class="form-control" id="pos_0_x" name="pos_0_x" placeholder="0">
+                  </p>
+                  <p>
+                    <label for="pos_0_y">Initial position Y</label>
+                    <input type="number" class="form-control" id="pos_0_y" name="pos_0_y" placeholder="0">
+                  </p>
+                </div>
+                <p class="alert alert-info small">The initial position is the first PTZ preset. Reorder presets below to change it.</p>
+                <a href="#" class="read-motors mb-3 d-block" title="Use current pose">Pick up the recent position</a>
+              </div><!-- .col -->
+            </div><!-- .row -->
+          </div><!-- .card-body -->
+        </div><!-- .card -->
+
+        <div class="card mb-3">
+          <div class="card-header">
+            <h2 class="card-title">PTZ Presets</h2>
+            <small>Save the current camera position and recall it with one click.</small>
+          </div>
+          <div class="card-body">
+            <div class="d-flex gap-2 mb-3">
+              <input type="text" class="form-control" id="ptz-preset-name" placeholder="Preset description, e.g. Front door" maxlength="64">
+              <button type="button" class="btn btn-outline-primary text-nowrap" id="ptz-preset-save" title="Save current position as a preset">
+                <i class="bi bi-plus-circle me-1"></i>Save position
+              </button>
+            </div>
+            <ul id="ptz-presets-list" class="list-group"></ul>
+            <small id="ptz-presets-empty" class="text-secondary d-block mt-2">No presets yet. Move the camera (preview overlay) and save a position above.</small>
+          </div>
+        </div>
+
+        <button type="submit" id="motors_submit" class="btn btn-primary"><i class="bi bi-save me-1"></i> Save changes</button>
+      </form>
+    </section>
+  </div>
+</main>
+
+<footer data-app-footer></footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="/a/config-motors.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/motors-ui/config-motors.js
+++ b/package/timps/files/www/motors-ui/config-motors.js
@@ -1,0 +1,670 @@
+(function () {
+  "use strict";
+
+  const motorsConfigEndpoint = "/x/json-motors-config.cgi";
+  const alertContainer = $("#motors-alerts");
+  const contentWrap = $("#motors-content");
+  const form = $("#motors-form");
+  const reloadButton = $("#motors-reload");
+  const submitButton = form
+    ? form.querySelector('button[type="submit"]')
+    : null;
+  const submitSpinner = submitButton
+    ? submitButton.querySelector(".spinner-border")
+    : null;
+  const submitLabel = submitButton
+    ? submitButton.querySelector(".label")
+    : null;
+  const submitDefaultText = submitLabel
+    ? submitLabel.textContent
+    : "Save motors";
+  const typeBadge = $("#motors-type-badge");
+  const versionBadge = $("#motors-version-badge");
+  let initialLoadComplete = false;
+  let motorIsSpi = false;
+
+  function normalizeMotionDriver(value) {
+    return value === "profiled" ? "profiled" : "legacy";
+  }
+
+  function escapeHtml(value) {
+    return String(value).replace(/[&<>"']/g, (ch) => ({
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#39;",
+    })[ch]);
+  }
+
+  function normalizePreviewControlMode(value) {
+    return value === "continuous" || value === "joystick" ? value : "step";
+  }
+
+  function updateMotionDriverInputs() {
+    const motionDriverEl = $("#motion_driver");
+    const accelWrap = $("#motion-accel-fields");
+    const help = $("#motion-driver-help");
+    const accelPan = $("#accel_pan");
+    const accelTilt = $("#accel_tilt");
+    if (!motionDriverEl) return;
+
+    const mode = normalizeMotionDriver(motionDriverEl.value);
+    const profiled = mode === "profiled";
+
+    if (accelWrap) {
+      accelWrap.classList.toggle("opacity-50", !profiled);
+    }
+    if (accelPan) {
+      accelPan.disabled = !profiled;
+      if (!profiled) accelPan.value = "0";
+    }
+    if (accelTilt) {
+      accelTilt.disabled = !profiled;
+      if (!profiled) accelTilt.value = "0";
+    }
+    if (help) {
+      if (profiled) {
+        help.className = "alert alert-info small mb-2";
+        help.textContent =
+          "Profiled mode active: acceleration fields control ramping in motors-daemon.";
+      } else {
+        help.className = "alert alert-secondary small mb-2";
+        help.textContent =
+          "Legacy mode active: acceleration values are ignored and saved as 0.";
+      }
+    }
+  }
+
+  function updateJoystickSensitivityInputs() {
+    const modeEl = $("#preview_control_mode");
+    const wrap = $("#joystick-sensitivity-field");
+    const slider = $("#joystick_sensitivity");
+    const valueLabel = $("#joystick_sensitivity-value");
+    if (!modeEl || !wrap) return;
+
+    const isJoystick = normalizePreviewControlMode(modeEl.value) === "joystick";
+    wrap.classList.toggle("opacity-50", !isJoystick);
+    if (slider) slider.disabled = !isJoystick;
+    if (valueLabel && slider) valueLabel.textContent = slider.value;
+  }
+
+  function showAlert(variant, message, timeout = 6000) {
+    if (!message) return;
+
+    // Use global alert system from main.js
+    if (window.showAlert && typeof window.showAlert === "function") {
+      window.showAlert(variant, message, timeout);
+      return;
+    }
+
+    // Fallback to local alert container if it exists
+    if (!alertContainer) return;
+    const alert = document.createElement("div");
+    alert.className = `alert alert-${variant || "secondary"} alert-dismissible fade show`;
+    alert.setAttribute("role", "alert");
+    alert.innerHTML = message;
+    const dismissBtn = document.createElement("button");
+    dismissBtn.type = "button";
+    dismissBtn.className = "btn-close";
+    dismissBtn.setAttribute("aria-label", "Close");
+    dismissBtn.addEventListener("click", () => alert.remove());
+    alert.appendChild(dismissBtn);
+    alertContainer.appendChild(alert);
+    if (timeout > 0) {
+      setTimeout(() => {
+        alert.classList.remove("show");
+        setTimeout(() => alert.remove(), 200);
+      }, timeout);
+    }
+  }
+
+  function parseMotorPins(raw) {
+    if (typeof raw !== "string") return [];
+    return raw.trim().split(/\s+/).filter(Boolean);
+  }
+
+  function setMotorPins(prefix, pins) {
+    if (!Array.isArray(pins)) return;
+    for (let i = 1; i <= 4; i += 1) {
+      const input = $(`#gpio_${prefix}_${i}`);
+      if (input) input.value = pins[i - 1] || "";
+    }
+  }
+
+  function setMotorFieldValue(id, value) {
+    const input = $(`#${id}`);
+    if (!input) return;
+    input.value = value === undefined || value === null ? "" : value;
+  }
+
+  function setMotorPinInputsEnabled(enabled) {
+    const disablePins = !enabled;
+    $$('#motors-form input[id^="gpio_"]').forEach((input) => {
+      input.disabled = disablePins;
+    });
+    $$(".flip_motor").forEach((btn) => {
+      btn.disabled = disablePins;
+      btn.classList.toggle("disabled", disablePins);
+    });
+  }
+
+  function updateBadge(isSpi) {
+    if (!typeBadge) return;
+    if (isSpi) {
+      typeBadge.textContent = "SPI motor board";
+      typeBadge.className = "badge text-bg-info";
+      typeBadge.title = "Pins are controlled over SPI, GPIO inputs disabled";
+    } else {
+      typeBadge.textContent = "Discrete GPIO driver";
+      typeBadge.className = "badge text-bg-dark";
+      typeBadge.title = "Pins driven directly via GPIO";
+    }
+  }
+
+  function updateHomingInputs() {
+    const homing = $("#homing");
+    const x = $("#pos_0_x");
+    const y = $("#pos_0_y");
+    if (!homing) return;
+    const disabled = !homing.checked;
+    if (x) x.disabled = disabled;
+    if (y) y.disabled = disabled;
+  }
+
+  function applyMotorsConfig(config = {}) {
+    if (typeof config !== "object" || !config) return;
+    setMotorPins("pan", parseMotorPins(config.gpio_pan));
+    setMotorPins("tilt", parseMotorPins(config.gpio_tilt));
+    setMotorFieldValue("steps_pan", config.steps_pan);
+    setMotorFieldValue("steps_tilt", config.steps_tilt);
+    setMotorFieldValue("speed_pan", config.speed_pan);
+    setMotorFieldValue("speed_tilt", config.speed_tilt);
+    setMotorFieldValue("accel_pan", config.accel_pan);
+    setMotorFieldValue("accel_tilt", config.accel_tilt);
+    const motionDriverEl = $("#motion_driver");
+    if (motionDriverEl) {
+      const mode = normalizeMotionDriver(config.motion_driver);
+      motionDriverEl.value = mode;
+    }
+    const previewControlModeEl = $("#preview_control_mode");
+    if (previewControlModeEl) {
+      previewControlModeEl.value = normalizePreviewControlMode(
+        config.preview_control_mode,
+      );
+    }
+    const joystickSensitivityEl = $("#joystick_sensitivity");
+    if (joystickSensitivityEl) {
+      const parsed = parseFloat(config.joystick_sensitivity);
+      joystickSensitivityEl.value =
+        Number.isFinite(parsed) && parsed >= 0.05 && parsed <= 4
+          ? parsed
+          : 2;
+    }
+    updateJoystickSensitivityInputs();
+    const homingEl = $("#homing");
+    if (homingEl) {
+      homingEl.checked = config.homing === true || config.homing === "true";
+    }
+    const firstPreset =
+      Array.isArray(config.presets) && config.presets.length
+        ? config.presets[0]
+        : null;
+    setMotorFieldValue("pos_0_x", firstPreset ? firstPreset.x : "");
+    setMotorFieldValue("pos_0_y", firstPreset ? firstPreset.y : "");
+    updateHomingInputs();
+    motorIsSpi = config.is_spi === true || config.is_spi === "true";
+    setMotorPinInputsEnabled(!motorIsSpi);
+    updateBadge(motorIsSpi);
+    updateMotionDriverInputs();
+  }
+
+  async function loadMotorsConfig(options = {}) {
+    const { silent = false } = options;
+    if (!silent) showBusy("Loading motor settings...");
+    try {
+      const response = await fetch(motorsConfigEndpoint, {
+        headers: { Accept: "application/json" },
+        cache: "no-store",
+      });
+      let payload = null;
+      try {
+        payload = await response.json();
+      } catch (parseErr) {
+        console.error("JSON parse error:", parseErr);
+        payload = null;
+      }
+      if (!response.ok || !payload || payload.result !== "success") {
+        const message = payload && payload.error && payload.error.message;
+        throw new Error(message || `HTTP ${response.status}`);
+      }
+      try {
+        applyMotorsConfig(payload.message || {});
+      } catch (applyErr) {
+        console.error("applyMotorsConfig error:", applyErr);
+        throw applyErr;
+      }
+      if (!initialLoadComplete) {
+        if (contentWrap) contentWrap.classList.remove("d-none");
+        initialLoadComplete = true;
+      }
+      return true;
+    } catch (err) {
+      console.error("Failed to load motors config", err);
+      showAlert(
+        "danger",
+        `Unable to load motor settings: ${err.message || err}`,
+      );
+      return false;
+    } finally {
+      if (!silent) hideBusy();
+    }
+  }
+
+  async function saveMotorsConfig() {
+    const form = $("#motors-form");
+    if (!form) return;
+
+    // Client-side validation to prevent 412 errors
+    const requiredPanFields = [
+      "gpio_pan_1",
+      "gpio_pan_2",
+      "gpio_pan_3",
+      "gpio_pan_4",
+    ];
+    const requiredTiltFields = [
+      "gpio_tilt_1",
+      "gpio_tilt_2",
+      "gpio_tilt_3",
+      "gpio_tilt_4",
+    ];
+
+    const formData = new FormData(form);
+    const errors = [];
+
+    // Check GPIO fields (skip for SPI motor boards where pins are irrelevant)
+    if (!motorIsSpi) {
+      for (const field of requiredPanFields) {
+        const value = formData.get(field);
+        if (!value || value.trim() === "") {
+          errors.push(
+            `${field.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase())} is required`,
+          );
+        }
+      }
+
+      // Detect whether the tilt axis is present: all GPIOs set to -1
+      // means the hardware has no tilt motor and tilt validation should
+      // be skipped entirely.
+      const tiltGpioValues = requiredTiltFields.map((f) =>
+        (formData.get(f) || "").trim(),
+      );
+      const tiltDisabled = tiltGpioValues.every((v) => v === "-1");
+
+      if (!tiltDisabled) {
+        for (const field of requiredTiltFields) {
+          const value = formData.get(field);
+          if (!value || value.trim() === "") {
+            errors.push(
+              `${field.replace(/_/g, " ").replace(/\b\w/g, (l) => l.toUpperCase())} is required`,
+            );
+          }
+        }
+      }
+    }
+
+    // Check steps fields
+    const stepsPan = formData.get("steps_pan");
+    const stepsTilt = formData.get("steps_tilt");
+    if (!stepsPan || parseInt(stepsPan) <= 0) {
+      errors.push("Pan max steps must be a positive number");
+    }
+
+    // Skip tilt steps validation when the tilt axis is disabled (all GPIOs -1).
+    // Pan-only cameras legitimately have steps_tilt = 0.
+    const tiltGpioVals = requiredTiltFields.map((f) =>
+      (formData.get(f) || "").trim(),
+    );
+    const tiltAxisMissing = tiltGpioVals.every((v) => v === "-1");
+    if (!tiltAxisMissing && (!stepsTilt || parseInt(stepsTilt) <= 0)) {
+      errors.push("Tilt max steps must be a positive number");
+    }
+
+    const accelPan = formData.get("accel_pan");
+    const accelTilt = formData.get("accel_tilt");
+    if (accelPan !== null && accelPan !== "" && parseInt(accelPan) < 0) {
+      errors.push("Pan acceleration must be zero or positive");
+    }
+    if (accelTilt !== null && accelTilt !== "" && parseInt(accelTilt) < 0) {
+      errors.push("Tilt acceleration must be zero or positive");
+    }
+
+    const motionDriver = formData.get("motion_driver");
+    if (motionDriver !== "legacy" && motionDriver !== "profiled") {
+      errors.push("Motion driver must be legacy or profiled");
+    }
+
+    const previewControlMode = formData.get("preview_control_mode");
+    if (normalizePreviewControlMode(previewControlMode) !== previewControlMode) {
+      errors.push("Preview PTZ controls must be step, continuous or joystick");
+    }
+
+    if (motionDriver !== "profiled") {
+      formData.set("accel_pan", "0");
+      formData.set("accel_tilt", "0");
+    }
+
+    // #joystick_sensitivity is disabled outside joystick mode (see
+    // updateJoystickSensitivityInputs()), and FormData silently drops
+    // disabled controls - without this, saving the form in any other mode
+    // would submit no value at all and the CGI's own fallback would reset
+    // whatever sensitivity was previously configured back to its default.
+    // The input's own .value still holds the loaded config value even
+    // while disabled, so re-adding it here just carries it through.
+    const joystickSensitivityEl = $("#joystick_sensitivity");
+    if (joystickSensitivityEl) {
+      formData.set("joystick_sensitivity", joystickSensitivityEl.value);
+    }
+
+    if (errors.length > 0) {
+      showAlert("danger", "Please fix the following errors:", 0);
+      errors.forEach((err) => showAlert("warning", err, 0));
+      return;
+    }
+
+    showBusy("Saving motor settings...");
+    try {
+      const homingEl = $("#homing");
+      const params = new URLSearchParams();
+      params.append("form", "motors");
+      params.append("homing", homingEl && homingEl.checked ? "true" : "false");
+      formData.forEach((value, key) => {
+        if (key !== "form" && key !== "homing") {
+          params.append(key, value == null ? "" : value);
+        }
+      });
+      const response = await fetch(motorsConfigEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: params.toString(),
+        cache: "no-store",
+      });
+      let payload = null;
+      try {
+        payload = await response.json();
+      } catch (_) {
+        payload = null;
+      }
+      if (!response.ok || !payload || payload.result !== "success") {
+        const message = payload && payload.error && payload.error.message;
+        throw new Error(message || `HTTP ${response.status}`);
+      }
+      applyMotorsConfig(payload.message || {});
+      showAlert("success", "Motor settings updated.");
+    } catch (err) {
+      console.error("Failed to save motors config", err);
+      showAlert(
+        "danger",
+        `Failed to save motor settings: ${err.message || err}`,
+      );
+    } finally {
+      hideBusy();
+    }
+  }
+
+  async function readMotorsPosition() {
+    try {
+      const res = await fetch(
+        "/x/json-motor.cgi?" + new URLSearchParams({ d: "j" }).toString(),
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const { message } = await res.json();
+      if (message) {
+        if ($("#pos_0_x")) $("#pos_0_x").value = message.xpos;
+        if ($("#pos_0_y")) $("#pos_0_y").value = message.ypos;
+      }
+      if ($("#homing")) $("#homing").checked = true;
+      updateHomingInputs();
+      showAlert("success", "Captured current position as new reference.", 4000);
+    } catch (err) {
+      console.error("Failed to read motors position", err);
+      showAlert(
+        "danger",
+        `Unable to read current position: ${err.message || err}`,
+      );
+    }
+  }
+
+  if (form) {
+    form.addEventListener("submit", (ev) => {
+      ev.preventDefault();
+      saveMotorsConfig();
+    });
+  }
+
+  if (reloadButton) {
+    reloadButton.addEventListener("click", async () => {
+      try {
+        reloadButton.disabled = true;
+        const success = await loadMotorsConfig({ silent: true });
+        if (success) {
+          showAlert("info", "Motor settings reloaded from camera.", 3000);
+        }
+      } catch (err) {
+        showAlert("danger", "Failed to reload motors settings.");
+      } finally {
+        reloadButton.disabled = false;
+      }
+    });
+  }
+
+  $$(".flip_motor").forEach((el) => {
+    el.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      const dir = el.dataset.direction;
+      if (!dir) return;
+      const base = "#gpio_" + dir + "_";
+      const pins = [1, 2, 3, 4].map((i) => $(base + i)?.value).reverse();
+      [1, 2, 3, 4].forEach((i, idx) => {
+        const field = $(base + i);
+        if (field && pins[idx] !== undefined) field.value = pins[idx];
+      });
+    });
+  });
+
+  $$(".read-motors").forEach((el) => {
+    el.addEventListener("click", (ev) => {
+      ev.preventDefault();
+      readMotorsPosition();
+    });
+  });
+
+  const homingSwitch = $("#homing");
+  if (homingSwitch) {
+    homingSwitch.addEventListener("change", updateHomingInputs);
+    updateHomingInputs();
+  }
+
+  const motionDriverSelect = $("#motion_driver");
+  if (motionDriverSelect) {
+    motionDriverSelect.addEventListener("change", updateMotionDriverInputs);
+  }
+
+  const previewControlModeSelect = $("#preview_control_mode");
+  if (previewControlModeSelect) {
+    previewControlModeSelect.addEventListener(
+      "change",
+      updateJoystickSensitivityInputs,
+    );
+  }
+  const joystickSensitivitySlider = $("#joystick_sensitivity");
+  if (joystickSensitivitySlider) {
+    // "input", not "change": track the thumb while dragging.
+    joystickSensitivitySlider.addEventListener(
+      "input",
+      updateJoystickSensitivityInputs,
+    );
+  }
+
+  // ------------------------------------------------------------------
+  // PTZ presets
+  // ------------------------------------------------------------------
+  const presetNameInput = $("#ptz-preset-name");
+  const presetSaveButton = $("#ptz-preset-save");
+  const presetsList = $("#ptz-presets-list");
+  const presetsEmpty = $("#ptz-presets-empty");
+
+  function renderPresets(presets) {
+    if (!presetsList) return;
+    presetsList.innerHTML = "";
+    if (presetsEmpty) {
+      presetsEmpty.classList.toggle("d-none", presets.length > 0);
+    }
+    presets.forEach((p) => {
+      const li = document.createElement("li");
+      li.className = "list-group-item d-flex align-items-center gap-2";
+
+      const nameInput = document.createElement("input");
+      nameInput.type = "text";
+      nameInput.className = "form-control form-control-sm flex-grow-1 preset-name";
+      nameInput.value = p.description || "";
+      nameInput.maxLength = 64;
+      nameInput.placeholder = `Preset ${p.id}`;
+
+      const xInput = document.createElement("input");
+      xInput.type = "number";
+      xInput.className = "form-control form-control-sm preset-x";
+      xInput.style.width = "4.5rem";
+      xInput.value = p.x;
+      xInput.min = "0";
+
+      const yInput = document.createElement("input");
+      yInput.type = "number";
+      yInput.className = "form-control form-control-sm preset-y";
+      yInput.style.width = "4.5rem";
+      yInput.value = p.y;
+      yInput.min = "0";
+
+      const saveBtn = document.createElement("button");
+      saveBtn.type = "button";
+      saveBtn.className = "btn btn-sm btn-outline-success";
+      saveBtn.title = "Save description and coordinates";
+      saveBtn.innerHTML = '<i class="bi bi-check-lg"></i>';
+      saveBtn.addEventListener("click", () => {
+        const description = nameInput.value.trim();
+        if (!description) {
+          showAlert("warning", "Enter a description for the preset.", 3000);
+          return;
+        }
+        const x = xInput.value.trim();
+        const y = yInput.value.trim();
+        if (!/^\d+$/.test(x) || !/^\d+$/.test(y)) {
+          showAlert("warning", "Coordinates must be whole numbers.", 3000);
+          return;
+        }
+        presetAction("pu", { n: p.id, description, x, y });
+      });
+
+      const moveBtn = document.createElement("button");
+      moveBtn.type = "button";
+      moveBtn.className = "btn btn-sm btn-outline-primary";
+      moveBtn.title = "Move to this preset";
+      moveBtn.innerHTML = '<i class="bi bi-play-fill"></i>';
+      moveBtn.addEventListener("click", () => presetAction("pr", { n: p.id }));
+
+      const delBtn = document.createElement("button");
+      delBtn.type = "button";
+      delBtn.className = "btn btn-sm btn-outline-danger";
+      delBtn.title = "Delete preset";
+      delBtn.innerHTML = '<i class="bi bi-trash"></i>';
+      delBtn.addEventListener("click", () => presetAction("pd", { n: p.id }));
+
+      li.append(nameInput, xInput, yInput, saveBtn, moveBtn, delBtn);
+      presetsList.appendChild(li);
+    });
+  }
+
+  async function loadPresets() {
+    try {
+      const res = await fetch(
+        "/x/json-motor.cgi?" + new URLSearchParams({ d: "pg" }).toString(),
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const payload = await res.json().catch(() => null);
+      if (!payload || payload.result !== "success") {
+        throw new Error(
+          (payload && payload.error && payload.error.message) ||
+            "Failed to load presets",
+        );
+      }
+      renderPresets(
+        payload.message && Array.isArray(payload.message.presets)
+          ? payload.message.presets
+          : [],
+      );
+    } catch (err) {
+      console.error("Failed to load PTZ presets", err);
+    }
+  }
+
+  // The build version rides along in the same `motors -j` status the CGI
+  // already proxies, so no extra endpoint. Stays blank on an older daemon
+  // build that has no "version" field, or when the daemon is down.
+  async function loadMotorsVersion() {
+    if (!versionBadge) return;
+    try {
+      const res = await fetch(
+        "/x/json-motor.cgi?" + new URLSearchParams({ d: "j" }).toString(),
+      );
+      const payload = await res.json();
+      const version = payload && payload.message && payload.message.version;
+      if (!version) return;
+      versionBadge.textContent = "motors " + version;
+      versionBadge.className = "badge text-bg-secondary";
+      versionBadge.title = "motors build version";
+    } catch (err) {
+      console.error("Failed to read motors version", err);
+    }
+  }
+
+  async function presetAction(action, extra) {
+    try {
+      const params = new URLSearchParams({ d: action });
+      Object.entries(extra || {}).forEach(([k, v]) => params.set(k, v));
+      const res = await fetch("/x/json-motor.cgi?" + params.toString());
+      const payload = await res.json().catch(() => null);
+      if (!res.ok || !payload || payload.result !== "success") {
+        const message = payload && payload.error && payload.error.message;
+        throw new Error(message || `HTTP ${res.status}`);
+      }
+      const status =
+        (payload.message && payload.message.status) || "OK";
+      showAlert("success", status, 3000);
+      await loadPresets();
+    } catch (err) {
+      console.error(`Preset action ${action} failed`, err);
+      showAlert(
+        "danger",
+        `Preset action failed: ${err.message || err}`,
+      );
+    }
+  }
+
+  if (presetSaveButton) {
+    presetSaveButton.addEventListener("click", async () => {
+      const description = (presetNameInput ? presetNameInput.value : "").trim();
+      if (!description) {
+        showAlert("warning", "Enter a description for the preset first.", 3000);
+        return;
+      }
+      await presetAction("ps", { description });
+      if (presetNameInput) presetNameInput.value = "";
+    });
+  }
+
+  loadPresets();
+
+  loadMotorsVersion();
+
+  loadMotorsConfig();
+})();

--- a/package/timps/files/www/motors-ui/json-motor-params.cgi
+++ b/package/timps/files/www/motors-ui/json-motor-params.cgi
@@ -1,0 +1,90 @@
+#!/bin/sh
+# shellcheck disable=SC1091,SC2086,SC2154,SC3043
+
+# Check authentication
+. /var/www/x/auth.sh
+require_auth
+
+MOTORS_CONFIG="/etc/thingino.json"
+
+# Get motor config values
+steps_pan_val=$(jct "$MOTORS_CONFIG" get motors.steps_pan 2>/dev/null)
+[ -z "$steps_pan_val" ] && steps_pan_val=0
+steps_tilt_val=$(jct "$MOTORS_CONFIG" get motors.steps_tilt 2>/dev/null)
+[ -z "$steps_tilt_val" ] && steps_tilt_val=0
+speed_pan_val=$(jct "$MOTORS_CONFIG" get motors.speed_pan 2>/dev/null)
+[ -z "$speed_pan_val" ] && speed_pan_val=0
+speed_tilt_val=$(jct "$MOTORS_CONFIG" get motors.speed_tilt 2>/dev/null)
+[ -z "$speed_tilt_val" ] && speed_tilt_val=0
+accel_pan_val=$(jct "$MOTORS_CONFIG" get motors.accel_pan 2>/dev/null)
+[ -z "$accel_pan_val" ] && accel_pan_val=0
+accel_tilt_val=$(jct "$MOTORS_CONFIG" get motors.accel_tilt 2>/dev/null)
+[ -z "$accel_tilt_val" ] && accel_tilt_val=0
+motion_driver_val=$(jct "$MOTORS_CONFIG" get motors.motion_driver 2>/dev/null)
+[ -z "$motion_driver_val" ] && motion_driver_val=legacy
+preview_control_mode_val=$(jct "$MOTORS_CONFIG" get motors.preview_control_mode 2>/dev/null)
+[ -z "$preview_control_mode_val" ] && preview_control_mode_val=step
+pos_0_x_val=$(jct "$MOTORS_CONFIG" get motors.presets.0.x 2>/dev/null)
+[ -z "$pos_0_x_val" ] && pos_0_x_val=0
+pos_0_y_val=$(jct "$MOTORS_CONFIG" get motors.presets.0.y 2>/dev/null)
+[ -z "$pos_0_y_val" ] && pos_0_y_val=0
+
+read_post_data() {
+	if [ -n "$CONTENT_LENGTH" ] && [ "$CONTENT_LENGTH" -gt 0 ]; then
+		body=$(dd bs=1 count="$CONTENT_LENGTH" 2>/dev/null)
+		eval "$(printf '%s' "$body" | awk -F'&' '{
+      for (i=1; i<=NF; i++) {
+        split($i, kv, "=")
+        key = kv[1]
+        value = kv[2]
+        gsub(/\+/, " ", value)
+        gsub(/%([0-9A-Fa-f]{2})/, "\\x\\1", value)
+        printf "POST_%s=\"%s\"\n", key, value
+      }
+    }')"
+	fi
+}
+
+if [ "$REQUEST_METHOD" = "POST" ]; then
+	read_post_data
+
+	changed=0
+
+	case "$POST_preview_control_mode" in
+		step | continuous | joystick)
+			if [ "$POST_preview_control_mode" != "$preview_control_mode_val" ]; then
+				jct "$MOTORS_CONFIG" set motors.preview_control_mode "$POST_preview_control_mode" >/dev/null 2>&1
+				preview_control_mode_val=$POST_preview_control_mode
+				changed=1
+			fi
+			;;
+	esac
+
+	case "$POST_speed_pan" in
+		'' | *[!0-9]*) ;;
+		*)
+			if [ "$POST_speed_pan" != "$speed_pan_val" ]; then
+				jct "$MOTORS_CONFIG" set motors.speed_pan "$POST_speed_pan" >/dev/null 2>&1
+				speed_pan_val=$POST_speed_pan
+				changed=1
+			fi
+			;;
+	esac
+
+	case "$POST_speed_tilt" in
+		'' | *[!0-9]*) ;;
+		*)
+			if [ "$POST_speed_tilt" != "$speed_tilt_val" ]; then
+				jct "$MOTORS_CONFIG" set motors.speed_tilt "$POST_speed_tilt" >/dev/null 2>&1
+				speed_tilt_val=$POST_speed_tilt
+				changed=1
+			fi
+			;;
+	esac
+
+	[ "$changed" = 1 ] && motors -R >/dev/null 2>&1
+fi
+
+printf 'Status: 200 OK\r\nContent-Type: application/json\r\nCache-Control: no-store\r\nConnection: close\r\n\r\n'
+
+printf '{"steps_pan":%s,"steps_tilt":%s,"speed_pan":%s,"speed_tilt":%s,"accel_pan":%s,"accel_tilt":%s,"motion_driver":"%s","preview_control_mode":"%s","pos_0_x":%s,"pos_0_y":%s}' "$steps_pan_val" "$steps_tilt_val" "$speed_pan_val" "$speed_tilt_val" "$accel_pan_val" "$accel_tilt_val" "$motion_driver_val" "$preview_control_mode_val" "$pos_0_x_val" "$pos_0_y_val"

--- a/package/timps/files/www/motors-ui/json-motor-token.cgi
+++ b/package/timps/files/www/motors-ui/json-motor-token.cgi
@@ -1,0 +1,73 @@
+#!/bin/sh
+# shellcheck disable=SC1091
+#
+# Hand the WebUI page the credential for motors-daemon's WebSocket listener.
+#
+# The listener requires a token from any non-loopback peer, and the browser IS
+# a non-loopback peer even when it loaded the page from this same camera - so
+# the PTZ panel cannot connect without one. The per-boot token lives in a
+# mode-0640 root-owned file that the page has no way to read; this CGI is the
+# bridge, and it is protected by the same WebUI session auth as every other
+# endpoint here.
+#
+# Only the per-boot token is ever exposed. A persistent motors.ws_token
+# secret from the config file never reaches a file at all - the daemon hashes
+# it at startup and wipes the plaintext - so there is nothing here that could
+# leak it.
+#
+# Deliberately modelled on timps's /x/timps-token.cgi rather than invented:
+# same problem, same deployment, and the WebUI already has one working shape
+# for it.
+
+# Check authentication
+. /var/www/x/auth.sh
+require_auth
+
+CONFIG="/etc/thingino.json"
+TOKEN_FILE="/run/motors.token"
+DEFAULT_PORT=8089
+
+# Honour a relocated token file / non-default port, matching what
+# load_ws_config_file() in motors-daemon reads.
+tf=$(jct "$CONFIG" get motors.ws_token_file 2>/dev/null)
+[ -n "$tf" ] && TOKEN_FILE="$tf"
+
+port=$(jct "$CONFIG" get motors.ws_port 2>/dev/null)
+case "$port" in
+	'' | *[!0-9]*) port="$DEFAULT_PORT" ;;
+esac
+
+# ws_enabled defaults to true in the daemon, so only an explicit false counts.
+enabled=true
+case "$(jct "$CONFIG" get motors.ws_enabled 2>/dev/null)" in
+	false | 0 | no | off) enabled=false ;;
+esac
+
+# marker file the daemon writes once a cert actually loads (not re-derived
+# from config here, to avoid a second copy of that resolution disagreeing)
+tls=false
+[ -e /run/motors.tls ] && tls=true
+
+printf 'Status: 200 OK\r\n'
+printf 'Content-Type: application/json\r\n'
+printf 'Cache-Control: no-store\r\n'
+printf 'Connection: close\r\n'
+printf '\r\n'
+
+# head -n1 + tr: the token is 32 hex characters and nothing else. Stripping
+# everything outside that set is what makes it safe to interpolate into the
+# hand-built JSON below without an escaper, the same way timps-token.cgi does
+# it - a token file that somehow contained a quote or a newline can then only
+# produce a short/empty token, never a malformed document.
+token=""
+[ -r "$TOKEN_FILE" ] && token=$(head -n1 "$TOKEN_FILE" 2>/dev/null | tr -cd '0-9A-Za-z')
+
+if [ -n "$token" ]; then
+	printf '{"token":"%s","port":%s,"enabled":%s,"tls":%s}\n' \
+		"$token" "$port" "$enabled" "$tls"
+else
+	# Not an HTTP error: "the listener is not usable right now" is a normal
+	# answer (ws_enabled=false, or the daemon refused to mint a token) and
+	# the page's job is to fall back to the CGI path, not to show an error.
+	printf '{"error":"no token available","port":%s,"enabled":false}\n' "$port"
+fi

--- a/package/timps/files/www/motors-ui/json-motor.cgi
+++ b/package/timps/files/www/motors-ui/json-motor.cgi
@@ -1,5 +1,5 @@
 #!/bin/sh
-# shellcheck disable=SC1091,SC2046,SC2329,SC3043
+# shellcheck disable=SC1091,SC2046,SC2317,SC2329,SC3043
 
 # Check authentication
 . /var/www/x/auth.sh

--- a/package/timps/files/www/motors-ui/json-motor.cgi
+++ b/package/timps/files/www/motors-ui/json-motor.cgi
@@ -76,58 +76,49 @@ json_escape() {
 # report a position that was already stale by the time it was read (the move
 # is asynchronous; the daemon has not finished it when the status is sampled).
 #
-# Live control now runs over motors-daemon's WebSocket where position arrives
-# as a server push, and the CGI path that remains is a fallback whose caller
-# (preview-motors.js) only ever console.log()s the echo. Callers that actually
-# want a position ask for one explicitly with d=j.
+# preview-motors.js tracks position client-side from the moves it issues and
+# only ever console.log()s this echo, so dropping it costs nothing there.
+# Callers that actually want a fresh position ask for one explicitly with d=j.
 motion_ok() {
 	json_ok "$1"
 }
 
 case "$d" in
 	g)
-		# Relative jog. Kept: this is the CGI fallback for the joystick when
-		# the WebSocket listener is off or unreachable, so it has to work.
+		# Relative jog - the joystick's per-step move.
 		motors -d g -x "$x" -y "$y" >/dev/null
 		motion_ok "moved"
 		;;
 	r)
-		# Homing / recalibration. Kept, and deliberately not moved to the
-		# WebSocket: it is a one-shot maintenance action, not a gesture, and
-		# it runs for tens of seconds - nothing about it benefits from a
-		# persistent socket.
+		# Homing / recalibration - a one-shot maintenance action, not a hold
+		# gesture, and it runs for tens of seconds.
 		motors -r >/dev/null
 		motion_ok "homing"
 		;;
 	h | x)
-		# Absolute move. Kept: used for centring and for the reposition that
-		# follows homing, and it is how ptz_presets-style jumps are issued
-		# from the page. Not a hold gesture, so the WebSocket buys it nothing.
+		# Absolute move - used for centring, the reposition after homing, and
+		# preset jumps issued from the page.
 		motors -d h -x "$x" -y "$y" >/dev/null
 		motion_ok "moved"
 		;;
 	s)
-		# Stop. Kept, and now more load-bearing than before: it is what the
-		# page falls back to when a socket dies mid-hold with the camera still
-		# panning toward its limit.
+		# Stop - halts an in-progress move; the page's release handler for a
+		# held direction.
 		motors -d s >/dev/null
 		motion_ok "stopped"
 		;;
 	b)
-		# Goback. Kept: MOTOR_GOBACK is a distinct driver operation that the
-		# WebSocket protocol deliberately does not expose, so nothing about
-		# the new path makes it redundant. It has no caller in this tree
-		# today, but removing it would be an unrelated dead-code change, not
-		# part of this migration.
+		# Goback - a distinct driver operation (MOTOR_GOBACK). No caller in
+		# this tree today; kept since removing it would be an unrelated
+		# dead-code change.
 		motors -d b >/dev/null
 		motion_ok "goback"
 		;;
 	j)
-		# Explicit one-shot status. Kept, and NOT redundant: config-motors.js
-		# calls it from the settings page's "capture current position" button,
-		# which has no WebSocket open and no reason to open one for a single
-		# read. (The 'i' case that sat next to it - `motors -i`, an initial-
-		# position echo - had no caller anywhere in this tree and is gone.)
+		# Explicit one-shot status - config-motors.js calls it from the
+		# settings page's "capture current position" button. (The 'i' case
+		# that sat next to it - `motors -i`, an initial-position echo - had
+		# no caller anywhere in this tree and is gone.)
 		payload=$(motors -j 2>/dev/null) || json_error "motors-status-failed"
 		json_ok "$payload"
 		;;

--- a/package/timps/files/www/motors-ui/json-motor.cgi
+++ b/package/timps/files/www/motors-ui/json-motor.cgi
@@ -1,0 +1,186 @@
+#!/bin/sh
+# shellcheck disable=SC1091,SC2046,SC2329,SC3043
+
+# Check authentication
+. /var/www/x/auth.sh
+require_auth
+
+http_200() {
+	printf 'Status: 200 OK\r\n'
+}
+
+http_400() {
+	printf 'Status: 400 Bad Request\r\n'
+}
+
+http_412() {
+	printf 'Status: 412 Precondition Failed\r\n'
+}
+
+json_header() {
+	printf 'Content-Type: application/json\r\n'
+	printf 'Pragma: no-cache\r\n'
+	printf 'Expires: %s\r\n' "$(TZ=GMT0 date +'%a, %d %b %Y %T %Z')"
+	printf 'Etag: "%s"\r\n' "$(cat /proc/sys/kernel/random/uuid)"
+	printf 'Connection: close\r\n'
+	printf '\r\n'
+}
+
+json_error() {
+	http_412
+	json_header
+	printf '{"error":{"code":412,"message":"%s"}}
+' "$1"
+	exit 0
+}
+
+json_ok() {
+	http_200
+	json_header
+	if [ "{" = "$(printf '%.1s' "$1")" ]; then
+		printf '{"code":200,"result":"success","message":%s}
+' "$1"
+	else
+		printf '{"code":200,"result":"success","message":"%s"}
+' "$1"
+	fi
+	exit 0
+}
+
+[ -n "$QUERY_STRING" ] && eval $(echo "$QUERY_STRING" | sed "s/&/;/g")
+
+# URL-decode string params (description, n); the rest are numeric/single char.
+urldecode() {
+	printf '%b' "$(echo "$1" | sed 's/+/ /g; s/%\([0-9A-Fa-f][0-9A-Fa-f]\)/\\x\1/g')"
+}
+[ -n "$description" ] && description=$(urldecode "$description")
+[ -n "$n" ] && n=$(urldecode "$n")
+[ -n "$order" ] && order=$(urldecode "$order")
+
+json_escape() {
+	printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g'
+}
+
+[ -z "$x" ] && x=0
+[ -z "$y" ] && y=0
+[ -z "$d" ] && d="g"
+
+# Motion commands answer with a bare acknowledgement.
+#
+# They used to fall through to a trailing emit_status that ran `motors -j` and
+# returned the position with every single move. That echo made sense when this
+# CGI was the only way to drive the motors and the page had no other source of
+# position - but it doubled the process cost of the hottest path in the whole
+# UI: a held arrow fired one of these every 90ms, and each one paid for
+# busybox-httpd, this shell, `motors`, and then a SECOND `motors` purely to
+# report a position that was already stale by the time it was read (the move
+# is asynchronous; the daemon has not finished it when the status is sampled).
+#
+# Live control now runs over motors-daemon's WebSocket where position arrives
+# as a server push, and the CGI path that remains is a fallback whose caller
+# (preview-motors.js) only ever console.log()s the echo. Callers that actually
+# want a position ask for one explicitly with d=j.
+motion_ok() {
+	json_ok "$1"
+}
+
+case "$d" in
+	g)
+		# Relative jog. Kept: this is the CGI fallback for the joystick when
+		# the WebSocket listener is off or unreachable, so it has to work.
+		motors -d g -x "$x" -y "$y" >/dev/null
+		motion_ok "moved"
+		;;
+	r)
+		# Homing / recalibration. Kept, and deliberately not moved to the
+		# WebSocket: it is a one-shot maintenance action, not a gesture, and
+		# it runs for tens of seconds - nothing about it benefits from a
+		# persistent socket.
+		motors -r >/dev/null
+		motion_ok "homing"
+		;;
+	h | x)
+		# Absolute move. Kept: used for centring and for the reposition that
+		# follows homing, and it is how ptz_presets-style jumps are issued
+		# from the page. Not a hold gesture, so the WebSocket buys it nothing.
+		motors -d h -x "$x" -y "$y" >/dev/null
+		motion_ok "moved"
+		;;
+	s)
+		# Stop. Kept, and now more load-bearing than before: it is what the
+		# page falls back to when a socket dies mid-hold with the camera still
+		# panning toward its limit.
+		motors -d s >/dev/null
+		motion_ok "stopped"
+		;;
+	b)
+		# Goback. Kept: MOTOR_GOBACK is a distinct driver operation that the
+		# WebSocket protocol deliberately does not expose, so nothing about
+		# the new path makes it redundant. It has no caller in this tree
+		# today, but removing it would be an unrelated dead-code change, not
+		# part of this migration.
+		motors -d b >/dev/null
+		motion_ok "goback"
+		;;
+	j)
+		# Explicit one-shot status. Kept, and NOT redundant: config-motors.js
+		# calls it from the settings page's "capture current position" button,
+		# which has no WebSocket open and no reason to open one for a single
+		# read. (The 'i' case that sat next to it - `motors -i`, an initial-
+		# position echo - had no caller anywhere in this tree and is gone.)
+		payload=$(motors -j 2>/dev/null) || json_error "motors-status-failed"
+		json_ok "$payload"
+		;;
+	pg)
+		# List PTZ presets from the motors.presets array in thingino.json:
+		# [{"id":N,"description":"..","x":N,"y":N}]
+		presets_json=$(jct /etc/thingino.json path '$.motors.presets[*]' --mode values 2>/dev/null)
+		[ -n "$presets_json" ] || presets_json='[]'
+		json_ok "{\"presets\":$presets_json}"
+		;;
+	ps)
+		# Save current motor position as a preset (auto slot)
+		[ -n "$description" ] || json_error "preset-description-required"
+		output=$(ptz_presets -a -1 "$description" 2>&1) || json_error "preset-save-failed"
+		json_ok "{\"status\":\"$output\"}"
+		;;
+	pr)
+		# Move to a preset
+		[ -n "$n" ] || json_error "preset-number-required"
+		output=$(ptz_presets "$n" 2>&1) || json_error "preset-run-failed"
+		json_ok "{\"status\":\"preset $n run\"}"
+		;;
+	pd)
+		# Delete a preset
+		[ -n "$n" ] || json_error "preset-number-required"
+		ptz_presets -r "$n" >/dev/null 2>&1
+		json_ok "{\"status\":\"preset $n deleted\"}"
+		;;
+	pu)
+		# Update an existing preset's description and coordinates
+		[ -n "$n" ] || json_error "preset-number-required"
+		[ -n "$description" ] || json_error "preset-description-required"
+		case "$x" in
+			'' | *[!0-9]*) json_error "preset-x-invalid" ;;
+		esac
+		case "$y" in
+			'' | *[!0-9]*) json_error "preset-y-invalid" ;;
+		esac
+		ptz_presets -a "$n" "$description" "$x" "$y" >/dev/null 2>&1 || json_error "preset-update-failed"
+		json_ok "{\"status\":\"preset $n updated\"}"
+		;;
+	po)
+		# Reorder presets: order is a comma-separated list of preset ids.
+		# Ids are stable; only the array order changes.
+		[ -n "$order" ] || json_error "preset-order-required"
+		output=$(ptz_presets -o "$order" 2>&1) || json_error "preset-reorder-failed"
+		json_ok "{\"status\":\"$output\"}"
+		;;
+	*)
+		json_error "motors-command-unsupported"
+		;;
+esac
+
+# Every case above exits through json_ok or json_error, so nothing reaches
+# here. Reaching it at all would mean a case fell through silently.
+json_error "motors-command-unhandled"

--- a/package/timps/files/www/motors-ui/json-motors-config.cgi
+++ b/package/timps/files/www/motors-ui/json-motors-config.cgi
@@ -1,0 +1,220 @@
+#!/bin/sh
+# shellcheck disable=SC1091,SC2154,SC3043
+
+# Check authentication
+. /var/www/x/auth.sh
+require_auth
+
+motors_domain="motors"
+motors_config_file="/etc/thingino.json"
+
+json_escape() {
+	printf '%s' "$1" | sed \
+		-e 's/\\/\\\\/g' \
+		-e 's/"/\\"/g' \
+		-e "s/\r/\\r/g" \
+		-e "s/\n/\\n/g"
+}
+
+read_post_data() {
+	if [ -n "$CONTENT_LENGTH" ] && [ "$CONTENT_LENGTH" -gt 0 ]; then
+		body=$(dd bs=1 count="$CONTENT_LENGTH" 2>/dev/null)
+		eval "$(printf '%s' "$body" | awk -F'&' '{
+      for (i=1; i<=NF; i++) {
+        split($i, kv, "=")
+        key = kv[1]
+        value = kv[2]
+        gsub(/\+/, " ", value)
+        gsub(/%([0-9A-Fa-f]{2})/, "\\x\\1", value)
+        printf "POST_%s=\"%s\"\n", key, value
+      }
+    }')"
+	fi
+}
+
+http_200() {
+	printf 'Status: 200 OK\r\n'
+}
+
+http_412() {
+	printf 'Status: 412 Precondition Failed\r\n'
+}
+
+json_header() {
+	printf 'Content-Type: application/json\r\n'
+	printf 'Cache-Control: no-store\r\n'
+	printf 'Pragma: no-cache\r\n'
+	printf 'Expires: %s\r\n' "$(TZ=GMT0 date +'%a, %d %b %Y %T %Z')"
+	printf 'Etag: "%s"\r\n' "$(cat /proc/sys/kernel/random/uuid)"
+	printf 'Connection: close\r\n'
+	printf '\r\n'
+}
+
+json_error() {
+	http_412
+	json_header
+	printf '{"error":{"code":412,"message":"%s"}}\n' "$(json_escape "$1")"
+	exit 0
+}
+
+json_ok() {
+	http_200
+	json_header
+	case "$1" in
+		\{*)
+			printf '{"code":200,"result":"success","message":%s}\n' "$1"
+			;;
+		*)
+			printf '{"code":200,"result":"success","message":"%s"}\n' "$(json_escape "$1")"
+			;;
+	esac
+	exit 0
+}
+
+motors_set_value() {
+	jct "$motors_config_file" set "$motors_domain.$1" "$2" >/dev/null 2>&1
+}
+
+motors_get_field() {
+	jct "$motors_config_file" get "$motors_domain.$1" 2>/dev/null
+}
+
+ensure_config_file() {
+	[ -f "$motors_config_file" ] && return
+	umask_old=$(umask)
+	umask 077
+	echo '{}' >"$motors_config_file"
+	umask "$umask_old"
+}
+
+current_config_payload() {
+	local payload
+	payload=$(jct "$motors_config_file" get "$motors_domain" 2>/dev/null)
+	if [ -z "$payload" ] || [ "$payload" = "null" ]; then
+		payload='{}'
+	fi
+	printf '%s' "$payload"
+}
+
+respond_with_config() {
+	ensure_config_file
+	json_ok "$(current_config_payload)"
+}
+
+handle_get() {
+	ensure_config_file
+	respond_with_config
+}
+
+handle_post() {
+	ensure_config_file
+	read_post_data
+	[ "$POST_form" = "motors" ] || json_error "motors-form-missing"
+
+	gpio_pan_1=$POST_gpio_pan_1
+	gpio_pan_2=$POST_gpio_pan_2
+	gpio_pan_3=$POST_gpio_pan_3
+	gpio_pan_4=$POST_gpio_pan_4
+	gpio_tilt_1=$POST_gpio_tilt_1
+	gpio_tilt_2=$POST_gpio_tilt_2
+	gpio_tilt_3=$POST_gpio_tilt_3
+	gpio_tilt_4=$POST_gpio_tilt_4
+	homing_value=${POST_homing:-false}
+	pos_0_x=$POST_pos_0_x
+	pos_0_y=$POST_pos_0_y
+	speed_pan_value=$POST_speed_pan
+	speed_tilt_value=$POST_speed_tilt
+	accel_pan_value=${POST_accel_pan:-0}
+	accel_tilt_value=${POST_accel_tilt:-0}
+	motion_driver_value=${POST_motion_driver:-legacy}
+	preview_control_mode_value=${POST_preview_control_mode:-step}
+	steps_pan_value=$POST_steps_pan
+	steps_tilt_value=$POST_steps_tilt
+	joystick_sensitivity_value=${POST_joystick_sensitivity:-2.00}
+
+	[ "$homing_value" = "true" ] || homing_value="false"
+
+	is_spi_value=$(motors_get_field is_spi)
+
+	if [ "true" != "$is_spi_value" ]; then
+		if [ -z "$gpio_pan_1" ] || [ -z "$gpio_pan_2" ] || [ -z "$gpio_pan_3" ] || [ -z "$gpio_pan_4" ] ||
+			[ -z "$gpio_tilt_1" ] || [ -z "$gpio_tilt_2" ] || [ -z "$gpio_tilt_3" ] || [ -z "$gpio_tilt_4" ]; then
+			json_error "All motor GPIO pins are required"
+		fi
+	fi
+
+	if [ "0$steps_pan_value" -le 0 ] || [ "0$steps_tilt_value" -le 0 ]; then
+		json_error "Motor max steps must be positive"
+	fi
+
+	if [ "0$accel_pan_value" -lt 0 ] || [ "0$accel_tilt_value" -lt 0 ]; then
+		json_error "Motor acceleration must be zero or positive"
+	fi
+
+	case "$motion_driver_value" in
+		legacy | profiled) ;;
+		*)
+			motion_driver_value="legacy"
+			;;
+	esac
+
+	case "$preview_control_mode_value" in
+		step | continuous | joystick) ;;
+		*)
+			preview_control_mode_value="step"
+			;;
+	esac
+
+	# busybox ash's test has no floating point; reject non-numeric, then
+	# clamp via awk into motor-daemon.c's own accepted range.
+	case "$joystick_sensitivity_value" in
+		'' | *[!0-9.]* | *.*.*) joystick_sensitivity_value="2.00" ;;
+	esac
+	joystick_sensitivity_value=$(awk -v v="$joystick_sensitivity_value" \
+		'BEGIN { if (v < 0.05) v = 0.05; if (v > 4) v = 4; printf "%.2f", v }')
+
+	if [ "true" != "$is_spi_value" ]; then
+		motors_set_value gpio_pan "$gpio_pan_1 $gpio_pan_2 $gpio_pan_3 $gpio_pan_4"
+		motors_set_value gpio_tilt "$gpio_tilt_1 $gpio_tilt_2 $gpio_tilt_3 $gpio_tilt_4"
+	fi
+
+	motors_set_value steps_pan "$steps_pan_value"
+	motors_set_value steps_tilt "$steps_tilt_value"
+	motors_set_value speed_pan "$speed_pan_value"
+	motors_set_value speed_tilt "$speed_tilt_value"
+	motors_set_value accel_pan "$accel_pan_value"
+	motors_set_value accel_tilt "$accel_tilt_value"
+	motors_set_value motion_driver "$motion_driver_value"
+	motors_set_value preview_control_mode "$preview_control_mode_value"
+	motors_set_value joystick_sensitivity "$joystick_sensitivity_value"
+	motors_set_value homing "$homing_value"
+
+	if [ -n "$pos_0_x" ] && [ -n "$pos_0_y" ]; then
+		# The initial point is the first preset; create it (id 0, "Home")
+		# when no preset exists yet.
+		if [ -z "$(motors_get_field presets.0.id)" ]; then
+			motors_set_value presets.0.id 0
+			motors_set_value presets.0.name "Home"
+		fi
+		motors_set_value presets.0.x "$pos_0_x"
+		motors_set_value presets.0.y "$pos_0_y"
+	fi
+
+	# Live-reloads the daemon config (see motor_ctl_reload() in
+	# motor-daemon.c for exactly which fields); GPIO still needs a reboot.
+	motors -R >/dev/null 2>&1
+
+	respond_with_config
+}
+
+case "$REQUEST_METHOD" in
+	GET)
+		handle_get
+		;;
+	POST)
+		handle_post
+		;;
+	*)
+		json_error "motors-method-unsupported"
+		;;
+esac

--- a/package/timps/files/www/motors-ui/motors.webui.json
+++ b/package/timps/files/www/motors-ui/motors.webui.json
@@ -1,0 +1,40 @@
+{
+  "name": "motors",
+  "label": "Pan/Tilt Motors",
+  "apiVersion": 1,
+  "nav": [
+    {
+      "section": "ddSettings",
+      "position": "after:GPIO pins",
+      "items": [
+        {
+          "label": "Pan/Tilt motors",
+          "href": "/config-motors.html"
+        }
+      ]
+    }
+  ],
+  "styles": [
+    "/a/preview-motors.css"
+  ],
+  "preview": {
+    "scripts": [
+      "/a/preview-motors.js",
+      "/a/preview-motors-settings.js"
+    ],
+    "html": "<div class=\"position-absolute top-50 start-50 translate-middle\" id=\"motor-overlay\" style=\"display:none\">\n  <div id=\"motor\">\n    <div class=\"jst\">\n      <a class=\"s\" data-dir=\"uc\"></a>\n      <a class=\"s\" data-dir=\"ur\"></a>\n      <a class=\"s\" data-dir=\"cr\"></a>\n      <a class=\"s\" data-dir=\"dr\"></a>\n      <a class=\"s\" data-dir=\"dc\"></a>\n      <a class=\"s\" data-dir=\"dl\"></a>\n      <a class=\"s\" data-dir=\"cl\"></a>\n      <a class=\"s\" data-dir=\"ul\"></a>\n      <a class=\"b\" data-dir=\"h\"></a>\n    </div>\n    <div id=\"motor-stick\"><div id=\"motor-stick-handle\"></div></div>\n    <div id=\"motor-pos\" aria-hidden=\"true\">\n      <span class=\"motor-pos-row motor-pos-pan\"><b>P</b><span class=\"motor-pos-track\"><i id=\"motor-pos-x\"></i></span><span id=\"motor-pos-text\">&#8211;</span></span>\n      <span class=\"motor-pos-row motor-pos-tilt\"><b>T</b><span class=\"motor-pos-track\"><i id=\"motor-pos-y\"></i></span></span>\n    </div>\n  </div>\n</div>"
+  },
+  "featureFlags": {
+    "motors": true,
+    "motorsWs": false
+  },
+  "cgi": [
+    "/x/json-motor.cgi",
+    "/x/json-motor-params.cgi",
+    "/x/json-motor-token.cgi",
+    "/x/json-motors-config.cgi"
+  ],
+  "pages": [
+    "/config-motors.html"
+  ]
+}

--- a/package/timps/files/www/motors-ui/preview-motors-settings.js
+++ b/package/timps/files/www/motors-ui/preview-motors-settings.js
@@ -1,0 +1,418 @@
+/**
+ * Preview-page PTZ settings modal (thingino-motors).
+ *
+ * An icon button in the Live View card header - alongside the motion-grid
+ * and stats toggles - opens a modal with quick settings (preview control
+ * mode, pan/tilt speed) and PTZ presets.
+ *
+ * Settings read/write through /x/json-motor-params.cgi (control mode and
+ * speeds; the CGI reloads the motors-daemon config on save so speed
+ * changes apply without a reboot). Presets read/write through
+ * /x/json-motor.cgi (d=pg / d=ps / d=pr / d=pd / d=pu / d=po).
+ *
+ * Plugin-owned file: registered via motors.webui.json `preview.scripts`,
+ * injected into the preview page at build time.
+ */
+(function () {
+  "use strict";
+
+  const PARAMS_ENDPOINT = "/x/json-motor-params.cgi";
+  const MOTOR_ENDPOINT = "/x/json-motor.cgi";
+
+  function normalizeControlMode(value) {
+    return value === "continuous" || value === "joystick" ? value : "step";
+  }
+
+  async function loadParams() {
+    const res = await fetch(PARAMS_ENDPOINT, { cache: "no-store" });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json();
+  }
+
+  async function saveParams(fields) {
+    const res = await fetch(PARAMS_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams(fields).toString(),
+      cache: "no-store",
+    });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    return res.json();
+  }
+
+  async function loadPresets() {
+    const res = await fetch(
+      `${MOTOR_ENDPOINT}?${new URLSearchParams({ d: "pg" }).toString()}`,
+      { cache: "no-store" },
+    );
+    const payload = await res.json().catch(() => null);
+    if (!res.ok || !payload || payload.result !== "success") {
+      const message = payload && payload.error && payload.error.message;
+      throw new Error(message || `HTTP ${res.status}`);
+    }
+    return payload.message && Array.isArray(payload.message.presets)
+      ? payload.message.presets
+      : [];
+  }
+
+  async function presetAction(action, extra) {
+    const params = new URLSearchParams({ d: action });
+    Object.entries(extra || {}).forEach(([k, v]) => params.set(k, v));
+    const res = await fetch(`${MOTOR_ENDPOINT}?${params.toString()}`);
+    const payload = await res.json().catch(() => null);
+    if (!res.ok || !payload || payload.result !== "success") {
+      const message = payload && payload.error && payload.error.message;
+      throw new Error(message || `HTTP ${res.status}`);
+    }
+    return (payload.message && payload.message.status) || "OK";
+  }
+
+  // -- modal markup ----------------------------------------------------
+  const MODAL_HTML =
+    '<div class="modal fade" id="ptzModal" tabindex="-1" aria-labelledby="ptzModalLabel" aria-hidden="true">' +
+    '  <div class="modal-dialog modal-lg">' +
+    '    <div class="modal-content">' +
+    '      <div class="modal-header">' +
+    '        <h5 class="modal-title" id="ptzModalLabel">PTZ Settings</h5>' +
+    '        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>' +
+    "      </div>" +
+    '      <div class="modal-body">' +
+    '        <ul class="nav nav-tabs" role="tablist">' +
+    '          <li class="nav-item" role="presentation">' +
+    '            <button class="nav-link active" id="ptz-settings-tab" data-bs-toggle="tab" data-bs-target="#ptz-settings-pane" type="button" role="tab" aria-controls="ptz-settings-pane" aria-selected="true">Movement</button>' +
+    "          </li>" +
+    '          <li class="nav-item" role="presentation">' +
+    '            <button class="nav-link" id="ptz-presets-tab" data-bs-toggle="tab" data-bs-target="#ptz-presets-pane" type="button" role="tab" aria-controls="ptz-presets-pane" aria-selected="false">Presets</button>' +
+    "          </li>" +
+    "        </ul>" +
+    '        <div class="tab-content pt-3">' +
+    '          <div class="tab-pane fade show active" id="ptz-settings-pane" role="tabpanel" aria-labelledby="ptz-settings-tab">' +
+    '            <p class="row">' +
+    '              <label class="form-label col-4" for="ptz-preview-control-mode">Preview controls</label>' +
+    '              <select class="form-select col" id="ptz-preview-control-mode">' +
+    '                <option value="step">Step move (click / double-click)</option>' +
+    '                <option value="continuous">Continuous move (press and hold)</option>' +
+    '                <option value="joystick">Virtual joystick (drag)</option>' +
+    "              </select>" +
+    "            </p>" +
+    '            <p class="row">' +
+    '              <label class="form-label col-4" for="ptz-speed-pan">Pan speed</label>' +
+    '              <input class="form-control col" type="number" id="ptz-speed-pan" min="0" placeholder="900">' +
+    "            </p>" +
+    '            <p class="row">' +
+    '              <label class="form-label col-4" for="ptz-speed-tilt">Tilt speed</label>' +
+    '              <input class="form-control col" type="number" id="ptz-speed-tilt" min="0" placeholder="900">' +
+    "            </p>" +
+    "          </div>" +
+    '          <div class="tab-pane fade" id="ptz-presets-pane" role="tabpanel" aria-labelledby="ptz-presets-tab">' +
+    '            <div class="d-flex gap-2 mb-3">' +
+    '              <input type="text" class="form-control" id="ptz-preset-name" placeholder="Preset description, e.g. Front door" maxlength="64">' +
+    '              <button type="button" class="btn btn-outline-primary text-nowrap" id="ptz-preset-save" title="Save current position as a preset">' +
+    '                <i class="bi bi-plus-circle me-1"></i>Save' +
+    "              </button>" +
+    "            </div>" +
+    '            <ul id="ptz-presets-list" class="list-group"></ul>' +
+    '            <small id="ptz-presets-empty" class="text-secondary d-block mt-2">No presets yet. Move the camera (preview overlay) and save a position above.</small>' +
+    "          </div>" +
+    "        </div>" +
+    "      </div>" +
+    '      <div class="modal-footer">' +
+    '        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>' +
+    '        <button type="button" class="btn btn-primary" id="ptz-save">Save settings</button>' +
+    "      </div>" +
+    "    </div>" +
+    "  </div>" +
+    "</div>";
+
+  // -- presets -----------------------------------------------------------
+  let currentPresets = [];
+
+  function renderPresets(presets) {
+    currentPresets = presets || [];
+    const list = $("#ptz-presets-list");
+    if (!list) return;
+    list.innerHTML = "";
+    const empty = $("#ptz-presets-empty");
+    if (empty) empty.classList.toggle("d-none", currentPresets.length > 0);
+    currentPresets.forEach((p) => list.appendChild(createPresetRow(p)));
+  }
+
+  function createPresetRow(p) {
+    const li = document.createElement("li");
+    li.className = "list-group-item d-flex align-items-center gap-2";
+    li.dataset.id = String(p.id);
+
+    const handle = document.createElement("span");
+    handle.className = "bi bi-grip-vertical drag-handle text-secondary";
+    handle.title = "Drag to reorder";
+    handle.draggable = true;
+    handle.addEventListener("dragstart", (e) => {
+      e.dataTransfer.effectAllowed = "move";
+      e.dataTransfer.setData("text/plain", String(p.id));
+      li.classList.add("dragging");
+    });
+    handle.addEventListener("dragend", () => li.classList.remove("dragging"));
+
+    const nameInput = document.createElement("input");
+    nameInput.type = "text";
+    nameInput.className = "form-control form-control-sm flex-grow-1 preset-name";
+    nameInput.value = p.description || "";
+    nameInput.maxLength = 64;
+    nameInput.placeholder = `Preset ${p.id}`;
+
+    const xInput = document.createElement("input");
+    xInput.type = "number";
+    xInput.className = "form-control form-control-sm preset-x";
+    xInput.style.width = "4.5rem";
+    xInput.value = p.x;
+    xInput.min = "0";
+
+    const yInput = document.createElement("input");
+    yInput.type = "number";
+    yInput.className = "form-control form-control-sm preset-y";
+    yInput.style.width = "4.5rem";
+    yInput.value = p.y;
+    yInput.min = "0";
+
+    const saveBtn = document.createElement("button");
+    saveBtn.type = "button";
+    saveBtn.className = "btn btn-sm btn-outline-success";
+    saveBtn.title = "Save description and coordinates";
+    saveBtn.innerHTML = '<i class="bi bi-check-lg"></i>';
+
+    const moveBtn = document.createElement("button");
+    moveBtn.type = "button";
+    moveBtn.className = "btn btn-sm btn-outline-primary";
+    moveBtn.title = "Move to this preset";
+    moveBtn.innerHTML = '<i class="bi bi-play-fill"></i>';
+
+    const delBtn = document.createElement("button");
+    delBtn.type = "button";
+    delBtn.className = "btn btn-sm btn-outline-danger";
+    delBtn.title = "Delete preset";
+    delBtn.innerHTML = '<i class="bi bi-trash"></i>';
+
+    saveBtn.addEventListener("click", () => {
+      const description = nameInput.value.trim();
+      if (!description) {
+        if (typeof showAlert === "function")
+          showAlert("warning", "Enter a description for the preset.", 3000);
+        return;
+      }
+      const x = xInput.value.trim();
+      const y = yInput.value.trim();
+      if (!/^\d+$/.test(x) || !/^\d+$/.test(y)) {
+        if (typeof showAlert === "function")
+          showAlert("warning", "Coordinates must be whole numbers.", 3000);
+        return;
+      }
+      runPresetAction("pu", { n: p.id, description, x, y });
+    });
+
+    moveBtn.addEventListener("click", () =>
+      runPresetAction("pr", { n: p.id }),
+    );
+    delBtn.addEventListener("click", () =>
+      runPresetAction("pd", { n: p.id }),
+    );
+
+    li.addEventListener("dragover", (e) => {
+      if (e.dataTransfer && e.dataTransfer.types.includes("text/plain")) {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = "move";
+        li.classList.add("drop-target");
+      }
+    });
+    li.addEventListener("dragleave", () => li.classList.remove("drop-target"));
+    li.addEventListener("drop", (e) => {
+      e.preventDefault();
+      li.classList.remove("drop-target");
+      const dragged = e.dataTransfer.getData("text/plain");
+      if (dragged && dragged !== String(p.id)) {
+        reorderPreset(dragged, String(p.id));
+      }
+    });
+
+    li.append(handle, nameInput, xInput, yInput, saveBtn, moveBtn, delBtn);
+    return li;
+  }
+
+  async function reorderPreset(draggedNumber, targetNumber) {
+    const from = currentPresets.findIndex(
+      (p) => String(p.id) === draggedNumber,
+    );
+    const to = currentPresets.findIndex(
+      (p) => String(p.id) === targetNumber,
+    );
+    if (from === -1 || to === -1 || from === to) return;
+
+    const moved = currentPresets.splice(from, 1)[0];
+    currentPresets.splice(to, 0, moved);
+
+    const order = currentPresets.map((p) => p.id).join(",");
+    renderPresets(currentPresets);
+
+    try {
+      await presetAction("po", { order });
+    } catch (err) {
+      console.error("Failed to reorder presets", err);
+      if (typeof showAlert === "function")
+        showAlert("danger", `Reorder failed: ${err.message}`, 5000);
+    }
+    await refreshPresets();
+  }
+
+  async function refreshPresets() {
+    try {
+      renderPresets(await loadPresets());
+    } catch (err) {
+      console.error("Failed to load PTZ presets", err);
+    }
+  }
+
+  async function runPresetAction(action, extra) {
+    try {
+      const status = await presetAction(action, extra);
+      if (typeof showAlert === "function") showAlert("success", status, 3000);
+      await refreshPresets();
+    } catch (err) {
+      console.error(`Preset action ${action} failed`, err);
+      if (typeof showAlert === "function")
+        showAlert("danger", `Preset action failed: ${err.message}`, 5000);
+    }
+  }
+
+  // -- settings -----------------------------------------------------------
+  function populateSettings(data) {
+    const mode = $("#ptz-preview-control-mode");
+    if (mode) mode.value = normalizeControlMode(data.preview_control_mode);
+    const pan = $("#ptz-speed-pan");
+    if (pan) pan.value = data.speed_pan ?? "";
+    const tilt = $("#ptz-speed-tilt");
+    if (tilt) tilt.value = data.speed_tilt ?? "";
+  }
+
+  async function saveSettings() {
+    const btn = $("#ptz-save");
+    if (!btn) return;
+
+    const mode = normalizeControlMode($("#ptz-preview-control-mode").value);
+    const pan = $("#ptz-speed-pan").value.trim();
+    const tilt = $("#ptz-speed-tilt").value.trim();
+
+    if (pan !== "" && !/^\d+$/.test(pan)) {
+      if (typeof showAlert === "function")
+        showAlert("warning", "Pan speed must be a whole number.", 4000);
+      return;
+    }
+    if (tilt !== "" && !/^\d+$/.test(tilt)) {
+      if (typeof showAlert === "function")
+        showAlert("warning", "Tilt speed must be a whole number.", 4000);
+      return;
+    }
+
+    const fields = { preview_control_mode: mode };
+    if (pan !== "") fields.speed_pan = pan;
+    if (tilt !== "") fields.speed_tilt = tilt;
+
+    btn.disabled = true;
+    try {
+      const data = await saveParams(fields);
+      if (window.motorParams) {
+        if (data.preview_control_mode !== undefined)
+          window.motorParams.preview_control_mode = data.preview_control_mode;
+        if (data.speed_pan !== undefined)
+          window.motorParams.speed_pan = data.speed_pan;
+        if (data.speed_tilt !== undefined)
+          window.motorParams.speed_tilt = data.speed_tilt;
+      }
+      // tell preview-motors.js to rebind so the saved mode applies live
+      const savedMode = normalizeControlMode(
+        data.preview_control_mode !== undefined
+          ? data.preview_control_mode
+          : mode,
+      );
+      document.dispatchEvent(
+        new CustomEvent("preview-motors:control-mode", {
+          detail: { mode: savedMode },
+        }),
+      );
+
+      if (typeof showAlert === "function")
+        showAlert("success", "PTZ settings saved.", 4000);
+      const modal = bootstrap.Modal.getInstance($("#ptzModal"));
+      if (modal) modal.hide();
+    } catch (err) {
+      console.error("Failed to save PTZ settings", err);
+      if (typeof showAlert === "function")
+        showAlert("danger", `Failed: ${err.message}`, 6000);
+    } finally {
+      btn.disabled = false;
+    }
+  }
+
+  // -- bootstrap ----------------------------------------------------------
+  function init() {
+    const style = document.createElement("style");
+    style.textContent =
+      "#ptz-presets-list .drag-handle{cursor:grab;user-select:none}" +
+      "#ptz-presets-list .drag-handle:active{cursor:grabbing}" +
+      "#ptz-presets-list li.dragging{opacity:.5}" +
+      "#ptz-presets-list li.drop-target{outline:2px dashed var(--bs-primary)}";
+    document.head.appendChild(style);
+
+    document.body.insertAdjacentHTML("beforeend", MODAL_HTML);
+
+    // anchor off #ms-stats-toggle's parent (that row has no class of its
+    // own); the old ".preview-header-actions" selector matched nothing
+    const frame = $("#frame");
+    const img = $("#preview");
+    const statsBtn = $("#ms-stats-toggle");
+    const connectBtn = $("#ms-connect");
+    const row =
+      (statsBtn && statsBtn.parentNode) || (connectBtn && connectBtn.parentNode);
+    const host = row || frame || (img && img.parentNode) || document.body;
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "btn btn-outline-secondary";
+    btn.id = "preview-ptz";
+    btn.title = "PTZ settings"; // icon-only button, so this carries the name
+    btn.setAttribute("aria-label", "PTZ settings");
+    btn.innerHTML = '<i class="bi bi-arrows-move"></i>';
+    if (row && connectBtn && connectBtn.parentNode === row)
+      row.insertBefore(btn, connectBtn);
+    else host.appendChild(btn);
+
+    btn.addEventListener("click", async () => {
+      try {
+        populateSettings(await loadParams());
+      } catch (err) {
+        console.error("Failed to load PTZ settings", err);
+      }
+      await refreshPresets();
+      new bootstrap.Modal($("#ptzModal")).show();
+    });
+
+    $("#ptz-save").addEventListener("click", saveSettings);
+
+    const presetSave = $("#ptz-preset-save");
+    if (presetSave) {
+      presetSave.addEventListener("click", async () => {
+        const description = $("#ptz-preset-name").value.trim();
+        if (!description) {
+          if (typeof showAlert === "function")
+            showAlert("warning", "Enter a description for the preset first.", 3000);
+          return;
+        }
+        await runPresetAction("ps", { description });
+        $("#ptz-preset-name").value = "";
+      });
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();

--- a/package/timps/files/www/motors-ui/preview-motors.css
+++ b/package/timps/files/www/motors-ui/preview-motors.css
@@ -1,0 +1,184 @@
+/* Virtual analog stick for the preview PTZ overlay, used when
+ * motors.preview_control_mode is "joystick". Plugin stylesheet rather than
+ * more rules in main.css: markup comes from this plugin's own manifest.
+ */
+
+#motor {
+  position: relative;
+  /* --motor-stick-size is written here at runtime (sizeStick() in
+   * preview-motors.js), not on #motor-stick: the readout rows are the
+   * ring's siblings and custom properties only inherit downward. */
+}
+
+#motor-stick,
+#motor-pos {
+  display: none;
+}
+
+#motor.stick-mode #motor-stick,
+#motor.stick-mode #motor-pos {
+  display: block;
+}
+
+/* The eight direction sectors would otherwise swallow every pointerdown. */
+#motor.stick-mode .jst a.s {
+  display: none;
+}
+
+#motor-stick {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  /* transform, not a margin hack: --motor-stick-size changes at runtime. */
+  transform: translate(-50%, -50%);
+  width: var(--motor-stick-size, 450px);
+  height: var(--motor-stick-size, 450px);
+  border-radius: 50%;
+  background: transparent; /* no fill - would cover most of the video */
+  border: 2px solid #ffffff59;
+  opacity: 0; /* hover/drag only, see below */
+  transition: opacity 220ms ease;
+  pointer-events: auto; /* re-enables over #motor-overlay's pointer-events:none */
+  touch-action: none; /* else the browser claims the gesture for scrolling */
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+/* .dragging too: pointer capture can carry a drag outside the ring. */
+#motor-stick:hover,
+#motor-stick.dragging {
+  opacity: 1;
+}
+
+#motor-stick::after {
+  content: ""; /* centre pip, marks the dead zone */
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 6px;
+  height: 6px;
+  margin: -3px 0 0 -3px;
+  border-radius: 50%;
+  background: #ffffff59;
+}
+
+#motor-stick-handle {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  width: 50px;
+  height: 50px;
+  margin: -25px 0 0 -25px;
+  border-radius: 50%;
+  background: #ff8800cc;
+  border: 3px solid #fffffff2;
+  box-shadow: 0 2px 8px #000000a6;
+  cursor: grab;
+  transition: transform 120ms ease-out; /* snap-back only, off during drag */
+}
+
+#motor-stick.dragging {
+  border-color: #ff8800a6;
+}
+
+#motor-stick.dragging #motor-stick-handle {
+  cursor: grabbing;
+  transition: none;
+}
+
+/* Live position readout: pan (left/right) as a horizontal bar under the
+ * ring, tilt (up/down) as a vertical one beside it - both positioned off
+ * --motor-stick-size, hidden individually by sizeStick() when they don't
+ * fit next to the ring. */
+#motor-pos {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  font-size: 11px;
+  font-weight: 500;
+  color: #fff;
+  text-shadow: 0 1px 2px #000000cc;
+  pointer-events: none;
+}
+
+.motor-pos-row {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.motor-pos-row b {
+  width: 9px;
+  font-weight: 600;
+  opacity: 0.75;
+  flex: none;
+}
+
+.motor-pos-track {
+  display: block;
+  border-radius: 2px;
+  background: #ffffff40;
+  overflow: hidden;
+}
+
+.motor-pos-track i {
+  display: block;
+  background: #ff8800;
+}
+
+.motor-pos-pan {
+  top: calc(var(--motor-stick-size, 450px) / 2 + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 176px;
+}
+
+.motor-pos-pan .motor-pos-track {
+  flex: 1;
+  height: 4px;
+}
+
+.motor-pos-pan .motor-pos-track i {
+  width: 0;
+  height: 100%;
+  transition: width 220ms linear;
+}
+
+/* Beside the ring, not stacked under the pan bar - two rows under a short
+ * (portrait-phone) ring is what overran the frame before. Label rotates via
+ * writing-mode (simpler than rotating the whole flex row + fill direction). */
+.motor-pos-tilt {
+  left: calc(var(--motor-stick-size, 450px) / 2 + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  flex-direction: column;
+  height: 90px;
+}
+
+.motor-pos-tilt b {
+  width: auto;
+  writing-mode: vertical-rl;
+}
+
+.motor-pos-tilt .motor-pos-track {
+  flex: 1;
+  width: 4px;
+  display: flex;
+  align-items: flex-end;
+}
+
+.motor-pos-tilt .motor-pos-track i {
+  width: 100%;
+  height: 0;
+  transition: height 220ms linear;
+}
+
+/* Fixed width: changing digits next to a flex track would jog it otherwise. */
+#motor-pos-text {
+  flex: none;
+  width: 62px;
+  text-align: right;
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}

--- a/package/timps/files/www/motors-ui/preview-motors.js
+++ b/package/timps/files/www/motors-ui/preview-motors.js
@@ -1,0 +1,772 @@
+/* PTZ joystick for the preview page.
+ *
+ * Two transports: CGI (/x/json-motor.cgi, always available) and WS
+ * (motors-daemon, only when built with BR2_PACKAGE_THINGINO_MOTORS_WS -
+ * window.thinginoUIConfig.device.motorsWs). The build flag alone doesn't
+ * guarantee a usable socket (daemon config, https mixed-content), so
+ * everything here checks "is the socket open right now" and falls back
+ * to CGI per call.
+ */
+
+function runMotorCmd(args) {
+  return fetch(`/x/json-motor.cgi?${args}`)
+    .then((res) => res.json())
+    .then(({ message }) => {
+      const { xpos, ypos } = message || {};
+      updatePositionDisplay(xpos, ypos);
+      return message;
+    });
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// WebSocket transport. Token via query string, not a header: the WebSocket
+// constructor can't set request headers on the handshake (same as timps's
+// EventSource); motors-daemon accepts ?token= for that reason.
+const MOTOR_WS_TOKEN_URL = "/x/json-motor-token.cgi";
+const MOTOR_WS_CONNECT_TIMEOUT_MS = 4000;
+// After this many failed attempts, stay on CGI for the rest of the page's life.
+const MOTOR_WS_MAX_ATTEMPTS = 3;
+
+const motorWs = (function () {
+  let socket = null;
+  let connecting = null;
+  let attempts = 0;
+  let seq = 1;
+  let frameListener = null;
+  let pushIntervalMs = 0;
+  const limits = { x: 0, y: 0 };
+
+  function buildFlagSet() {
+    const cfg = window.thinginoUIConfig || {};
+    return !!(cfg.device && cfg.device.motorsWs === true);
+  }
+
+  function usable() {
+    if (!buildFlagSet()) return false;
+    if (attempts >= MOTOR_WS_MAX_ATTEMPTS) return false;
+    return true; // https:// vs wss:// is decided later, in openSocket()
+  }
+
+  // https:// page must use wss:// (mixed content) or not connect at all -
+  // never ws:// even if the daemon offers it, since an untrusted self-signed
+  // wss:// cert has no browser prompt to fall back on.
+  function socketScheme(info) {
+    if (location.protocol !== "https:") return "ws";
+    return info && info.tls === true ? "wss" : null;
+  }
+
+  function onMessage(ev) {
+    let frame;
+    try {
+      frame = JSON.parse(ev.data);
+    } catch (err) {
+      return;
+    }
+    if (frame.type === "hello" || frame.type === "status") {
+      // Daemon's own travel limits; 0 means unknown, fall back to fixed steps.
+      if (typeof frame.x_max === "number") limits.x = frame.x_max;
+      if (typeof frame.y_max === "number") limits.y = frame.y_max;
+    }
+    // Keep window.motorPosition current from every WS push too, not just
+    // the CGI one-shot path - see updatePositionDisplay()'s own comment.
+    if (typeof frame.x === "number" && typeof frame.y === "number") {
+      updatePositionDisplay(frame.x, frame.y);
+    }
+    // Errors included - "unknown_cmd" is how a daemon older than the
+    // vector command is detected.
+    if (frameListener) frameListener(frame);
+  }
+
+  function openSocket(info) {
+    const port = parseInt(info.port, 10) || 8089;
+    const scheme = socketScheme(info);
+    if (!scheme) {
+      // https:// page, daemon has no cert: fall back to the CGI path
+      return Promise.reject(new Error("no wss:// on an https:// page"));
+    }
+    // Bracket a raw IPv6 literal, the same way preview.html does when it
+    // builds timps's base URL - location.hostname hands it back unbracketed.
+    let host = location.hostname;
+    if (host.indexOf(":") >= 0 && host[0] !== "[") host = "[" + host + "]";
+    const url =
+      scheme +
+      "://" +
+      host +
+      ":" +
+      port +
+      "/ws?token=" +
+      encodeURIComponent(info.token);
+
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(url);
+      const timer = setTimeout(() => {
+        try {
+          ws.close();
+        } catch (err) {
+          /* already gone */
+        }
+        reject(new Error("connect timeout"));
+      }, MOTOR_WS_CONNECT_TIMEOUT_MS);
+
+      ws.onopen = () => {
+        clearTimeout(timer);
+        socket = ws;
+        attempts = 0;
+        console.info("motors: PTZ control over " + scheme + "://");
+        // Position pushes only subscribed when something draws them (see
+        // subscribe()) - travel limits arrive unprompted in "hello" either way.
+        if (pushIntervalMs) {
+          try {
+            ws.send(
+              JSON.stringify({
+                cmd: "subscribe",
+                interval_ms: pushIntervalMs,
+              }),
+            );
+          } catch (err) {
+            /* the send below will report it */
+          }
+        }
+        resolve(ws);
+      };
+      ws.onerror = () => {
+        clearTimeout(timer);
+        reject(new Error("socket error"));
+      };
+      ws.onclose = () => {
+        if (socket === ws) socket = null;
+      };
+      ws.onmessage = onMessage;
+    });
+  }
+
+  function connect() {
+    if (!usable()) return Promise.resolve(null);
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      return Promise.resolve(socket);
+    }
+    if (connecting) return connecting;
+
+    attempts += 1;
+    connecting = fetch(MOTOR_WS_TOKEN_URL, { cache: "no-store" })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((info) => {
+        if (!info || info.enabled === false || !info.token) {
+          throw new Error("listener not available");
+        }
+        return openSocket(info);
+      })
+      .catch((err) => {
+        console.warn(
+          "motors: WebSocket control unavailable, using the CGI path",
+          err,
+        );
+        socket = null;
+        return null;
+      })
+      .then((ws) => {
+        connecting = null;
+        return ws;
+      });
+
+    return connecting;
+  }
+
+  // Synchronous: returns 0 (falsy) on failure so a half-open socket can't
+  // swallow a stop; returns the stamped id on success (seq starts at 1, so
+  // callers can treat it as a boolean too) for matching error frames back.
+  function trySend(obj) {
+    if (!socket || socket.readyState !== WebSocket.OPEN) return 0;
+    try {
+      obj.id = seq++;
+      socket.send(JSON.stringify(obj));
+      return obj.id;
+    } catch (err) {
+      console.warn("motors: WebSocket send failed", err);
+      return 0;
+    }
+  }
+
+  return {
+    connect,
+    trySend,
+    isOpen: () => !!socket && socket.readyState === WebSocket.OPEN,
+    limits,
+    enabledAtBuild: buildFlagSet,
+    setFrameListener: (fn) => {
+      frameListener = fn;
+    },
+    // Safe before or after the socket opens; whichever is second sends it.
+    subscribe: (intervalMs) => {
+      pushIntervalMs = intervalMs;
+      trySend({ cmd: "subscribe", interval_ms: intervalMs });
+    },
+  };
+})();
+
+function normalizePreviewControlMode(value) {
+  return value === "continuous" || value === "joystick" ? value : "step";
+}
+
+function getPreviewControlMode() {
+  const motorParams = window.motorParams || {};
+  return normalizePreviewControlMode(motorParams.preview_control_mode);
+}
+
+async function ensureMotorParams() {
+  if (window.motorParams) {
+    return window.motorParams;
+  }
+  try {
+    const response = await fetch("/x/json-motor-params.cgi", {
+      cache: "no-store",
+    });
+    const motorParams = await response.json();
+    window.motorParams = motorParams;
+    return motorParams;
+  } catch (error) {
+    console.error("Failed to load motor parameters:", error);
+    window.motorParams = {
+      steps_pan: 0,
+      steps_tilt: 0,
+      pos_0_x: 0,
+      pos_0_y: 0,
+      preview_control_mode: "step",
+    };
+    return window.motorParams;
+  }
+}
+
+// Axis sign from data-dir ("ul", "cr", "dc", ...); shared by step and hold mode.
+function motorDirSigns(dir) {
+  return {
+    x: dir.includes("l") ? -1 : dir.includes("r") ? 1 : 0,
+    y: dir.includes("d") ? -1 : dir.includes("u") ? 1 : 0,
+  };
+}
+
+async function moveMotor(dir, steps = 100, d = "g") {
+  // Use motor parameters loaded from backend
+  const motorParams = window.motorParams || {
+    steps_pan: 0,
+    steps_tilt: 0,
+    pos_0_x: 0,
+    pos_0_y: 0,
+  };
+  const x_max = motorParams.steps_pan;
+  const y_max = motorParams.steps_tilt;
+  const x0 = Number(motorParams.pos_0_x);
+  const y0 = Number(motorParams.pos_0_y);
+  const step = x_max / steps;
+  if (dir === "homing") {
+    // Stays on CGI regardless of transport: one-shot, not a gesture.
+    await runMotorCmd("d=r");
+    if (Number.isFinite(x0) && Number.isFinite(y0)) {
+      await sleep(800);
+      await runMotorCmd("d=x&x=" + x0 + "&y=" + y0);
+    }
+  } else if (dir === "cc") {
+    const cx = x_max / 2;
+    const cy = y_max / 2;
+    if (!motorWs.trySend({ cmd: "move", mode: "abs", x: cx, y: cy })) {
+      runMotorCmd("d=x&x=" + cx + "&y=" + cy);
+    }
+  } else {
+    const sign = motorDirSigns(dir);
+    const x = sign.x * step;
+    const y = sign.y * step;
+    if (!motorWs.trySend({ cmd: "move", mode: "rel", x: x, y: y })) {
+      runMotorCmd("d=g&x=" + x + "&y=" + y);
+    }
+  }
+}
+
+function updatePositionDisplay(xpos, ypos) {
+  if (xpos === undefined) return;
+  // Expose for other plugins/view models (e.g. the settings modal's
+  // "capture current position" button) - kept in sync from BOTH transports
+  // below (the CGI one-shot response and every WS position push), so a
+  // reader always gets the latest value without polling json-motor.cgi d=j
+  // itself. bindPositionReadout()'s own DOM bars are separate and unaffected.
+  window.motorPosition = { xpos, ypos };
+}
+
+// upstream's keyboard-jog (Shift+arrow) feature is deliberately not ported
+// here, same decision as this morning's merge: it depends on a
+// `currentStepName` module-level variable (and the step-size UI that sets
+// it) that this fork's own preview-motors.js never adopted, so pulling in
+// just this commit's refinement of it would reference an undeclared
+// variable. Revisit as one deliberate piece of work if this fork ever wants
+// keyboard PTZ, not as a side effect of a routine upstream sync.
+
+// --- initialization ----------------------------------------------------
+document.addEventListener("DOMContentLoaded", async function () {
+  const uiConfig = window.thinginoUIConfig || {};
+  const hasMotors = uiConfig.device && uiConfig.device.motors === true;
+
+  if (!hasMotors) {
+    return;
+  }
+  await ensureMotorParams();
+
+  const motorOverlay = $("#motor-overlay");
+  if (motorOverlay) {
+    motorOverlay.style.display = "";
+  }
+
+  // Not awaited: a slow/absent listener must not delay binding the controls.
+  motorWs.connect();
+
+  let timer;
+
+  let renderPosition = null; // joystick mode's live pan/tilt readout, or null
+  let activeControlMode = null;
+  let modeAbort = null; // owns every listener the active mode registered
+
+  function bindStepControls() {
+    $$(".jst a.s").forEach((el) => {
+      el.onclick = (ev) => {
+        if (ev.detail === 1) {
+          timer = setTimeout(() => {
+            moveMotor(ev.target.dataset.dir, 100);
+          }, 200);
+        }
+      };
+      el.ondblclick = (ev) => {
+        if (ev.detail === 2) {
+          clearTimeout(timer);
+          moveMotor(ev.target.dataset.dir, 10);
+        }
+      };
+    });
+  }
+
+  function bindContinuousControls(signal) {
+    let holdInterval = null;
+    let wsHolding = false;
+    const intervalMs = 90;
+
+    // Hold-to-move over the socket: one command down, one stop up. The delta
+    // is the full axis travel - motor_ctl_relative() clamps to the limit and
+    // recomputes, so this means "go until the far end"; no limit (x_max 0)
+    // falls back to nudges below.
+    const startWsHold = (dir) => {
+      const sign = motorDirSigns(dir);
+      const params = window.motorParams || {};
+      const xTravel = motorWs.limits.x || Number(params.steps_pan) || 0;
+      const yTravel = motorWs.limits.y || Number(params.steps_tilt) || 0;
+      if ((sign.x && !xTravel) || (sign.y && !yTravel)) return false;
+
+      if (
+        !motorWs.trySend({
+          cmd: "move",
+          mode: "rel",
+          x: sign.x * xTravel,
+          y: sign.y * yTravel,
+        })
+      ) {
+        return false;
+      }
+      wsHolding = true;
+      return true;
+    };
+
+    // Re-issue a small nudge every 90ms; ceasing to send them IS the stop.
+    const stopCgiMove = () => {
+      if (holdInterval) {
+        clearInterval(holdInterval);
+        holdInterval = null;
+      }
+    };
+
+    const startCgiMove = (dir) => {
+      stopCgiMove();
+      moveMotor(dir, 100);
+      holdInterval = setInterval(() => {
+        moveMotor(dir, 100);
+      }, intervalMs);
+    };
+
+    const startContinuousMove = (dir) => {
+      if (!dir) return;
+      stopContinuousMove();
+      if (motorWs.isOpen() && startWsHold(dir)) return;
+      startCgiMove(dir);
+    };
+
+    // Bound to every way a press can end - a missed release leaves the
+    // camera panning to its limit. Idempotent.
+    function stopContinuousMove() {
+      stopCgiMove();
+      if (wsHolding) {
+        wsHolding = false;
+        if (!motorWs.trySend({ cmd: "stop" })) {
+          runMotorCmd("d=s"); // socket died mid-gesture, still moving
+        }
+      }
+    }
+
+    $$(".jst a.s").forEach((el) => {
+      const stopHandler = () => stopContinuousMove();
+      el.addEventListener("pointerdown", (ev) => {
+        ev.preventDefault();
+        if (el.setPointerCapture && ev.pointerId !== undefined) {
+          el.setPointerCapture(ev.pointerId);
+        }
+        startContinuousMove(el.dataset.dir);
+      }, { signal });
+      el.addEventListener("pointerup", stopHandler, { signal });
+      el.addEventListener("pointerleave", stopHandler, { signal });
+      el.addEventListener("pointercancel", stopHandler, { signal });
+      el.addEventListener("lostpointercapture", stopHandler, { signal });
+      el.addEventListener("contextmenu", (ev) => ev.preventDefault(), { signal });
+    });
+
+    // A backgrounded tab gets no pointer event; catch it here too.
+    window.addEventListener("blur", stopContinuousMove, { signal });
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) stopContinuousMove();
+    }, { signal });
+
+    // Switching mode mid-press must not leave the camera panning to its limit.
+    if (signal) signal.addEventListener("abort", stopContinuousMove);
+  }
+
+  // Live pan/tilt readout, joystick mode only - a held stick runs toward a
+  // limit the video gives no warning of. 200ms cadence (matches the
+  // socket's own); the CSS transition smooths it further for free.
+  function bindPositionReadout() {
+    const wrap = $("#motor-pos");
+    const barX = $("#motor-pos-x");
+    const barY = $("#motor-pos-y");
+    const text = $("#motor-pos-text");
+    if (!wrap) return null;
+
+    motorWs.subscribe(200);
+
+    return function render(frame) {
+      if (typeof frame.x !== "number" || typeof frame.y !== "number") return;
+      const xMax = frame.x_max || motorWs.limits.x;
+      const yMax = frame.y_max || motorWs.limits.y;
+      if (barX) barX.style.width = xMax ? (frame.x / xMax) * 100 + "%" : "0";
+      // tilt's bar is vertical (preview-motors.css), filled by height
+      if (barY) barY.style.height = yMax ? (frame.y / yMax) * 100 + "%" : "0";
+      if (text) text.textContent = frame.x + " / " + frame.y;
+    };
+  }
+
+  // Virtual analog stick. The drag deflection goes over the wire as a
+  // per-mille value, not a distance/speed - only the daemon knows travel
+  // limits, speed cap, and (motor_ctl_vector) per-axis speed support.
+  function bindJoystickControls(signal) {
+    const stick = $("#motor-stick");
+    const handle = $("#motor-stick-handle");
+    if (!stick || !handle) {
+      // stale manifest asset; degrade rather than nothing
+      bindContinuousControls(signal);
+      return;
+    }
+
+    $("#motor").classList.add("stick-mode");
+
+    // Ring size: measured from the real preview box (timps's
+    // ".ms-video-wrap" or the stock "#frame"), not a vw/vh guess, since
+    // neither can know the stream's aspect ratio. --motor-stick-size lives
+    // on #motor (not the ring): the readout rows are the ring's siblings
+    // and custom properties only inherit downward.
+    const GAP = 8; // matches the +8px offsets in preview-motors.css
+    const MIN_RING = 110; // below this the ring stops being drag-able
+    const motorEl = $("#motor");
+    const panEl = $(".motor-pos-pan");
+    const tiltEl = $(".motor-pos-tilt");
+    function sizeStick() {
+      const frame = $(".ms-video-wrap") || $("#frame");
+      if (!frame) return;
+      const box = frame.getBoundingClientRect();
+      if (!box.width || !box.height) return;
+
+      // Un-hide before measuring, or a row hidden on a previous run reports
+      // a zero box and stays hidden forever.
+      if (panEl) panEl.style.display = "";
+      if (tiltEl) tiltEl.style.display = "";
+      const panReach = panEl
+        ? GAP + panEl.getBoundingClientRect().height
+        : 0;
+      const tiltReach = tiltEl ? GAP + tiltEl.getBoundingClientRect().width : 0;
+
+      // Reserve the readout, then size the ring in what's left (92% for
+      // a small margin) - has room for the readout by construction.
+      const reserved = Math.min(
+        box.width - 2 * tiltReach,
+        box.height - 2 * panReach,
+      );
+      let size = Math.min(450, reserved * 0.92);
+      let panFits = true;
+      let tiltFits = true;
+
+      if (size < MIN_RING) {
+        // Too small for both: ring gets the frame, readout rows that don't
+        // fit are dropped rather than left to overflow:hidden-clip.
+        size = Math.max(
+          MIN_RING,
+          Math.min(450, Math.min(box.width, box.height) * 0.92),
+        );
+        panFits = size / 2 + panReach <= box.height / 2;
+        tiltFits = size / 2 + tiltReach <= box.width / 2;
+      }
+
+      motorEl.style.setProperty("--motor-stick-size", size.toFixed(0) + "px");
+      if (panEl) panEl.style.display = panFits ? "" : "none";
+      if (tiltEl) tiltEl.style.display = tiltFits ? "" : "none";
+    }
+    sizeStick();
+    window.addEventListener("resize", sizeStick, { signal });
+    // img-fluid markup only reaches its real aspect ratio once the first
+    // frame loads; timps's markup has no #preview, so this is a no-op there.
+    const previewImg = $("#preview");
+    if (previewImg) previewImg.addEventListener("load", sizeStick, { signal });
+
+    const SEND_INTERVAL_MS = 90; // matches the CGI hold loop's cadence
+    const DEAD_ZONE = 0.12; // felt dead zone; daemon's own is a smaller backstop
+
+    let dragging = false;
+    let radius = 1;
+    let centre = { x: 0, y: 0 };
+    let vector = { x: 0, y: 0 };
+    let overSocket = false;
+    let vectorRejected = false;
+    let lastVectorId = 0;
+    let lastSentAt = 0;
+    let flushTimer = null;
+    let cgiInterval = null;
+
+    motorWs.setFrameListener((frame) => {
+      if (renderPosition && (frame.type === "status" || frame.type === "hello"))
+        renderPosition(frame);
+      // Daemon predates the vector command: give up on the socket
+      // permanently (not per-press) and finish the gesture on the CGI.
+      if (
+        frame.type === "error" &&
+        frame.id === lastVectorId &&
+        (frame.code === "unknown_cmd" || frame.code === "no_limits")
+      ) {
+        console.warn("motors: daemon rejected the vector command", frame.code);
+        vectorRejected = true;
+        if (dragging && overSocket) {
+          motorWs.trySend({ cmd: "stop" });
+          overSocket = false;
+          startCgiNudges();
+        }
+      }
+    });
+
+    // CGI fallback: no speed field, so proportionality comes from nudge size
+    // scaled by deflection, on the classic 90ms tick.
+    function startCgiNudges() {
+      stopCgiNudges();
+      const params = window.motorParams || {};
+      const stepX = Number(params.steps_pan) / 100 || 0;
+      const stepY = Number(params.steps_tilt) / 100 || 0;
+      cgiInterval = setInterval(() => {
+        const x = Math.round((stepX * vector.x) / 1000);
+        const y = Math.round((stepY * vector.y) / 1000);
+        if (x || y) runMotorCmd("d=g&x=" + x + "&y=" + y);
+      }, SEND_INTERVAL_MS);
+    }
+
+    function stopCgiNudges() {
+      if (cgiInterval) {
+        clearInterval(cgiInterval);
+        cgiInterval = null;
+      }
+    }
+
+    function sendVector() {
+      lastSentAt = performance.now();
+      lastVectorId = motorWs.trySend({
+        cmd: "vector",
+        x: vector.x,
+        y: vector.y,
+      });
+      if (!lastVectorId) {
+        // Socket died mid-drag, still moving: switch transports.
+        overSocket = false;
+        runMotorCmd("d=s");
+        startCgiNudges();
+      }
+    }
+
+    // Trailing-edge throttle: a leading-only one would drop the last sample
+    // of a gesture, which is the one that says how fast to keep going.
+    function queueVector() {
+      const wait = SEND_INTERVAL_MS - (performance.now() - lastSentAt);
+      if (wait <= 0) {
+        if (flushTimer) {
+          clearTimeout(flushTimer);
+          flushTimer = null;
+        }
+        sendVector();
+        return;
+      }
+      if (!flushTimer) {
+        flushTimer = setTimeout(() => {
+          flushTimer = null;
+          // overSocket too: transport may have switched to CGI since queued
+          if (dragging && overSocket) sendVector();
+        }, wait);
+      }
+    }
+
+    function updateFromPointer(ev) {
+      let dx = ev.clientX - centre.x;
+      let dy = ev.clientY - centre.y;
+      const dist = Math.hypot(dx, dy);
+
+      // Clamp to the ring, or the deflection has no upper bound.
+      if (dist > radius) {
+        dx = (dx / dist) * radius;
+        dy = (dy / dist) * radius;
+      }
+
+      handle.style.transform = "translate(" + dx + "px," + dy + "px)";
+
+      const norm = Math.min(dist, radius) / radius;
+      if (norm < DEAD_ZONE) {
+        vector = { x: 0, y: 0 };
+        return;
+      }
+      // Rescale so the throw starts at the dead-zone edge, not 12% deflection.
+      const scale = ((norm - DEAD_ZONE) / (1 - DEAD_ZONE)) * 1000;
+      vector = {
+        x: Math.round((dx / (dist || 1)) * scale),
+        y: Math.round((-dy / (dist || 1)) * scale), // screen y is inverted vs logical y
+      };
+    }
+
+    function endDrag() {
+      if (!dragging) return;
+      dragging = false;
+      stick.classList.remove("dragging");
+      handle.style.transform = "";
+      if (flushTimer) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+      }
+      vector = { x: 0, y: 0 };
+      stopCgiNudges();
+      if (overSocket) {
+        overSocket = false;
+        if (!motorWs.trySend({ cmd: "stop" })) runMotorCmd("d=s");
+      }
+    }
+
+    stick.addEventListener("pointerdown", (ev) => {
+      ev.preventDefault();
+      const box = stick.getBoundingClientRect();
+      radius = box.width / 2;
+      centre = { x: box.left + radius, y: box.top + box.height / 2 };
+      dragging = true;
+      stick.classList.add("dragging");
+      // Guarded: setPointerCapture can throw NotFoundError, which would
+      // otherwise skip binding the rest of the gesture entirely.
+      try {
+        if (stick.setPointerCapture && ev.pointerId !== undefined) {
+          stick.setPointerCapture(ev.pointerId);
+        }
+      } catch (err) {
+        // no capture; blur/visibilitychange below still catch a runaway drag
+      }
+      overSocket = motorWs.isOpen() && !vectorRejected;
+      updateFromPointer(ev);
+      if (overSocket) sendVector();
+      else startCgiNudges();
+    }, { signal });
+
+    stick.addEventListener("pointermove", (ev) => {
+      if (!dragging) return;
+      ev.preventDefault();
+      updateFromPointer(ev);
+      if (overSocket) queueVector();
+    }, { signal });
+
+    // Every way a drag can end has to land here, same reasoning as the arrows.
+    ["pointerup", "pointercancel", "lostpointercapture"].forEach((name) =>
+      stick.addEventListener(name, endDrag, { signal }),
+    );
+    stick.addEventListener("contextmenu", (ev) => ev.preventDefault(), { signal });
+
+    window.addEventListener("blur", endDrag, { signal });
+    document.addEventListener("visibilitychange", () => {
+      if (document.hidden) endDrag();
+    }, { signal });
+
+    // leaving mid-drag must stop the motor and the position-readout listener
+    if (signal)
+      signal.addEventListener("abort", () => {
+        endDrag();
+        motorWs.setFrameListener(null);
+      });
+  }
+
+  // (Re-)bind the widget to one control mode; safe to call repeatedly since
+  // aborting modeAbort tears down the previous mode's listeners first.
+  function applyControlMode(mode) {
+    mode = normalizePreviewControlMode(mode);
+    if (mode === activeControlMode) return;
+
+    if (modeAbort) modeAbort.abort();
+    modeAbort = new AbortController();
+    const signal = modeAbort.signal;
+
+    // step mode's onclick/ondblclick aren't covered by the signal
+    $$(".jst a.s").forEach((el) => {
+      el.onclick = null;
+      el.ondblclick = null;
+    });
+    const motorEl = $("#motor");
+    if (motorEl) motorEl.classList.remove("stick-mode");
+
+    activeControlMode = mode;
+    renderPosition = mode === "joystick" ? bindPositionReadout() : null;
+
+    if (mode === "joystick") {
+      bindJoystickControls(signal);
+    } else if (mode === "continuous") {
+      bindContinuousControls(signal);
+    } else {
+      bindStepControls();
+    }
+  }
+
+  applyControlMode(getPreviewControlMode());
+
+  // re-render hook: preview-motors-settings.js fires this after a save
+  window.previewMotors = window.previewMotors || {};
+  window.previewMotors.applyControlMode = applyControlMode;
+  document.addEventListener("preview-motors:control-mode", (ev) => {
+    applyControlMode(
+      (ev.detail && ev.detail.mode) || getPreviewControlMode(),
+    );
+  });
+
+  $(".jst a.b").onclick = (ev) => {
+    if (ev.detail === 1) {
+      timer = setTimeout(() => {
+        moveMotor("cc");
+      }, 200);
+    }
+  };
+
+  $(".jst a.b").ondblclick = (ev) => {
+    clearTimeout(timer);
+    moveMotor("homing");
+  };
+
+  // Over the socket this arrives unprompted in "hello"; only CGI needs to ask.
+  if (!motorWs.enabledAtBuild()) {
+    runMotorCmd("d=j");
+  }
+});

--- a/package/timps/files/www/motors-ui/preview-motors.js
+++ b/package/timps/files/www/motors-ui/preview-motors.js
@@ -1,11 +1,5 @@
-/* PTZ joystick for the preview page.
- *
- * Two transports: CGI (/x/json-motor.cgi, always available) and WS
- * (motors-daemon, only when built with BR2_PACKAGE_THINGINO_MOTORS_WS -
- * window.thinginoUIConfig.device.motorsWs). The build flag alone doesn't
- * guarantee a usable socket (daemon config, https mixed-content), so
- * everything here checks "is the socket open right now" and falls back
- * to CGI per call.
+/* PTZ joystick for the preview page. CGI transport only
+ * (/x/json-motor.cgi) - always available, no daemon build flag needed.
  */
 
 function runMotorCmd(args) {
@@ -21,191 +15,6 @@ function runMotorCmd(args) {
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
-
-// WebSocket transport. Token via query string, not a header: the WebSocket
-// constructor can't set request headers on the handshake (same as timps's
-// EventSource); motors-daemon accepts ?token= for that reason.
-const MOTOR_WS_TOKEN_URL = "/x/json-motor-token.cgi";
-const MOTOR_WS_CONNECT_TIMEOUT_MS = 4000;
-// After this many failed attempts, stay on CGI for the rest of the page's life.
-const MOTOR_WS_MAX_ATTEMPTS = 3;
-
-const motorWs = (function () {
-  let socket = null;
-  let connecting = null;
-  let attempts = 0;
-  let seq = 1;
-  let frameListener = null;
-  let pushIntervalMs = 0;
-  const limits = { x: 0, y: 0 };
-
-  function buildFlagSet() {
-    const cfg = window.thinginoUIConfig || {};
-    return !!(cfg.device && cfg.device.motorsWs === true);
-  }
-
-  function usable() {
-    if (!buildFlagSet()) return false;
-    if (attempts >= MOTOR_WS_MAX_ATTEMPTS) return false;
-    return true; // https:// vs wss:// is decided later, in openSocket()
-  }
-
-  // https:// page must use wss:// (mixed content) or not connect at all -
-  // never ws:// even if the daemon offers it, since an untrusted self-signed
-  // wss:// cert has no browser prompt to fall back on.
-  function socketScheme(info) {
-    if (location.protocol !== "https:") return "ws";
-    return info && info.tls === true ? "wss" : null;
-  }
-
-  function onMessage(ev) {
-    let frame;
-    try {
-      frame = JSON.parse(ev.data);
-    } catch (err) {
-      return;
-    }
-    if (frame.type === "hello" || frame.type === "status") {
-      // Daemon's own travel limits; 0 means unknown, fall back to fixed steps.
-      if (typeof frame.x_max === "number") limits.x = frame.x_max;
-      if (typeof frame.y_max === "number") limits.y = frame.y_max;
-    }
-    // Keep window.motorPosition current from every WS push too, not just
-    // the CGI one-shot path - see updatePositionDisplay()'s own comment.
-    if (typeof frame.x === "number" && typeof frame.y === "number") {
-      updatePositionDisplay(frame.x, frame.y);
-    }
-    // Errors included - "unknown_cmd" is how a daemon older than the
-    // vector command is detected.
-    if (frameListener) frameListener(frame);
-  }
-
-  function openSocket(info) {
-    const port = parseInt(info.port, 10) || 8089;
-    const scheme = socketScheme(info);
-    if (!scheme) {
-      // https:// page, daemon has no cert: fall back to the CGI path
-      return Promise.reject(new Error("no wss:// on an https:// page"));
-    }
-    // Bracket a raw IPv6 literal, the same way preview.html does when it
-    // builds timps's base URL - location.hostname hands it back unbracketed.
-    let host = location.hostname;
-    if (host.indexOf(":") >= 0 && host[0] !== "[") host = "[" + host + "]";
-    const url =
-      scheme +
-      "://" +
-      host +
-      ":" +
-      port +
-      "/ws?token=" +
-      encodeURIComponent(info.token);
-
-    return new Promise((resolve, reject) => {
-      const ws = new WebSocket(url);
-      const timer = setTimeout(() => {
-        try {
-          ws.close();
-        } catch (err) {
-          /* already gone */
-        }
-        reject(new Error("connect timeout"));
-      }, MOTOR_WS_CONNECT_TIMEOUT_MS);
-
-      ws.onopen = () => {
-        clearTimeout(timer);
-        socket = ws;
-        attempts = 0;
-        console.info("motors: PTZ control over " + scheme + "://");
-        // Position pushes only subscribed when something draws them (see
-        // subscribe()) - travel limits arrive unprompted in "hello" either way.
-        if (pushIntervalMs) {
-          try {
-            ws.send(
-              JSON.stringify({
-                cmd: "subscribe",
-                interval_ms: pushIntervalMs,
-              }),
-            );
-          } catch (err) {
-            /* the send below will report it */
-          }
-        }
-        resolve(ws);
-      };
-      ws.onerror = () => {
-        clearTimeout(timer);
-        reject(new Error("socket error"));
-      };
-      ws.onclose = () => {
-        if (socket === ws) socket = null;
-      };
-      ws.onmessage = onMessage;
-    });
-  }
-
-  function connect() {
-    if (!usable()) return Promise.resolve(null);
-    if (socket && socket.readyState === WebSocket.OPEN) {
-      return Promise.resolve(socket);
-    }
-    if (connecting) return connecting;
-
-    attempts += 1;
-    connecting = fetch(MOTOR_WS_TOKEN_URL, { cache: "no-store" })
-      .then((res) => (res.ok ? res.json() : null))
-      .then((info) => {
-        if (!info || info.enabled === false || !info.token) {
-          throw new Error("listener not available");
-        }
-        return openSocket(info);
-      })
-      .catch((err) => {
-        console.warn(
-          "motors: WebSocket control unavailable, using the CGI path",
-          err,
-        );
-        socket = null;
-        return null;
-      })
-      .then((ws) => {
-        connecting = null;
-        return ws;
-      });
-
-    return connecting;
-  }
-
-  // Synchronous: returns 0 (falsy) on failure so a half-open socket can't
-  // swallow a stop; returns the stamped id on success (seq starts at 1, so
-  // callers can treat it as a boolean too) for matching error frames back.
-  function trySend(obj) {
-    if (!socket || socket.readyState !== WebSocket.OPEN) return 0;
-    try {
-      obj.id = seq++;
-      socket.send(JSON.stringify(obj));
-      return obj.id;
-    } catch (err) {
-      console.warn("motors: WebSocket send failed", err);
-      return 0;
-    }
-  }
-
-  return {
-    connect,
-    trySend,
-    isOpen: () => !!socket && socket.readyState === WebSocket.OPEN,
-    limits,
-    enabledAtBuild: buildFlagSet,
-    setFrameListener: (fn) => {
-      frameListener = fn;
-    },
-    // Safe before or after the socket opens; whichever is second sends it.
-    subscribe: (intervalMs) => {
-      pushIntervalMs = intervalMs;
-      trySend({ cmd: "subscribe", interval_ms: intervalMs });
-    },
-  };
-})();
 
 function normalizePreviewControlMode(value) {
   return value === "continuous" || value === "joystick" ? value : "step";
@@ -262,7 +71,6 @@ async function moveMotor(dir, steps = 100, d = "g") {
   const y0 = Number(motorParams.pos_0_y);
   const step = x_max / steps;
   if (dir === "homing") {
-    // Stays on CGI regardless of transport: one-shot, not a gesture.
     await runMotorCmd("d=r");
     if (Number.isFinite(x0) && Number.isFinite(y0)) {
       await sleep(800);
@@ -271,36 +79,24 @@ async function moveMotor(dir, steps = 100, d = "g") {
   } else if (dir === "cc") {
     const cx = x_max / 2;
     const cy = y_max / 2;
-    if (!motorWs.trySend({ cmd: "move", mode: "abs", x: cx, y: cy })) {
-      runMotorCmd("d=x&x=" + cx + "&y=" + cy);
-    }
+    runMotorCmd("d=x&x=" + cx + "&y=" + cy);
   } else {
     const sign = motorDirSigns(dir);
     const x = sign.x * step;
     const y = sign.y * step;
-    if (!motorWs.trySend({ cmd: "move", mode: "rel", x: x, y: y })) {
-      runMotorCmd("d=g&x=" + x + "&y=" + y);
-    }
+    runMotorCmd("d=g&x=" + x + "&y=" + y);
   }
 }
 
 function updatePositionDisplay(xpos, ypos) {
   if (xpos === undefined) return;
   // Expose for other plugins/view models (e.g. the settings modal's
-  // "capture current position" button) - kept in sync from BOTH transports
-  // below (the CGI one-shot response and every WS position push), so a
-  // reader always gets the latest value without polling json-motor.cgi d=j
-  // itself. bindPositionReadout()'s own DOM bars are separate and unaffected.
+  // "capture current position" button), kept in sync from every CGI move
+  // response so a reader always gets the latest value without polling
+  // json-motor.cgi d=j itself. bindPositionReadout()'s own DOM bars are
+  // separate and unaffected.
   window.motorPosition = { xpos, ypos };
 }
-
-// upstream's keyboard-jog (Shift+arrow) feature is deliberately not ported
-// here, same decision as this morning's merge: it depends on a
-// `currentStepName` module-level variable (and the step-size UI that sets
-// it) that this fork's own preview-motors.js never adopted, so pulling in
-// just this commit's refinement of it would reference an undeclared
-// variable. Revisit as one deliberate piece of work if this fork ever wants
-// keyboard PTZ, not as a side effect of a routine upstream sync.
 
 // --- initialization ----------------------------------------------------
 document.addEventListener("DOMContentLoaded", async function () {
@@ -317,12 +113,8 @@ document.addEventListener("DOMContentLoaded", async function () {
     motorOverlay.style.display = "";
   }
 
-  // Not awaited: a slow/absent listener must not delay binding the controls.
-  motorWs.connect();
-
   let timer;
 
-  let renderPosition = null; // joystick mode's live pan/tilt readout, or null
   let activeControlMode = null;
   let modeAbort = null; // owns every listener the active mode registered
 
@@ -346,33 +138,7 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   function bindContinuousControls(signal) {
     let holdInterval = null;
-    let wsHolding = false;
     const intervalMs = 90;
-
-    // Hold-to-move over the socket: one command down, one stop up. The delta
-    // is the full axis travel - motor_ctl_relative() clamps to the limit and
-    // recomputes, so this means "go until the far end"; no limit (x_max 0)
-    // falls back to nudges below.
-    const startWsHold = (dir) => {
-      const sign = motorDirSigns(dir);
-      const params = window.motorParams || {};
-      const xTravel = motorWs.limits.x || Number(params.steps_pan) || 0;
-      const yTravel = motorWs.limits.y || Number(params.steps_tilt) || 0;
-      if ((sign.x && !xTravel) || (sign.y && !yTravel)) return false;
-
-      if (
-        !motorWs.trySend({
-          cmd: "move",
-          mode: "rel",
-          x: sign.x * xTravel,
-          y: sign.y * yTravel,
-        })
-      ) {
-        return false;
-      }
-      wsHolding = true;
-      return true;
-    };
 
     // Re-issue a small nudge every 90ms; ceasing to send them IS the stop.
     const stopCgiMove = () => {
@@ -393,7 +159,6 @@ document.addEventListener("DOMContentLoaded", async function () {
     const startContinuousMove = (dir) => {
       if (!dir) return;
       stopContinuousMove();
-      if (motorWs.isOpen() && startWsHold(dir)) return;
       startCgiMove(dir);
     };
 
@@ -401,12 +166,6 @@ document.addEventListener("DOMContentLoaded", async function () {
     // camera panning to its limit. Idempotent.
     function stopContinuousMove() {
       stopCgiMove();
-      if (wsHolding) {
-        wsHolding = false;
-        if (!motorWs.trySend({ cmd: "stop" })) {
-          runMotorCmd("d=s"); // socket died mid-gesture, still moving
-        }
-      }
     }
 
     $$(".jst a.s").forEach((el) => {
@@ -435,32 +194,9 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (signal) signal.addEventListener("abort", stopContinuousMove);
   }
 
-  // Live pan/tilt readout, joystick mode only - a held stick runs toward a
-  // limit the video gives no warning of. 200ms cadence (matches the
-  // socket's own); the CSS transition smooths it further for free.
-  function bindPositionReadout() {
-    const wrap = $("#motor-pos");
-    const barX = $("#motor-pos-x");
-    const barY = $("#motor-pos-y");
-    const text = $("#motor-pos-text");
-    if (!wrap) return null;
-
-    motorWs.subscribe(200);
-
-    return function render(frame) {
-      if (typeof frame.x !== "number" || typeof frame.y !== "number") return;
-      const xMax = frame.x_max || motorWs.limits.x;
-      const yMax = frame.y_max || motorWs.limits.y;
-      if (barX) barX.style.width = xMax ? (frame.x / xMax) * 100 + "%" : "0";
-      // tilt's bar is vertical (preview-motors.css), filled by height
-      if (barY) barY.style.height = yMax ? (frame.y / yMax) * 100 + "%" : "0";
-      if (text) text.textContent = frame.x + " / " + frame.y;
-    };
-  }
-
-  // Virtual analog stick. The drag deflection goes over the wire as a
-  // per-mille value, not a distance/speed - only the daemon knows travel
-  // limits, speed cap, and (motor_ctl_vector) per-axis speed support.
+  // Virtual analog stick. The drag deflection maps to a proportional nudge
+  // size on the classic 90ms CGI tick - no live position push in this
+  // transport, so the numeric pan/tilt readout stays at its placeholder.
   function bindJoystickControls(signal) {
     const stick = $("#motor-stick");
     const handle = $("#motor-stick-handle");
@@ -530,40 +266,15 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (previewImg) previewImg.addEventListener("load", sizeStick, { signal });
 
     const SEND_INTERVAL_MS = 90; // matches the CGI hold loop's cadence
-    const DEAD_ZONE = 0.12; // felt dead zone; daemon's own is a smaller backstop
+    const DEAD_ZONE = 0.12; // felt dead zone
 
     let dragging = false;
     let radius = 1;
     let centre = { x: 0, y: 0 };
     let vector = { x: 0, y: 0 };
-    let overSocket = false;
-    let vectorRejected = false;
-    let lastVectorId = 0;
-    let lastSentAt = 0;
-    let flushTimer = null;
     let cgiInterval = null;
 
-    motorWs.setFrameListener((frame) => {
-      if (renderPosition && (frame.type === "status" || frame.type === "hello"))
-        renderPosition(frame);
-      // Daemon predates the vector command: give up on the socket
-      // permanently (not per-press) and finish the gesture on the CGI.
-      if (
-        frame.type === "error" &&
-        frame.id === lastVectorId &&
-        (frame.code === "unknown_cmd" || frame.code === "no_limits")
-      ) {
-        console.warn("motors: daemon rejected the vector command", frame.code);
-        vectorRejected = true;
-        if (dragging && overSocket) {
-          motorWs.trySend({ cmd: "stop" });
-          overSocket = false;
-          startCgiNudges();
-        }
-      }
-    });
-
-    // CGI fallback: no speed field, so proportionality comes from nudge size
+    // No speed field over CGI, so proportionality comes from nudge size
     // scaled by deflection, on the classic 90ms tick.
     function startCgiNudges() {
       stopCgiNudges();
@@ -581,42 +292,6 @@ document.addEventListener("DOMContentLoaded", async function () {
       if (cgiInterval) {
         clearInterval(cgiInterval);
         cgiInterval = null;
-      }
-    }
-
-    function sendVector() {
-      lastSentAt = performance.now();
-      lastVectorId = motorWs.trySend({
-        cmd: "vector",
-        x: vector.x,
-        y: vector.y,
-      });
-      if (!lastVectorId) {
-        // Socket died mid-drag, still moving: switch transports.
-        overSocket = false;
-        runMotorCmd("d=s");
-        startCgiNudges();
-      }
-    }
-
-    // Trailing-edge throttle: a leading-only one would drop the last sample
-    // of a gesture, which is the one that says how fast to keep going.
-    function queueVector() {
-      const wait = SEND_INTERVAL_MS - (performance.now() - lastSentAt);
-      if (wait <= 0) {
-        if (flushTimer) {
-          clearTimeout(flushTimer);
-          flushTimer = null;
-        }
-        sendVector();
-        return;
-      }
-      if (!flushTimer) {
-        flushTimer = setTimeout(() => {
-          flushTimer = null;
-          // overSocket too: transport may have switched to CGI since queued
-          if (dragging && overSocket) sendVector();
-        }, wait);
       }
     }
 
@@ -651,16 +326,8 @@ document.addEventListener("DOMContentLoaded", async function () {
       dragging = false;
       stick.classList.remove("dragging");
       handle.style.transform = "";
-      if (flushTimer) {
-        clearTimeout(flushTimer);
-        flushTimer = null;
-      }
       vector = { x: 0, y: 0 };
       stopCgiNudges();
-      if (overSocket) {
-        overSocket = false;
-        if (!motorWs.trySend({ cmd: "stop" })) runMotorCmd("d=s");
-      }
     }
 
     stick.addEventListener("pointerdown", (ev) => {
@@ -679,17 +346,14 @@ document.addEventListener("DOMContentLoaded", async function () {
       } catch (err) {
         // no capture; blur/visibilitychange below still catch a runaway drag
       }
-      overSocket = motorWs.isOpen() && !vectorRejected;
       updateFromPointer(ev);
-      if (overSocket) sendVector();
-      else startCgiNudges();
+      startCgiNudges();
     }, { signal });
 
     stick.addEventListener("pointermove", (ev) => {
       if (!dragging) return;
       ev.preventDefault();
       updateFromPointer(ev);
-      if (overSocket) queueVector();
     }, { signal });
 
     // Every way a drag can end has to land here, same reasoning as the arrows.
@@ -703,12 +367,8 @@ document.addEventListener("DOMContentLoaded", async function () {
       if (document.hidden) endDrag();
     }, { signal });
 
-    // leaving mid-drag must stop the motor and the position-readout listener
-    if (signal)
-      signal.addEventListener("abort", () => {
-        endDrag();
-        motorWs.setFrameListener(null);
-      });
+    // leaving mid-drag must stop the motor
+    if (signal) signal.addEventListener("abort", endDrag);
   }
 
   // (Re-)bind the widget to one control mode; safe to call repeatedly since
@@ -730,7 +390,6 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (motorEl) motorEl.classList.remove("stick-mode");
 
     activeControlMode = mode;
-    renderPosition = mode === "joystick" ? bindPositionReadout() : null;
 
     if (mode === "joystick") {
       bindJoystickControls(signal);
@@ -765,8 +424,5 @@ document.addEventListener("DOMContentLoaded", async function () {
     moveMotor("homing");
   };
 
-  // Over the socket this arrives unprompted in "hello"; only CGI needs to ask.
-  if (!motorWs.enabledAtBuild()) {
-    runMotorCmd("d=j");
-  }
+  runMotorCmd("d=j");
 });

--- a/package/timps/files/www/motors-ui/preview-motors.js
+++ b/package/timps/files/www/motors-ui/preview-motors.js
@@ -1,5 +1,11 @@
-/* PTZ joystick for the preview page. CGI transport only
- * (/x/json-motor.cgi) - always available, no daemon build flag needed.
+/* PTZ joystick for the preview page.
+ *
+ * Two transports: CGI (/x/json-motor.cgi, always available) and WS
+ * (motors-daemon, only when built with BR2_PACKAGE_THINGINO_MOTORS_WS -
+ * window.thinginoUIConfig.device.motorsWs). The build flag alone doesn't
+ * guarantee a usable socket (daemon config, https mixed-content), so
+ * everything here checks "is the socket open right now" and falls back
+ * to CGI per call.
  */
 
 function runMotorCmd(args) {
@@ -15,6 +21,191 @@ function runMotorCmd(args) {
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+// WebSocket transport. Token via query string, not a header: the WebSocket
+// constructor can't set request headers on the handshake (same as timps's
+// EventSource); motors-daemon accepts ?token= for that reason.
+const MOTOR_WS_TOKEN_URL = "/x/json-motor-token.cgi";
+const MOTOR_WS_CONNECT_TIMEOUT_MS = 4000;
+// After this many failed attempts, stay on CGI for the rest of the page's life.
+const MOTOR_WS_MAX_ATTEMPTS = 3;
+
+const motorWs = (function () {
+  let socket = null;
+  let connecting = null;
+  let attempts = 0;
+  let seq = 1;
+  let frameListener = null;
+  let pushIntervalMs = 0;
+  const limits = { x: 0, y: 0 };
+
+  function buildFlagSet() {
+    const cfg = window.thinginoUIConfig || {};
+    return !!(cfg.device && cfg.device.motorsWs === true);
+  }
+
+  function usable() {
+    if (!buildFlagSet()) return false;
+    if (attempts >= MOTOR_WS_MAX_ATTEMPTS) return false;
+    return true; // https:// vs wss:// is decided later, in openSocket()
+  }
+
+  // https:// page must use wss:// (mixed content) or not connect at all -
+  // never ws:// even if the daemon offers it, since an untrusted self-signed
+  // wss:// cert has no browser prompt to fall back on.
+  function socketScheme(info) {
+    if (location.protocol !== "https:") return "ws";
+    return info && info.tls === true ? "wss" : null;
+  }
+
+  function onMessage(ev) {
+    let frame;
+    try {
+      frame = JSON.parse(ev.data);
+    } catch (err) {
+      return;
+    }
+    if (frame.type === "hello" || frame.type === "status") {
+      // Daemon's own travel limits; 0 means unknown, fall back to fixed steps.
+      if (typeof frame.x_max === "number") limits.x = frame.x_max;
+      if (typeof frame.y_max === "number") limits.y = frame.y_max;
+    }
+    // Keep window.motorPosition current from every WS push too, not just
+    // the CGI one-shot path - see updatePositionDisplay()'s own comment.
+    if (typeof frame.x === "number" && typeof frame.y === "number") {
+      updatePositionDisplay(frame.x, frame.y);
+    }
+    // Errors included - "unknown_cmd" is how a daemon older than the
+    // vector command is detected.
+    if (frameListener) frameListener(frame);
+  }
+
+  function openSocket(info) {
+    const port = parseInt(info.port, 10) || 8089;
+    const scheme = socketScheme(info);
+    if (!scheme) {
+      // https:// page, daemon has no cert: fall back to the CGI path
+      return Promise.reject(new Error("no wss:// on an https:// page"));
+    }
+    // Bracket a raw IPv6 literal, the same way preview.html does when it
+    // builds timps's base URL - location.hostname hands it back unbracketed.
+    let host = location.hostname;
+    if (host.indexOf(":") >= 0 && host[0] !== "[") host = "[" + host + "]";
+    const url =
+      scheme +
+      "://" +
+      host +
+      ":" +
+      port +
+      "/ws?token=" +
+      encodeURIComponent(info.token);
+
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(url);
+      const timer = setTimeout(() => {
+        try {
+          ws.close();
+        } catch (err) {
+          /* already gone */
+        }
+        reject(new Error("connect timeout"));
+      }, MOTOR_WS_CONNECT_TIMEOUT_MS);
+
+      ws.onopen = () => {
+        clearTimeout(timer);
+        socket = ws;
+        attempts = 0;
+        console.info("motors: PTZ control over " + scheme + "://");
+        // Position pushes only subscribed when something draws them (see
+        // subscribe()) - travel limits arrive unprompted in "hello" either way.
+        if (pushIntervalMs) {
+          try {
+            ws.send(
+              JSON.stringify({
+                cmd: "subscribe",
+                interval_ms: pushIntervalMs,
+              }),
+            );
+          } catch (err) {
+            /* the send below will report it */
+          }
+        }
+        resolve(ws);
+      };
+      ws.onerror = () => {
+        clearTimeout(timer);
+        reject(new Error("socket error"));
+      };
+      ws.onclose = () => {
+        if (socket === ws) socket = null;
+      };
+      ws.onmessage = onMessage;
+    });
+  }
+
+  function connect() {
+    if (!usable()) return Promise.resolve(null);
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      return Promise.resolve(socket);
+    }
+    if (connecting) return connecting;
+
+    attempts += 1;
+    connecting = fetch(MOTOR_WS_TOKEN_URL, { cache: "no-store" })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((info) => {
+        if (!info || info.enabled === false || !info.token) {
+          throw new Error("listener not available");
+        }
+        return openSocket(info);
+      })
+      .catch((err) => {
+        console.warn(
+          "motors: WebSocket control unavailable, using the CGI path",
+          err,
+        );
+        socket = null;
+        return null;
+      })
+      .then((ws) => {
+        connecting = null;
+        return ws;
+      });
+
+    return connecting;
+  }
+
+  // Synchronous: returns 0 (falsy) on failure so a half-open socket can't
+  // swallow a stop; returns the stamped id on success (seq starts at 1, so
+  // callers can treat it as a boolean too) for matching error frames back.
+  function trySend(obj) {
+    if (!socket || socket.readyState !== WebSocket.OPEN) return 0;
+    try {
+      obj.id = seq++;
+      socket.send(JSON.stringify(obj));
+      return obj.id;
+    } catch (err) {
+      console.warn("motors: WebSocket send failed", err);
+      return 0;
+    }
+  }
+
+  return {
+    connect,
+    trySend,
+    isOpen: () => !!socket && socket.readyState === WebSocket.OPEN,
+    limits,
+    enabledAtBuild: buildFlagSet,
+    setFrameListener: (fn) => {
+      frameListener = fn;
+    },
+    // Safe before or after the socket opens; whichever is second sends it.
+    subscribe: (intervalMs) => {
+      pushIntervalMs = intervalMs;
+      trySend({ cmd: "subscribe", interval_ms: intervalMs });
+    },
+  };
+})();
 
 function normalizePreviewControlMode(value) {
   return value === "continuous" || value === "joystick" ? value : "step";
@@ -71,6 +262,7 @@ async function moveMotor(dir, steps = 100, d = "g") {
   const y0 = Number(motorParams.pos_0_y);
   const step = x_max / steps;
   if (dir === "homing") {
+    // Stays on CGI regardless of transport: one-shot, not a gesture.
     await runMotorCmd("d=r");
     if (Number.isFinite(x0) && Number.isFinite(y0)) {
       await sleep(800);
@@ -79,24 +271,36 @@ async function moveMotor(dir, steps = 100, d = "g") {
   } else if (dir === "cc") {
     const cx = x_max / 2;
     const cy = y_max / 2;
-    runMotorCmd("d=x&x=" + cx + "&y=" + cy);
+    if (!motorWs.trySend({ cmd: "move", mode: "abs", x: cx, y: cy })) {
+      runMotorCmd("d=x&x=" + cx + "&y=" + cy);
+    }
   } else {
     const sign = motorDirSigns(dir);
     const x = sign.x * step;
     const y = sign.y * step;
-    runMotorCmd("d=g&x=" + x + "&y=" + y);
+    if (!motorWs.trySend({ cmd: "move", mode: "rel", x: x, y: y })) {
+      runMotorCmd("d=g&x=" + x + "&y=" + y);
+    }
   }
 }
 
 function updatePositionDisplay(xpos, ypos) {
   if (xpos === undefined) return;
   // Expose for other plugins/view models (e.g. the settings modal's
-  // "capture current position" button), kept in sync from every CGI move
-  // response so a reader always gets the latest value without polling
-  // json-motor.cgi d=j itself. bindPositionReadout()'s own DOM bars are
-  // separate and unaffected.
+  // "capture current position" button) - kept in sync from BOTH transports
+  // below (the CGI one-shot response and every WS position push), so a
+  // reader always gets the latest value without polling json-motor.cgi d=j
+  // itself. bindPositionReadout()'s own DOM bars are separate and unaffected.
   window.motorPosition = { xpos, ypos };
 }
+
+// upstream's keyboard-jog (Shift+arrow) feature is deliberately not ported
+// here, same decision as this morning's merge: it depends on a
+// `currentStepName` module-level variable (and the step-size UI that sets
+// it) that this fork's own preview-motors.js never adopted, so pulling in
+// just this commit's refinement of it would reference an undeclared
+// variable. Revisit as one deliberate piece of work if this fork ever wants
+// keyboard PTZ, not as a side effect of a routine upstream sync.
 
 // --- initialization ----------------------------------------------------
 document.addEventListener("DOMContentLoaded", async function () {
@@ -113,8 +317,12 @@ document.addEventListener("DOMContentLoaded", async function () {
     motorOverlay.style.display = "";
   }
 
+  // Not awaited: a slow/absent listener must not delay binding the controls.
+  motorWs.connect();
+
   let timer;
 
+  let renderPosition = null; // joystick mode's live pan/tilt readout, or null
   let activeControlMode = null;
   let modeAbort = null; // owns every listener the active mode registered
 
@@ -138,7 +346,33 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   function bindContinuousControls(signal) {
     let holdInterval = null;
+    let wsHolding = false;
     const intervalMs = 90;
+
+    // Hold-to-move over the socket: one command down, one stop up. The delta
+    // is the full axis travel - motor_ctl_relative() clamps to the limit and
+    // recomputes, so this means "go until the far end"; no limit (x_max 0)
+    // falls back to nudges below.
+    const startWsHold = (dir) => {
+      const sign = motorDirSigns(dir);
+      const params = window.motorParams || {};
+      const xTravel = motorWs.limits.x || Number(params.steps_pan) || 0;
+      const yTravel = motorWs.limits.y || Number(params.steps_tilt) || 0;
+      if ((sign.x && !xTravel) || (sign.y && !yTravel)) return false;
+
+      if (
+        !motorWs.trySend({
+          cmd: "move",
+          mode: "rel",
+          x: sign.x * xTravel,
+          y: sign.y * yTravel,
+        })
+      ) {
+        return false;
+      }
+      wsHolding = true;
+      return true;
+    };
 
     // Re-issue a small nudge every 90ms; ceasing to send them IS the stop.
     const stopCgiMove = () => {
@@ -159,6 +393,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     const startContinuousMove = (dir) => {
       if (!dir) return;
       stopContinuousMove();
+      if (motorWs.isOpen() && startWsHold(dir)) return;
       startCgiMove(dir);
     };
 
@@ -166,6 +401,12 @@ document.addEventListener("DOMContentLoaded", async function () {
     // camera panning to its limit. Idempotent.
     function stopContinuousMove() {
       stopCgiMove();
+      if (wsHolding) {
+        wsHolding = false;
+        if (!motorWs.trySend({ cmd: "stop" })) {
+          runMotorCmd("d=s"); // socket died mid-gesture, still moving
+        }
+      }
     }
 
     $$(".jst a.s").forEach((el) => {
@@ -194,9 +435,32 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (signal) signal.addEventListener("abort", stopContinuousMove);
   }
 
-  // Virtual analog stick. The drag deflection maps to a proportional nudge
-  // size on the classic 90ms CGI tick - no live position push in this
-  // transport, so the numeric pan/tilt readout stays at its placeholder.
+  // Live pan/tilt readout, joystick mode only - a held stick runs toward a
+  // limit the video gives no warning of. 200ms cadence (matches the
+  // socket's own); the CSS transition smooths it further for free.
+  function bindPositionReadout() {
+    const wrap = $("#motor-pos");
+    const barX = $("#motor-pos-x");
+    const barY = $("#motor-pos-y");
+    const text = $("#motor-pos-text");
+    if (!wrap) return null;
+
+    motorWs.subscribe(200);
+
+    return function render(frame) {
+      if (typeof frame.x !== "number" || typeof frame.y !== "number") return;
+      const xMax = frame.x_max || motorWs.limits.x;
+      const yMax = frame.y_max || motorWs.limits.y;
+      if (barX) barX.style.width = xMax ? (frame.x / xMax) * 100 + "%" : "0";
+      // tilt's bar is vertical (preview-motors.css), filled by height
+      if (barY) barY.style.height = yMax ? (frame.y / yMax) * 100 + "%" : "0";
+      if (text) text.textContent = frame.x + " / " + frame.y;
+    };
+  }
+
+  // Virtual analog stick. The drag deflection goes over the wire as a
+  // per-mille value, not a distance/speed - only the daemon knows travel
+  // limits, speed cap, and (motor_ctl_vector) per-axis speed support.
   function bindJoystickControls(signal) {
     const stick = $("#motor-stick");
     const handle = $("#motor-stick-handle");
@@ -266,15 +530,40 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (previewImg) previewImg.addEventListener("load", sizeStick, { signal });
 
     const SEND_INTERVAL_MS = 90; // matches the CGI hold loop's cadence
-    const DEAD_ZONE = 0.12; // felt dead zone
+    const DEAD_ZONE = 0.12; // felt dead zone; daemon's own is a smaller backstop
 
     let dragging = false;
     let radius = 1;
     let centre = { x: 0, y: 0 };
     let vector = { x: 0, y: 0 };
+    let overSocket = false;
+    let vectorRejected = false;
+    let lastVectorId = 0;
+    let lastSentAt = 0;
+    let flushTimer = null;
     let cgiInterval = null;
 
-    // No speed field over CGI, so proportionality comes from nudge size
+    motorWs.setFrameListener((frame) => {
+      if (renderPosition && (frame.type === "status" || frame.type === "hello"))
+        renderPosition(frame);
+      // Daemon predates the vector command: give up on the socket
+      // permanently (not per-press) and finish the gesture on the CGI.
+      if (
+        frame.type === "error" &&
+        frame.id === lastVectorId &&
+        (frame.code === "unknown_cmd" || frame.code === "no_limits")
+      ) {
+        console.warn("motors: daemon rejected the vector command", frame.code);
+        vectorRejected = true;
+        if (dragging && overSocket) {
+          motorWs.trySend({ cmd: "stop" });
+          overSocket = false;
+          startCgiNudges();
+        }
+      }
+    });
+
+    // CGI fallback: no speed field, so proportionality comes from nudge size
     // scaled by deflection, on the classic 90ms tick.
     function startCgiNudges() {
       stopCgiNudges();
@@ -292,6 +581,42 @@ document.addEventListener("DOMContentLoaded", async function () {
       if (cgiInterval) {
         clearInterval(cgiInterval);
         cgiInterval = null;
+      }
+    }
+
+    function sendVector() {
+      lastSentAt = performance.now();
+      lastVectorId = motorWs.trySend({
+        cmd: "vector",
+        x: vector.x,
+        y: vector.y,
+      });
+      if (!lastVectorId) {
+        // Socket died mid-drag, still moving: switch transports.
+        overSocket = false;
+        runMotorCmd("d=s");
+        startCgiNudges();
+      }
+    }
+
+    // Trailing-edge throttle: a leading-only one would drop the last sample
+    // of a gesture, which is the one that says how fast to keep going.
+    function queueVector() {
+      const wait = SEND_INTERVAL_MS - (performance.now() - lastSentAt);
+      if (wait <= 0) {
+        if (flushTimer) {
+          clearTimeout(flushTimer);
+          flushTimer = null;
+        }
+        sendVector();
+        return;
+      }
+      if (!flushTimer) {
+        flushTimer = setTimeout(() => {
+          flushTimer = null;
+          // overSocket too: transport may have switched to CGI since queued
+          if (dragging && overSocket) sendVector();
+        }, wait);
       }
     }
 
@@ -326,8 +651,16 @@ document.addEventListener("DOMContentLoaded", async function () {
       dragging = false;
       stick.classList.remove("dragging");
       handle.style.transform = "";
+      if (flushTimer) {
+        clearTimeout(flushTimer);
+        flushTimer = null;
+      }
       vector = { x: 0, y: 0 };
       stopCgiNudges();
+      if (overSocket) {
+        overSocket = false;
+        if (!motorWs.trySend({ cmd: "stop" })) runMotorCmd("d=s");
+      }
     }
 
     stick.addEventListener("pointerdown", (ev) => {
@@ -346,14 +679,17 @@ document.addEventListener("DOMContentLoaded", async function () {
       } catch (err) {
         // no capture; blur/visibilitychange below still catch a runaway drag
       }
+      overSocket = motorWs.isOpen() && !vectorRejected;
       updateFromPointer(ev);
-      startCgiNudges();
+      if (overSocket) sendVector();
+      else startCgiNudges();
     }, { signal });
 
     stick.addEventListener("pointermove", (ev) => {
       if (!dragging) return;
       ev.preventDefault();
       updateFromPointer(ev);
+      if (overSocket) queueVector();
     }, { signal });
 
     // Every way a drag can end has to land here, same reasoning as the arrows.
@@ -367,8 +703,12 @@ document.addEventListener("DOMContentLoaded", async function () {
       if (document.hidden) endDrag();
     }, { signal });
 
-    // leaving mid-drag must stop the motor
-    if (signal) signal.addEventListener("abort", endDrag);
+    // leaving mid-drag must stop the motor and the position-readout listener
+    if (signal)
+      signal.addEventListener("abort", () => {
+        endDrag();
+        motorWs.setFrameListener(null);
+      });
   }
 
   // (Re-)bind the widget to one control mode; safe to call repeatedly since
@@ -390,6 +730,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (motorEl) motorEl.classList.remove("stick-mode");
 
     activeControlMode = mode;
+    renderPosition = mode === "joystick" ? bindPositionReadout() : null;
 
     if (mode === "joystick") {
       bindJoystickControls(signal);
@@ -424,5 +765,8 @@ document.addEventListener("DOMContentLoaded", async function () {
     moveMotor("homing");
   };
 
-  runMotorCmd("d=j");
+  // Over the socket this arrives unprompted in "hello"; only CGI needs to ask.
+  if (!motorWs.enabledAtBuild()) {
+    runMotorCmd("d=j");
+  }
 });

--- a/package/timps/files/www/preview.html
+++ b/package/timps/files/www/preview.html
@@ -2,10 +2,27 @@
 <!--
   thingino · timps preview
 
-  Native MSE/fMP4 player (no iframe): fetches
+  Native fMP4 player (no iframe): fetches
       http://<location.hostname>:8880/stream.mp4?chn=N
-  from timpsd, a port of timps's own embedded player (src/mp4/httpd.c,
-  PLAYER_TAIL). Installed straight over thingino-webui's own /preview.html
+  from timpsd and plays it with one of two client-side pipelines, chosen by
+  the #ms-latency select:
+
+    * MSE/<video> (default) - a port of timps's own embedded player
+      (src/mp4/httpd.c, PLAYER_TAIL): SourceBuffer + a deliberate 0/0.5/1.5/3 s
+      jitter margin behind the live edge, so a WiFi hiccup drains instead of
+      freezing (0 s = no cushion at all, still this same pipeline). Plays audio
+      when timps muxes AAC. Picking any of these entries is also the manual way
+      back out of real-time mode, at any time.
+    * "Real-time" - WebCodecs: the same byte stream is parsed in JS and each
+      access unit goes straight to a VideoDecoder, painted on a canvas as it
+      arrives. No buffer, no playback clock: ~0.2-0.3 s glass-to-glass instead
+      of ~1.7 s, at the cost of visible freezes on a bad link and NO AUDIO
+      (video-only path). Offered only where window.VideoDecoder exists and the
+      selected stream is H.264; otherwise removed/disabled, never silently
+      broken. See dev_notes/PREVIEW_REALTIME_IDEAS_2026-08-29.md in the timps
+      repo for the measurements behind this.
+
+  Installed straight over thingino-webui's own /preview.html
   (see timps.mk) but still goes through the normal plugin pipeline - the
   preview-body marker below is replaced with contributed overlays (PTZ
   joystick, ...); do not hand-copy plugin markup in here, and do not spell
@@ -45,6 +62,20 @@
       height: 100%;
       background: #000;
       object-fit: contain;
+    }
+    /* Real-time (WebCodecs) player surface. Sits exactly over the <video>,
+       which stays laid out but visibility:hidden in that mode so
+       preview-motion.js can keep measuring the display box from it. Never
+       takes the pointer: the joystick overlay and the video controls
+       underneath must stay clickable. */
+    #ms-canvas {
+      position: absolute;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      background: #000;
+      object-fit: contain;
+      pointer-events: none;
     }
     /* live motion-grid overlay (drawn by /a/preview-motion.js); it never
        captures the pointer, so the motor joystick keeps working */
@@ -106,7 +137,7 @@
         <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2">
           <div>
             <h2 class="card-title mb-0">timps Live View</h2>
-            <small>Native fMP4/MSE player (no iframe), stream from port 8880</small>
+            <small>Native fMP4 player (no iframe), stream from port 8880</small>
           </div>
           <div class="d-flex flex-wrap gap-2">
             <select class="form-select form-select-sm" id="ms-stream" title="Select stream" style="width:auto; min-width: 140px;">
@@ -114,15 +145,31 @@
               <option value="1">Sub stream</option>
             </select>
             <select class="form-select form-select-sm" id="ms-latency" title="Target buffer margin behind live (lower = less delay, more risk of stalls on a weak link)" style="width:auto;">
+              <!-- "rt" switches the player from MSE/<video> to the WebCodecs
+                   canvas path (no jitter buffer, video only). Removed at
+                   runtime when the browser has no VideoDecoder, disabled when
+                   the selected stream is not H.264. -->
+              <option value="rt">Real-time (no audio)</option>
+              <option value="0">No buffer (0s)</option>
               <option value="0.5">Low latency (0.5s)</option>
               <option value="1.5" selected>Balanced (1.5s)</option>
               <option value="3">Stable (3s)</option>
             </select>
             <!-- motion-grid overlay toggle: hidden until /a/preview-motion.js
-                 confirms this timps build has IMP_IVS motion detection -->
+                 confirms this timps build has IMP_IVS motion detection AND
+                 that motion detection is currently enabled; it hides again
+                 live if motion is switched off elsewhere in the WebUI -->
             <button type="button" class="btn btn-outline-secondary" id="ms-motion"
               title="Motion grid overlay" style="display:none">
               <i class="bi bi-grid-3x3"></i>
+            </button>
+            <!-- push-to-talk (browser mic -> camera speaker): hidden until
+                 /a/preview-talk.js confirms caps.backchannel.talk_ws AND that
+                 timps is reachable over TLS (getUserMedia needs a secure
+                 context, and only wss:// is openable from an https:// page) -->
+            <button type="button" class="btn btn-outline-secondary" id="ms-talk"
+              title="Talk to the camera (microphone -&gt; camera speaker)" style="display:none">
+              <i class="bi bi-mic"></i>
             </button>
             <button type="button" class="btn btn-outline-secondary" id="ms-stats-toggle" title="Stream stats">
               <i class="bi bi-graph-up"></i>
@@ -135,6 +182,7 @@
         <div class="card-body">
           <div class="ms-video-wrap">
             <video id="ms-video" autoplay muted controls playsinline disableremoteplayback></video>
+            <canvas id="ms-canvas" style="display:none" aria-hidden="true"></canvas>
             <canvas id="motion-overlay" style="display:none" aria-hidden="true"></canvas>
             <div class="position-absolute top-50 start-50 translate-middle text-center" id="ms-connecting-overlay" style="display:none;">
               <div class="spinner-border text-light mb-2" role="status" style="width:3rem;height:3rem;">
@@ -145,6 +193,10 @@
             <!-- THINGINO_PLUGIN_PREVIEW_BODY -->
           </div>
           <div class="ms-hint mt-2" id="ms-status"></div>
+          <!-- talk-channel state, written only by /a/preview-talk.js. Its own
+               element rather than sharing #ms-status: the player writes that
+               one continuously and the two would clobber each other. -->
+          <div class="ms-hint mt-1" id="ms-talk-status" style="display:none"></div>
         </div>
       </div>
     </section>
@@ -209,6 +261,7 @@
     const MS_PORT = 8880;
 
     const video = document.getElementById("ms-video");
+    const rtCanvas = document.getElementById("ms-canvas");
     const connectButton = document.getElementById("ms-connect");
     const streamSelect = document.getElementById("ms-stream");
     const latencySelect = document.getElementById("ms-latency");
@@ -234,23 +287,123 @@
     // never RTSP. Resolves to null when the endpoint is unavailable (e.g.
     // prudynt build); the stream is then fetched without a token and the
     // existing 401 fallback message still applies.
-    window.timpsTokenInfo = window.timpsTokenInfo ||
-      fetch("/x/timps-token.cgi", { cache: "no-store" })
+    function fetchTimpsTokenInfo() {
+      return fetch("/x/timps-token.cgi", { cache: "no-store" })
         .then((r) => (r.ok ? r.json() : null))
         .catch(() => null);
+    }
+    window.timpsTokenInfo = window.timpsTokenInfo || fetchTimpsTokenInfo();
+    // The token is per timps BOOT: if timpsd restarts under a running player,
+    // every request with the old token comes back 401 and the preview is stuck
+    // until a page reload. Re-fetching it (and re-publishing the promise the
+    // other preview scripts read) is what makes a daemon restart recoverable.
+    function refreshTimpsToken() {
+      window.timpsTokenInfo = fetchTimpsTokenInfo();
+      return window.timpsTokenInfo;
+    }
 
     const params = new URLSearchParams(window.location.search);
     const defaultStream = params.get("stream") || sessionStorage.getItem("ms.stream") || "0";
 
+    // Player mode + jitter margin, both driven by the one #ms-latency select
+    // and persisted under the same sessionStorage key as before:
+    //   "0.5" / "1.5" / "3"  -> MSE/<video>, that many seconds behind live
+    //   "rt"                 -> WebCodecs/canvas real-time player (no buffer)
+    // The numeric values keep their old meaning, so an "ms.latency" written by
+    // an older build still restores the same margin here (and parseFloat("rt")
+    // is NaN, so an older build reading a "rt" value falls back to 1.5s).
+    const RT_VALUE = "rt";
+    const DEFAULT_MARGIN_S = 1.5;    // unchanged default: the <option selected> above
     // Target buffer margin behind live (seconds), read live by the
     // updateend handler below - changing it while connected takes effect on
-    // the very next segment, no reconnect needed.
-    let targetBehindS = parseFloat(sessionStorage.getItem("ms.latency")) || 1.5;
+    // the very next segment, no reconnect needed. Only used in MSE mode.
+    // 0 is a legal value (zero-cushion MSE: still SourceBuffer + <video>, just
+    // no deliberate margin), so every parse here has to distinguish "0" from
+    // "not a number" - a plain `parseFloat(v) || 1.5` would silently eat it.
+    function parseMargin(v) {
+      const n = parseFloat(v);
+      return (isFinite(n) && n >= 0) ? n : null;
+    }
+    let targetBehindS = DEFAULT_MARGIN_S;
+    let mode = "mse";                                    // "mse" | "rt"
+    let lastBufferedValue = String(DEFAULT_MARGIN_S);    // margin to return to from rt
+    (function readLatencyPref() {
+      const saved = sessionStorage.getItem("ms.latency");
+      if (saved === RT_VALUE) { mode = "rt"; return; }
+      const n = parseMargin(saved);
+      if (n !== null) { targetBehindS = n; lastBufferedValue = String(n); }
+    })();
+
+    // Real-time availability, gate 1 of 2: the browser. WebCodecs' VideoDecoder
+    // is Chrome/Edge 94+, Safari 16.4+, Firefox 130+ - everywhere else the
+    // option is removed outright rather than offered and then failing.
+    const rtOption = latencySelect
+      ? latencySelect.querySelector('option[value="' + RT_VALUE + '"]') : null;
+    const HAVE_WEBCODECS = typeof window.VideoDecoder === "function" &&
+                           typeof window.EncodedVideoChunk === "function";
+    if (!HAVE_WEBCODECS) {
+      if (rtOption) rtOption.remove();
+      if (mode === "rt") { mode = "mse"; sessionStorage.setItem("ms.latency", lastBufferedValue); }
+    }
+
+    function syncLatencySelect() {
+      if (!latencySelect) return;
+      latencySelect.value = mode === "rt" ? RT_VALUE : String(targetBehindS);
+    }
+
+    // Show the canvas / hide the <video> (and vice versa). The <video> keeps
+    // its box - visibility:hidden, not display:none - because preview-motion.js
+    // measures the display rect from it; window.msPreviewSize tells that script
+    // the intrinsic frame size while the <video> has no metadata of its own.
+    function applyModeUi() {
+      const rtOn = mode === "rt";
+      if (rtCanvas) rtCanvas.style.display = rtOn ? "" : "none";
+      video.style.visibility = rtOn ? "hidden" : "";
+      if (!rtOn) window.msPreviewSize = null;
+      syncLatencySelect();
+    }
+
+    // Audio contract for the real-time path: it decodes VIDEO ONLY (there is
+    // no AudioDecoder/AudioWorklet chain here). Rather than silently muting
+    // forever we (a) label the option "no audio", (b) remember an unmute the
+    // user made in MSE mode and restore it the moment they pick a buffered
+    // option again, and (c) say so in the status line - but only when the
+    // stream actually carries audio the buffered player could have played.
+    let userUnmuted = false;
+    video.addEventListener("volumechange", () => {
+      if (mode !== "rt") userUnmuted = !video.muted;
+    });
+    function applyModeAudio() {
+      if (mode === "rt") { if (!video.muted) video.muted = true; }
+      else if (userUnmuted && video.muted) video.muted = false;
+    }
+
+    // The one control that owns the player choice: picking ANY of the buffered
+    // margins here always switches (back) to the MSE/<video> path, at any
+    // time, connected or not - that is the manual escape hatch out of
+    // real-time mode, independent of the automatic fallbacks below.
     if (latencySelect) {
-      latencySelect.value = String(targetBehindS);
+      syncLatencySelect();
       latencySelect.addEventListener("change", () => {
-        targetBehindS = parseFloat(latencySelect.value) || 1.5;
-        sessionStorage.setItem("ms.latency", String(targetBehindS));
+        const v = latencySelect.value;
+        sessionStorage.setItem("ms.latency", v);
+        const newMode = v === RT_VALUE ? "rt" : "mse";
+        if (newMode === "mse") {
+          const n = parseMargin(v);
+          targetBehindS = n === null ? DEFAULT_MARGIN_S : n;
+          lastBufferedValue = String(targetBehindS);
+        }
+        if (newMode === mode) return;   // margin-only change: live, no reconnect
+        mode = newMode;
+        rtRetries = 0;
+        applyModeUi();
+        applyModeAudio();
+        // Swapping the pipeline needs a fresh connection (different consumer of
+        // the same fMP4 stream); while disconnected, just say what will happen
+        // rather than auto-connecting behind a deliberate Disconnect.
+        if (running) stopStream("Switching player…").then(() => startStream());
+        else setStatus((newMode === "rt" ? "Real-time player" : "Buffered player") +
+                       " selected - click Connect.");
       });
     }
 
@@ -513,17 +666,73 @@
       return null;
     }
 
+    // Resolve the timps endpoint from the per-boot token info (scheme/port),
+    // and the "&token=..." suffix both the stream fetch and /control use.
+    async function endpoint() {
+      const info = await window.timpsTokenInfo;
+      if (info) base = (info.tls ? "https" : "http") + "://" + host + ":" + (info.port || MS_PORT);
+      return { base: base, tok: info && info.token ? "&token=" + encodeURIComponent(info.token) : "" };
+    }
+
+    // GET /control, cached briefly: both the MSE start path (does this stream
+    // carry AAC?) and the real-time gate (is this stream H.264?) need it, and
+    // a live main/sub switch would otherwise fetch it twice in a second.
+    let controlCache = null, controlCacheAt = 0, controlInflight = null;
+    async function controlSnapshot(apiBase, tok, maxAgeMs) {
+      const now = Date.now();
+      if (controlCache && now - controlCacheAt < (maxAgeMs === undefined ? 10000 : maxAgeMs))
+        return controlCache;
+      if (controlInflight) return controlInflight;   // coalesce parallel callers
+      controlInflight = (async () => {
+        try {
+          const r = await fetch(apiBase + "/control" + (tok ? "?" + tok.slice(1) : ""),
+                                { cache: "no-store" });
+          if (!r.ok) return null;
+          const j = await r.json();
+          controlCache = j; controlCacheAt = Date.now();
+          return j;
+        } catch (e) { return null; }  // unreachable -> caller picks a safe default
+        finally { controlInflight = null; }
+      })();
+      return controlInflight;
+    }
+
     // Ask timps (GET /control) whether audio is enabled AND AAC; anything else
     // (pcma/pcmu/disabled/unreachable) means the fMP4 is video-only, so we must
     // NOT claim an AAC track to MSE. Uses the same token that unlocks /control.
     async function streamHasAac(apiBase, tok) {
-      try {
-        const r = await fetch(apiBase + "/control" + (tok ? "?" + tok.slice(1) : ""),
-                              { cache: "no-store" });
-        if (!r.ok) return false;
-        const j = await r.json();
-        return !!(j && j.audio && j.audio.enabled && j.audio.codec === "aac");
-      } catch (e) { return false; }   // unreachable -> safe video-only
+      const j = await controlSnapshot(apiBase, tok);
+      return !!(j && j.audio && j.audio.enabled && j.audio.codec === "aac");
+    }
+
+    // Real-time availability, gate 2 of 2: the SELECTED stream must be H.264.
+    // WebCodecs HEVC support is platform-dependent patchwork, so an H.265
+    // stream never gets offered this path - the option is disabled with a
+    // reason instead of silently producing a black canvas. Re-run whenever the
+    // main/sub selection changes, since the two channels can differ.
+    async function refreshRtOption() {
+      if (!HAVE_WEBCODECS || !rtOption || !latencySelect) return;
+      const chn = streamSelect.value === "1" ? "1" : "0";
+      const { base: b, tok } = await endpoint();
+      const j = await controlSnapshot(b, tok);
+      const vcfg = j && j.video ? j.video[chn] : null;
+      // unreachable /control: leave the option as-is rather than yanking it
+      // out from under the user; the moov parser rejects non-H.264 anyway.
+      if (!vcfg) return;
+      const ok = String(vcfg.codec || "").toLowerCase() === "h264";
+      rtOption.disabled = !ok;
+      rtOption.title = ok ? "" :
+        "Real-time decoding needs H.264; this stream is " + String(vcfg.codec).toUpperCase();
+      if (!ok && mode === "rt") {
+        mode = "mse";
+        targetBehindS = parseMargin(lastBufferedValue) === null ? DEFAULT_MARGIN_S : parseMargin(lastBufferedValue);
+        sessionStorage.setItem("ms.latency", lastBufferedValue);
+        applyModeUi();
+        applyModeAudio();
+        setStatus("Real-time mode is H.264-only - this stream is " +
+                  String(vcfg.codec).toUpperCase() + "; using buffered playback.");
+        if (running) stopStream("Switching player…").then(() => startStream());
+      }
     }
 
     async function stopStream(reason = "Disconnected") {
@@ -537,11 +746,396 @@
         try { if (mediaSource.readyState === "open") mediaSource.endOfStream(); } catch (e) { /* ignore */ }
         mediaSource = null;
       }
+      rtTeardown();
       video.removeAttribute("src");
       try { video.load(); } catch (e) { /* ignore */ }
       setConnectingUi(false);
       setConnectedUi(false);
       setStatus(reason);
+    }
+
+    // ===================================================================
+    // Real-time player (WebCodecs + canvas), the "rt" entry of #ms-latency.
+    //
+    // Same endpoint, same token, same ?chn= as the MSE path - only the client
+    // side differs: fetch() -> incremental fMP4 box parse -> VideoDecoder ->
+    // drawImage() on every output frame. No SourceBuffer, no playback clock,
+    // no jitter cushion: the newest frame is simply shown when it arrives
+    // (measured arrival->render ~1ms on cam-garage). The flip side is that a
+    // network stall is a visible freeze-then-jump instead of a smooth drain,
+    // which is why this is an explicit option and not the default.
+    //
+    // The parser only has to handle what src/mp4/fmp4.c actually emits:
+    // ftyp, one moov, then one moof+mdat per access unit (frame-granular),
+    // AVCC length-prefixed NALs in the mdat.
+    // ===================================================================
+
+    const RT_MAX_RETRIES = 5;
+    let rt = null;             // active real-time player state, or null
+    let rtRetries = 0;         // consecutive reconnect attempts (reset on 1st frame)
+    let rtTokenRefreshed = false;  // one token renewal per healthy run, no 401 loop
+
+    /* One ISO-BMFF box at `off`, or null when the buffer does not hold it all */
+    function boxAt(bytes, off) {
+      if (off + 8 > bytes.length) return null;
+      const dv = new DataView(bytes.buffer, bytes.byteOffset + off, bytes.length - off);
+      let size = dv.getUint32(0), hdr = 8;
+      const type = String.fromCharCode(bytes[off + 4], bytes[off + 5], bytes[off + 6], bytes[off + 7]);
+      if (size === 1) {                       // 64-bit extended size
+        if (off + 16 > bytes.length) return null;
+        size = dv.getUint32(8) * 4294967296 + dv.getUint32(12);
+        hdr = 16;
+      }
+      if (size < hdr || off + size > bytes.length) return null;
+      return { type: type, size: size, payload: bytes.subarray(off + hdr, off + size) };
+    }
+
+    /* Walk a container path, e.g. findBox(trak, ["mdia","minf","stbl","stsd"]) */
+    function findBox(bytes, path) {
+      let cur = bytes;
+      for (let i = 0; i < path.length; i++) {
+        let found = null, off = 0, b;
+        while ((b = boxAt(cur, off))) {
+          if (b.type === path[i]) { found = b.payload; break; }
+          off += b.size;
+        }
+        if (!found) return null;
+        cur = found;
+      }
+      return cur;
+    }
+
+    /* Video track id + media timescale + avcC out of the init segment.
+       Two byte-offset traps live here, both silent when wrong:
+       - tkhd's track_ID sits at +20 for version 1 (64-bit times) and +12 for
+         version 0; getting it backwards configures the decoder fine and then
+         never matches a single moof, so no frame is ever fed to it.
+       - avcC is a CHILD of the avc1 sample entry, which starts with 78 fixed
+         VisualSampleEntry bytes after its own 8-byte box header. */
+    function rtParseMoov(moov) {
+      const out = { trackId: null, timescale: 90000, avcC: null, videoFourCC: null };
+      let off = 0, b;
+      while ((b = boxAt(moov, off))) {
+        if (b.type === "trak") {
+          const trak = b.payload;
+          const tkhd = findBox(trak, ["tkhd"]);
+          let trackId = null;
+          if (tkhd && tkhd.length >= 24) {
+            const dv = new DataView(tkhd.buffer, tkhd.byteOffset, tkhd.length);
+            trackId = tkhd[0] === 1 ? dv.getUint32(20) : dv.getUint32(12);
+          }
+          const stsd = findBox(trak, ["mdia", "minf", "stbl", "stsd"]);
+          // stsd payload: version(1)+flags(3)+entry_count(4), then entries
+          const entry = stsd ? boxAt(stsd, 8) : null;
+          if (entry && (entry.type === "avc1" || entry.type === "avc3" ||
+                        entry.type === "hvc1" || entry.type === "hev1")) {
+            out.videoFourCC = entry.type;
+            out.trackId = trackId;
+            if (entry.type === "avc1" || entry.type === "avc3")
+              out.avcC = findBox(entry.payload.subarray(78), ["avcC"]);
+            const mdhd = findBox(trak, ["mdia", "mdhd"]);
+            if (mdhd && mdhd.length >= 24) {
+              const dv = new DataView(mdhd.buffer, mdhd.byteOffset, mdhd.length);
+              const ts = mdhd[0] === 1 ? dv.getUint32(20) : dv.getUint32(12);
+              if (ts > 0) out.timescale = ts;
+            }
+          }
+        }
+        off += b.size;
+      }
+      return out;
+    }
+
+    /* traf -> tfhd.track_ID (always right after the 4 fullbox bytes) */
+    function rtTrafTrackId(traf) {
+      const tfhd = findBox(traf, ["tfhd"]);
+      if (!tfhd || tfhd.length < 8) return null;
+      return new DataView(tfhd.buffer, tfhd.byteOffset, tfhd.length).getUint32(4);
+    }
+
+    /* traf -> tfdt baseMediaDecodeTime (fmp4.c writes version 1, 64-bit) */
+    function rtTrafDts(traf) {
+      const tfdt = findBox(traf, ["tfdt"]);
+      if (!tfdt || tfdt.length < 8) return null;
+      const dv = new DataView(tfdt.buffer, tfdt.byteOffset, tfdt.length);
+      return tfdt[0] === 1
+        ? (tfdt.length >= 12 ? dv.getUint32(4) * 4294967296 + dv.getUint32(8) : null)
+        : dv.getUint32(4);
+    }
+
+    /* Does this AVCC access unit contain an IDR NAL? An AU can lead with AUD
+       or SPS/PPS, so scan the whole length-prefixed chain rather than just
+       looking at the first NAL header. */
+    function rtIsKeyframe(au, lenSize) {
+      let off = 0;
+      while (off + lenSize < au.length) {
+        let n = 0;
+        for (let i = 0; i < lenSize; i++) n = n * 256 + au[off + i];
+        if (n <= 0 || off + lenSize + n > au.length) break;
+        const nalType = au[off + lenSize] & 0x1f;
+        if (nalType === 5) return true;               // IDR slice
+        off += lenSize + n;
+      }
+      return false;
+    }
+
+    function rtTeardown() {
+      if (!rt) return;
+      const st = rt;
+      rt = null;
+      st.dead = true;
+      if (st.statsTimer) { clearInterval(st.statsTimer); st.statsTimer = null; }
+      if (st.decoder) {
+        try { if (st.decoder.state !== "closed") st.decoder.close(); } catch (e) { /* ignore */ }
+        st.decoder = null;
+      }
+      if (rtCanvas) {
+        const ctx = rtCanvas.getContext("2d");
+        if (ctx) ctx.clearRect(0, 0, rtCanvas.width, rtCanvas.height);
+      }
+    }
+
+    // Leave the real-time path for the buffered one, keeping the select, the
+    // persisted preference and the audio state consistent. Used when the
+    // browser refuses the actual codec config, on a fatal decoder error, or
+    // when the init segment turns out not to be H.264 after all.
+    function rtFallbackToMse(why) {
+      mode = "mse";
+      targetBehindS = parseMargin(lastBufferedValue) === null ? DEFAULT_MARGIN_S : parseMargin(lastBufferedValue);
+      sessionStorage.setItem("ms.latency", lastBufferedValue);
+      if (rtOption) { rtOption.disabled = true; rtOption.title = why; }
+      applyModeUi();
+      applyModeAudio();
+      stopStream(why + " - switched to buffered playback.").then(() => startStream());
+    }
+
+    async function startRtStream(mySession) {
+      const chn = streamSelect.value === "1" ? "1" : "0";
+      const { base: b, tok } = await endpoint();
+      if (session !== mySession) return;
+      const src = b + "/stream.mp4?chn=" + chn + tok;
+      const hasAac = await streamHasAac(b, tok);
+      if (session !== mySession) return;
+
+      const ctx = rtCanvas ? rtCanvas.getContext("2d") : null;
+      if (!ctx) { rtFallbackToMse("No 2D canvas available"); return; }
+
+      const st = {
+        dead: false, decoder: null, trackId: null, timescale: 90000,
+        lenSize: 4, pendingVideo: false, pendingDts: null, sawKey: false,
+        frames: 0, lastFrames: 0, queueMax: 0, lastArrival: 0, lat: 0,
+        buf: new Uint8Array(0), statsTimer: null, w: 0, h: 0
+      };
+      rt = st;
+
+      const audioNote = hasAac ? " · audio unavailable in this mode" : "";
+      const label = chn === "1" ? "sub" : "main";
+
+      function fatal(msg) {
+        if (st.dead || session !== mySession) return;
+        scheduleReconnect(msg);
+      }
+
+      function scheduleReconnect(msg) {
+        if (session !== mySession) return;
+        rtTeardown();
+        try { if (abortCtrl) abortCtrl.abort(); } catch (e) { /* ignore */ }
+        abortCtrl = null;
+        running = false;
+        if (rtRetries >= RT_MAX_RETRIES) {
+          setConnectedUi(false);
+          setConnectingUi(false);
+          setStatus(msg + " - gave up after " + RT_MAX_RETRIES +
+                    " attempts. Click Connect to retry.");
+          return;
+        }
+        const delay = Math.min(8000, 500 * Math.pow(2, rtRetries));
+        rtRetries++;
+        setStatus(msg + " - reconnecting in " + (delay / 1000).toFixed(1) +
+                  "s (attempt " + rtRetries + "/" + RT_MAX_RETRIES + ")…");
+        setTimeout(() => {
+          // a stop / stream switch / mode switch in the meantime bumps the
+          // session token, and that silently cancels this retry
+          if (session !== mySession || mode !== "rt") return;
+          startStream();
+        }, delay);
+      }
+
+      function onFrame(frame) {
+        if (st.dead) { try { frame.close(); } catch (e) { /* ignore */ } return; }
+        const w = frame.displayWidth || frame.codedWidth;
+        const h = frame.displayHeight || frame.codedHeight;
+        if (w && h && (st.w !== w || st.h !== h)) {
+          st.w = w; st.h = h;
+          rtCanvas.width = w; rtCanvas.height = h;
+          // tells preview-motion.js the intrinsic size; the hidden <video>
+          // has no metadata of its own while this player owns the frame
+          window.msPreviewSize = { w: w, h: h };
+        }
+        // A backgrounded tab still gets frames; decode them (so the stream
+        // keeps flowing and we stay at the live edge) but skip the paint.
+        if (!document.hidden) {
+          try { ctx.drawImage(frame, 0, 0, rtCanvas.width, rtCanvas.height); }
+          catch (e) { /* transient canvas loss; next frame retries */ }
+        }
+        try { frame.close(); } catch (e) { /* ignore */ }
+        st.frames++;
+        if (st.lastArrival) st.lat = performance.now() - st.lastArrival;
+        if (st.frames === 1) {                 // a decoded frame = healthy link
+          rtRetries = 0;
+          rtTokenRefreshed = false;
+        }
+      }
+
+      function configure(moov) {
+        const info = rtParseMoov(moov);
+        if (!info.avcC) {
+          rtFallbackToMse(info.videoFourCC && info.videoFourCC.indexOf("hv") === 0
+            ? "Real-time mode is H.264-only (this stream is H.265)"
+            : "No H.264 configuration in the stream");
+          return false;
+        }
+        st.trackId = info.trackId;
+        st.timescale = info.timescale;
+        st.lenSize = (info.avcC[4] & 3) + 1;   // AVCDecoderConfigurationRecord
+        const codec = "avc1." +
+          [1, 2, 3].map((i) => info.avcC[i].toString(16).padStart(2, "0")).join("");
+        const config = { codec: codec, description: info.avcC, optimizeForLatency: true };
+        const dec = new VideoDecoder({
+          output: onFrame,
+          error: (e) => fatal("Decoder error: " + (e && e.message ? e.message : e))
+        });
+        // isConfigSupported is the honest check for the ACTUAL profile/level,
+        // not just "is there a VideoDecoder" - but it is async, so configure()
+        // optimistically (chunks are already arriving) and fall back if the
+        // answer comes back negative.
+        VideoDecoder.isConfigSupported(config).then((r) => {
+          if (!st.dead && r && r.supported === false)
+            rtFallbackToMse("Browser cannot decode " + codec);
+        }).catch(() => { /* not implemented -> rely on configure()/error() */ });
+        try {
+          dec.configure(config);
+        } catch (e) {
+          rtFallbackToMse("Cannot configure decoder (" + codec + ")");
+          return false;
+        }
+        st.decoder = dec;
+        setStatus("Real-time (" + label + " stream, " + codec + ")" + audioNote);
+        return true;
+      }
+
+      function onBox(type, payload) {
+        if (type === "moov") {
+          configure(payload);
+        } else if (type === "moof") {
+          st.lastArrival = performance.now();
+          const traf = findBox(payload, ["traf"]);
+          st.pendingVideo = !!traf && rtTrafTrackId(traf) === st.trackId;
+          st.pendingDts = traf ? rtTrafDts(traf) : null;
+        } else if (type === "mdat") {
+          if (!st.pendingVideo || !st.decoder || st.decoder.state !== "configured") return;
+          if (payload.length <= st.lenSize) return;
+          const key = rtIsKeyframe(payload, st.lenSize);
+          // VideoDecoder rejects a delta chunk before the first key frame;
+          // timps starts fragments at an IDR, but drop anything that arrives
+          // before one rather than throwing on it.
+          if (!key && !st.sawKey) return;
+          if (key) st.sawKey = true;
+          const ts = st.pendingDts !== null
+            ? Math.round(st.pendingDts * 1000000 / st.timescale)
+            : 0;
+          try {
+            st.decoder.decode(new EncodedVideoChunk({
+              type: key ? "key" : "delta", timestamp: ts,
+              // copy: the parser's view aliases a buffer we keep slicing
+              data: payload.slice()
+            }));
+            if (st.decoder.decodeQueueSize > st.queueMax)
+              st.queueMax = st.decoder.decodeQueueSize;
+          } catch (e) {
+            fatal("Decode failed: " + (e && e.message ? e.message : e));
+          }
+        }
+      }
+
+      /* incremental box splitter over the chunked HTTP body */
+      function push(chunk) {
+        const merged = new Uint8Array(st.buf.length + chunk.length);
+        merged.set(st.buf, 0);
+        merged.set(chunk, st.buf.length);
+        st.buf = merged;
+        let off = 0, b;
+        while (!st.dead && (b = boxAt(st.buf, off))) {
+          onBox(b.type, b.payload);
+          off += b.size;
+        }
+        st.buf = off ? st.buf.subarray(off) : st.buf;
+        // A never-completing box would otherwise grow without bound (a
+        // truncated/corrupt stream, or a proxy mangling the body).
+        if (st.buf.length > 16 * 1024 * 1024) {
+          fatal("Stream framing lost (oversized box)");
+        }
+      }
+
+      // Mode-specific stats in the same hint line the MSE path uses for its
+      // status: measured decode rate, decoder backlog and the arrival->render
+      // delay that is the whole point of this player.
+      st.statsTimer = setInterval(() => {
+        if (st.dead || !st.decoder) return;
+        const fps = st.frames - st.lastFrames;
+        st.lastFrames = st.frames;
+        setStatus("Real-time (" + label + " stream) · " +
+          (st.w ? st.w + "x" + st.h + " · " : "") +
+          fps.toFixed(0) + " fps · " + st.frames + " frames · queue " +
+          st.decoder.decodeQueueSize + " · render +" + st.lat.toFixed(1) + " ms" +
+          audioNote);
+      }, 1000);
+
+      const ctrl = new AbortController();
+      abortCtrl = ctrl;
+      try {
+        const res = await fetch(src, { signal: ctrl.signal, cache: "no-store" });
+        if (session !== mySession) { try { ctrl.abort(); } catch (e) { /* ignore */ } return; }
+        if (!res.ok || !res.body) {
+          // 5xx is transient - timps answers 503 once http_max_clients is
+          // reached, which a retry usually clears. 4xx is a decision (auth,
+          // bad channel): stop and say so instead of hammering the camera.
+          if (res.status >= 500) { scheduleReconnect("Connect failed: HTTP " + res.status); return; }
+          // ...except a 401 right after the stream dropped, which is what a
+          // timpsd restart looks like from here: the per-boot token we hold is
+          // simply the previous boot's. Pull a fresh one and retry once.
+          if (res.status === 401 && !rtTokenRefreshed) {
+            rtTokenRefreshed = true;
+            controlCache = null;
+            refreshTimpsToken();
+            rtRetries = 0;                   // new failure class, fresh budget
+            scheduleReconnect("Stream token expired (timps restarted?) - renewing");
+            return;
+          }
+          rtTeardown();
+          running = false;
+          await stopStream("Connect failed: HTTP " + res.status +
+            (res.status === 401 ? " (timps HTTP auth - open " + b + " once and log in)" : ""));
+          return;
+        }
+        setConnectedUi(true);
+        setStatus("Real-time (" + label + " stream) · waiting for a key frame…");
+        const rd = res.body.getReader();
+        while (true) {
+          const { done, value } = await rd.read();
+          if (done || st.dead || session !== mySession) break;
+          push(value);
+        }
+        if (!st.dead && session === mySession) scheduleReconnect("Stream ended");
+      } catch (e) {
+        if (st.dead || session !== mySession) return;   // aborted by us
+        // The mixed-content hint is only meaningful if we never got a single
+        // frame; after that it is just noise on an ordinary mid-stream drop.
+        scheduleReconnect("Stream error: " + (e && e.message ? e.message : e) +
+          (st.frames === 0 && rtRetries === 0
+            ? " - if the web UI runs on HTTPS this is likely blocked mixed content (see page source)"
+            : ""));
+      }
     }
 
     // Port of timps's embedded MSE player (src/mp4/httpd.c PLAYER_TAIL):
@@ -553,12 +1147,16 @@
       const mySession = ++session;   // this attempt owns the player now
       setStatus("Connecting...");
       setConnectingUi(true);
+      applyModeUi();
+      applyModeAudio();
+      if (mode === "rt") return startRtStream(mySession);
+      return startMseStream(forceVideoOnly, mySession);
+    }
 
+    async function startMseStream(forceVideoOnly, mySession) {
       const chn = streamSelect.value === "1" ? "1" : "0";
-      const info = await window.timpsTokenInfo;
-      if (info) base = (info.tls ? "https" : "http") + "://" + host + ":" + (info.port || MS_PORT);
-      const tok = info && info.token
-        ? "&token=" + encodeURIComponent(info.token) : "";
+      const ep = await endpoint();
+      const tok = ep.tok;
       const src = base + "/stream.mp4?chn=" + chn + tok;
       // iOS Safari never exposes window.MediaSource; since iOS 17.1 it
       // exposes window.ManagedMediaSource instead (requires
@@ -674,6 +1272,11 @@
             q.push(value);
             pump();
           }
+          // Clean end of the response body (daemon restart, client-limit
+          // eviction, ...): the UI used to keep saying "Connected" while the
+          // picture was frozen. Say what happened instead.
+          if (session === mySession && running && !dead)
+            setStatus("Stream ended - click Connect to reconnect.");
         } catch (e) {
           if (session === mySession && running) {
             setStatus("Stream error: " + (e && e.message ? e.message : e) +
@@ -695,13 +1298,16 @@
     // resolution/SPS needs a fresh MediaSource) - no manual Disconnect needed
     streamSelect.addEventListener("change", () => {
       sessionStorage.setItem("ms.stream", streamSelect.value || "0");
+      // main and sub can run different codecs, so the real-time gate is
+      // per-channel; this may also bounce an active rt session back to MSE
+      refreshRtOption();
       if (running) {
-        stopStream("Switching stream...").then(startStream);
+        stopStream("Switching stream...").then(() => startStream());
       }
     });
 
     connectButton.addEventListener("click", () => {
-      if (running) stopStream(); else startStream();
+      if (running) { rtRetries = 0; stopStream(); } else startStream();
     });
 
     window.addEventListener("pagehide", () => {
@@ -710,6 +1316,8 @@
 
     streamSelect.value = defaultStream === "1" ? "1" : "0";
     setConnectedUi(false);
+    applyModeUi();
+    refreshRtOption();     // async; may disable "rt" once /control answers
     startStream().catch((err) => {
       console.warn("Auto-connect failed:", err);
       setStatus("Auto-connect failed. Click Connect to try again.");
@@ -717,5 +1325,6 @@
   })();
 </script>
 <script src="/a/preview-motion.js"></script>
+<script src="/a/preview-talk.js"></script>
 </body>
 </html>

--- a/package/timps/files/www/x/json-recordings.cgi
+++ b/package/timps/files/www/x/json-recordings.cgi
@@ -14,9 +14,21 @@ CONF=/etc/timps.conf
 DIR=$(sed -n 's/^[[:space:]]*record\.dir[[:space:]]*=[[:space:]]*"\{0,1\}\([^"#]*\).*/\1/p' "$CONF" 2>/dev/null | head -n1 | tr -d ' \t')
 [ -z "$DIR" ] && DIR=/mnt/mmcblk0p1
 BASE="$DIR/$(hostname)/records"
+# Resolved once, used by within_base() below - if BASE itself doesn't exist
+# yet (no recordings ever made), fall back to the literal path so the
+# listing branch further down still reports an empty list instead of erroring.
+REAL_BASE=$(readlink -f "$BASE" 2>/dev/null) || REAL_BASE=$BASE
 
 qval() { printf '%s' "$QUERY_STRING" | sed -n "s/.*$1=\([^&]*\).*/\1/p"; }
-urldec() { printf '%b' "$(printf '%s' "$1" | sed 's/+/ /g; s/%\(..\)/\\x\1/g')"; }
+# Found by review: printf '%b' interprets EVERY backslash escape in its
+# argument, not just the \xHH sequences the second/third substitutions
+# below insert for %XX - a raw (unencoded) backslash in the query string
+# hits one of printf's other escapes (e.g. \c, "stop all output now") and
+# truncates the decoded value. Doubling any backslash already present in
+# the input FIRST means %b's \\ -> \ folds it right back to a single
+# literal backslash instead of triggering a special escape; it runs before
+# the %XX substitution below so the backslashes THAT inserts stay single.
+urldec() { printf '%b' "$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/+/ /g; s/%\(..\)/\\x\1/g')"; }
 
 FILE=$(urldec "$(qval file)")
 DEL=$(urldec "$(qval del)")
@@ -24,8 +36,23 @@ DEL=$(urldec "$(qval del)")
 # reject absolute paths and traversal
 safe() { case "$1" in "" | /* | *..*) return 1 ;; *) return 0 ;; esac }
 
+# The leaf-only symlink check further down (-L on $BASE/$FILE) only catches
+# a symlinked FILE - a symlinked DIRECTORY anywhere under BASE (e.g. a
+# planted "records/x -> /etc") walks the leaf-check right past it, since
+# the leaf itself is then a perfectly ordinary file. Resolving the whole
+# path and checking it's still under BASE closes that: a request that
+# reaches outside the recordings tree via any intermediate symlink is
+# rejected regardless of what the final component looks like.
+within_base() {
+	resolved=$(readlink -f "$1" 2>/dev/null) || return 1
+	case "$resolved" in
+		"$REAL_BASE"/*) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
 if [ -n "$DEL" ]; then
-	if safe "$DEL" && [ -f "$BASE/$DEL" ] && [ ! -L "$BASE/$DEL" ]; then
+	if safe "$DEL" && [ -f "$BASE/$DEL" ] && [ ! -L "$BASE/$DEL" ] && within_base "$BASE/$DEL"; then
 		rm -f "$BASE/$DEL"
 		printf 'Content-Type: application/json\r\n\r\n{"ok":true}\n'
 	else printf 'Status: 400 Bad Request\r\n\r\n'; fi
@@ -33,9 +60,10 @@ if [ -n "$DEL" ]; then
 fi
 
 if [ -n "$FILE" ]; then
-	# reject traversal, missing files, and symlinks (a planted symlink on an
-	# ext-formatted SD could otherwise exfiltrate arbitrary files)
-	if ! safe "$FILE" || [ ! -f "$BASE/$FILE" ] || [ -L "$BASE/$FILE" ]; then
+	# reject traversal, missing files, symlinked leaves, and (within_base)
+	# any symlinked directory component - a planted symlink anywhere under
+	# BASE could otherwise exfiltrate or delete arbitrary files
+	if ! safe "$FILE" || [ ! -f "$BASE/$FILE" ] || [ -L "$BASE/$FILE" ] || ! within_base "$BASE/$FILE"; then
 		printf 'Status: 404 Not Found\r\n\r\n'
 		exit 0
 	fi

--- a/package/timps/files/www/x/timps-imp.cgi
+++ b/package/timps/files/www/x/timps-imp.cgi
@@ -132,15 +132,39 @@ case "$cmd" in
 		;;
 	ir850 | ir940 | white)
 		# manual light override: switch auto detection off first (like the stock
-		# prudynt CGI), then drive the GPIO through thingino's light tool
+		# prudynt CGI), then drive the GPIO through thingino's light tool.
+		# val validated against light's own documented mode set (package/
+		# thingino-daynightd/files/light) for consistency with the color/
+		# daynight branches above - unquoted $val reaching a command line
+		# isn't shell-injectable (word-splitting/globbing only, no eval),
+		# but an unvalidated value was still inconsistent with those.
+		# 0/1 are in the list because they are what actually arrives:
+		# a/timps-control-bar.js toggleButton() posts a NUMERIC val (0/1),
+		# never a word - light maps them to off/on itself. "gpio"/"pin" are
+		# deliberately NOT accepted: that mode writes thingino.json.
+		case "$val" in
+			0 | 1 | on | off | toggle | read) ;;
+			*) bad_request "invalid value for $cmd" ;;
+		esac
 		curl -s $TIMPS_CURL_K -m 5 -X POST "$CONTROL_URL" \
 			-d '{"daynight":{"enabled":false}}' >/dev/null 2>&1
 		light $cmd $val
 		;;
 	ircut)
+		# val validated against ircut's own documented mode set
+		# (package/thingino-daynightd/files/ircut) plus the numeric 0/1
+		# form its own dispatch accepts - and the only form the WebUI ever
+		# sends (a/timps-control-bar.js toggleButton()).
+		case "$val" in
+			0 | 1 | on | off | toggle | status | read) ;;
+			*) bad_request "invalid value for ircut" ;;
+		esac
 		curl -s $TIMPS_CURL_K -m 5 -X POST "$CONTROL_URL" \
 			-d '{"daynight":{"enabled":false}}' >/dev/null 2>&1
 		ircut $val >/dev/null
+		;;
+	*)
+		bad_request "unknown cmd"
 		;;
 esac
 

--- a/package/timps/timps.hash
+++ b/package/timps/timps.hash
@@ -1,3 +1,2 @@
 # Locally calculated
-sha256  42ed60ccf97a0bb43380d27dd89a9c42e4b351b3046d96262419e30595b6f638  timps-v1.9.3-git4.tar.gz
-sha256  f7410bf9eaaeb2ce2abcea95a15784aec2970c8f3cbd5caf2f5fe6655b45c01f  timps-v1.9.5.tar.gz
+sha256  72aacff0706f0135715b19aa2df04727753531921ca4d4339a6c191e25967734  timps-v1.9.5-git4.tar.gz

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -639,9 +639,10 @@ TARGET_FINALIZE_HOOKS += TIMPS_PURGE_STOCK_WEBUI
 
 # Same prepend trick as TIMPS_REAPPLY_WEBUI_OVERLAY, for thingino-motors'
 # own www files instead of thingino-webui's: reapplied before assemble_plugins
-# runs, so a plain (non-fork) thingino-motors build still gets the full
-# joystick/CSS/CGIs over CGI transport. motorsWs stays false in the shipped
-# manifest - WS itself still needs the fork; this only carries the UI.
+# runs, so a timps build always gets the joystick/CSS/CGIs, whether motors
+# ships from upstream (CGI transport, motorsWs stays false) or from the WS
+# fork (motorsWs flipped true below, wss:// if WS_TLS is also on - the JS
+# itself picks ws:// vs wss:// at runtime from the page's own protocol).
 ifeq ($(BR2_PACKAGE_THINGINO_MOTORS),y)
 define TIMPS_REAPPLY_MOTORS_UI
 	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/config-motors.html \
@@ -662,6 +663,13 @@ define TIMPS_REAPPLY_MOTORS_UI
 		$(TARGET_DIR)/var/www/x/json-motors-config.cgi
 	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/motors.webui.json \
 		$(TARGET_DIR)/var/www/a/plugins/motors.webui.json
+ifeq ($(BR2_PACKAGE_THINGINO_MOTORS_WS),y)
+	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/www/motors-ui/json-motor-token.cgi \
+		$(TARGET_DIR)/var/www/x/json-motor-token.cgi
+	$(SED) 's/"motorsWs": false/"motorsWs": true/' \
+		$(TARGET_DIR)/var/www/a/plugins/motors.webui.json
+	grep -q '"motorsWs": true' $(TARGET_DIR)/var/www/a/plugins/motors.webui.json
+endif
 endef
 TARGET_FINALIZE_HOOKS := TIMPS_REAPPLY_MOTORS_UI $(TARGET_FINALIZE_HOOKS)
 endif

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -643,6 +643,20 @@ TARGET_FINALIZE_HOOKS += TIMPS_PURGE_STOCK_WEBUI
 # ships from upstream (CGI transport, motorsWs stays false) or from the WS
 # fork (motorsWs flipped true below, wss:// if WS_TLS is also on - the JS
 # itself picks ws:// vs wss:// at runtime from the page's own protocol).
+# ifeq/endif can't nest inside a define...endef recipe body (it's just text
+# handed to the shell, not re-parsed as Make) - so the WS-only lines are a
+# separate variable, conditionally defined here and referenced unconditionally
+# below; empty when undefined.
+ifeq ($(BR2_PACKAGE_THINGINO_MOTORS_WS),y)
+define TIMPS_REAPPLY_MOTORS_WS_CMDS
+	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/www/motors-ui/json-motor-token.cgi \
+		$(TARGET_DIR)/var/www/x/json-motor-token.cgi
+	$(SED) 's/"motorsWs": false/"motorsWs": true/' \
+		$(TARGET_DIR)/var/www/a/plugins/motors.webui.json
+	grep -q '"motorsWs": true' $(TARGET_DIR)/var/www/a/plugins/motors.webui.json
+endef
+endif
+
 ifeq ($(BR2_PACKAGE_THINGINO_MOTORS),y)
 define TIMPS_REAPPLY_MOTORS_UI
 	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/config-motors.html \
@@ -663,13 +677,7 @@ define TIMPS_REAPPLY_MOTORS_UI
 		$(TARGET_DIR)/var/www/x/json-motors-config.cgi
 	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/motors.webui.json \
 		$(TARGET_DIR)/var/www/a/plugins/motors.webui.json
-ifeq ($(BR2_PACKAGE_THINGINO_MOTORS_WS),y)
-	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/www/motors-ui/json-motor-token.cgi \
-		$(TARGET_DIR)/var/www/x/json-motor-token.cgi
-	$(SED) 's/"motorsWs": false/"motorsWs": true/' \
-		$(TARGET_DIR)/var/www/a/plugins/motors.webui.json
-	grep -q '"motorsWs": true' $(TARGET_DIR)/var/www/a/plugins/motors.webui.json
-endif
+	$(TIMPS_REAPPLY_MOTORS_WS_CMDS)
 endef
 TARGET_FINALIZE_HOOKS := TIMPS_REAPPLY_MOTORS_UI $(TARGET_FINALIZE_HOOKS)
 endif

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,7 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.9.5
+TIMPS_VERSION = v1.9.6
 TIMPS_LICENSE = MIT
 # Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
 # once it exists so legal-info can capture it.
@@ -222,6 +222,7 @@ define TIMPS_BUILD_CMDS
 		USE_OSD_HINTING=$(if $(BR2_PACKAGE_TIMPS_OSD_HINTING),1,0) \
 		USE_BACKCHANNEL=$(if $(BR2_PACKAGE_TIMPS_BACKCHANNEL),1,0) \
 		USE_BC_AAC=$(if $(BR2_PACKAGE_TIMPS_BC_AAC),1,0) \
+		USE_BC_WS=$(if $(BR2_PACKAGE_TIMPS_BC_WS),1,0) \
 		HELIXLIB="-lhelix-aac" \
 		HELIX_INC=$(STAGING_DIR)/usr/include \
 		USE_PLAY=$(if $(BR2_PACKAGE_TIMPS_PLAY),1,0) \
@@ -635,6 +636,35 @@ define TIMPS_PURGE_STOCK_WEBUI
 endef
 TARGET_FINALIZE_HOOKS := TIMPS_REAPPLY_WEBUI_OVERLAY $(TARGET_FINALIZE_HOOKS)
 TARGET_FINALIZE_HOOKS += TIMPS_PURGE_STOCK_WEBUI
+
+# Same prepend trick as TIMPS_REAPPLY_WEBUI_OVERLAY, for thingino-motors'
+# own www files instead of thingino-webui's: reapplied before assemble_plugins
+# runs, so a plain (non-fork) thingino-motors build still gets the full
+# joystick/CSS/CGIs over CGI transport. motorsWs stays false in the shipped
+# manifest - WS itself still needs the fork; this only carries the UI.
+ifeq ($(BR2_PACKAGE_THINGINO_MOTORS),y)
+define TIMPS_REAPPLY_MOTORS_UI
+	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/config-motors.html \
+		$(TARGET_DIR)/var/www/config-motors.html
+	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/preview-motors.js \
+		$(TARGET_DIR)/var/www/a/preview-motors.js
+	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/preview-motors-settings.js \
+		$(TARGET_DIR)/var/www/a/preview-motors-settings.js
+	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/preview-motors.css \
+		$(TARGET_DIR)/var/www/a/preview-motors.css
+	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/config-motors.js \
+		$(TARGET_DIR)/var/www/a/config-motors.js
+	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/www/motors-ui/json-motor.cgi \
+		$(TARGET_DIR)/var/www/x/json-motor.cgi
+	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/www/motors-ui/json-motor-params.cgi \
+		$(TARGET_DIR)/var/www/x/json-motor-params.cgi
+	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/www/motors-ui/json-motors-config.cgi \
+		$(TARGET_DIR)/var/www/x/json-motors-config.cgi
+	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/motors.webui.json \
+		$(TARGET_DIR)/var/www/a/plugins/motors.webui.json
+endef
+TARGET_FINALIZE_HOOKS := TIMPS_REAPPLY_MOTORS_UI $(TARGET_FINALIZE_HOOKS)
+endif
 
 # libstdc++.so is 2130 KB and, once timps links the C++ runtime statically and
 # libaudioprocess-neo replaces the proprietary (C++) libaudioProcess.so, has no


### PR DESCRIPTION
## Summary
Mirrors `package/timps` from `Lu-Fi/thingino-firmware@ciao` as of today — one commit rather than a 32-commit history replay (several were superseded in-branch, e.g. two tag corrections landing on v1.9.6).

Includes everything since the last sync, notably:
- `timps` became a real WebUI plugin instead of forking core files
- a symlink-traversal + CGI validation security fix
- the browser-mic talk feature (WebSocket, CGI-transport UI) and its WebUI button
- the motors joystick UI reapply from #1578 (superseded by this PR - can close that one)
- assorted bugfixes: motion-grid toggle, privacy editor recovery, TLS cert default, DROP_LIBSTDCPP dependency
- pinned tag now v1.9.6

## Note
Supersedes #1578 (same content is part of this sync). Happy to split into smaller PRs if that's preferred for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)