### PR TITLE
package/timps: auto-enable http.https when TLS+WebUI-TLS are both built in

### DIFF
--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -257,6 +257,16 @@ define TIMPS_INSTALL_TARGET_CMDS
 			$(TARGET_DIR)/etc/timps.conf; \
 	fi
 
+	# When timps is built with TLS AND the WebUI's own uhttpd also has TLS
+	# active, ship http.https already enabled - S95timps's ensure_tls_certs()
+	# only links the shared cert pair when it sees this already set, so
+	# leaving it commented meant every TLS+WebUI image needed a manual
+	# post-flash edit before HTTPS actually worked.
+	if [ "$(BR2_PACKAGE_TIMPS_TLS)" = "y" ] && [ "$(BR2_PACKAGE_THINGINO_UHTTPD_TLS)" = "y" ]; then \
+		$(SED) 's|^# http.https .*|http.https    = 1                       # serve the HTTP port over TLS|' \
+			$(TARGET_DIR)/etc/timps.conf; \
+	fi
+
 	# Install init script
 	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/S95timps \
 		$(TARGET_DIR)/etc/init.d/S95timps


### PR DESCRIPTION
When a board is built with BR2_PACKAGE_TIMPS_TLS and the WebUI's own uhttpd
also has TLS (BR2_PACKAGE_THINGINO_UHTTPD_TLS), timps.conf shipped with
http.https commented out. S95timps's ensure_tls_certs() only links the
shared cert pair (see its own comment on why sharing the WebUI's cert
matters for per-origin browser trust) when it sees http.https already
set - so every TLS+WebUI image needed a manual post-flash edit before
HTTPS on timps's own HTTP port actually worked.

This ships http.https already enabled by default under that combined
condition, install-time, mirroring the sensor.model sed already done a
few lines above it.

Verified on real hardware (wuuk_y0510_t31x_sc4336p_ssv6158): fresh flash,
no manual config edit, http.https = 1 present on first boot and a real
TLS handshake succeeds against timps's HTTP port using the WebUI's
shared certificate.