### PR TITLE
package/timps: fix stale hash for v1.9.6 tarball

### DIFF
--- a/package/timps/timps.hash
+++ b/package/timps/timps.hash
@@ -1,2 +1,2 @@
 # Locally calculated
-sha256  72aacff0706f0135715b19aa2df04727753531921ca4d4339a6c191e25967734  timps-v1.9.5-git4.tar.gz
+sha256  5a08e72b71e9129b51f552e40205feb6bb6f395557cafa93dfb81fb5c814063b  timps-v1.9.6-git4.tar.gz


### PR DESCRIPTION
Follow-up to #1579. TIMPS_VERSION was bumped to v1.9.6 but timps.hash was
never updated, still pinning the v1.9.5 tarball hash. This breaks a fresh
build (No hash found for timps-v1.9.6-git4.tar.gz).

Correct hash independently verified: cloned Lu-Fi/timps at tag v1.9.6
(with the `include` submodule) from scratch, reproduced Buildroot's git
download tarball, and confirmed the sha256 matches byte-for-byte.