### PR TITLE
package/timps: default BC_WS to y once its dependencies are met

### DIFF
--- a/package/timps/Config.in
+++ b/package/timps/Config.in
@@ -194,8 +194,15 @@ config BR2_PACKAGE_TIMPS_BC_WS
 	depends on BR2_PACKAGE_TIMPS_BACKCHANNEL
 	depends on BR2_PACKAGE_TIMPS_TLS
 	depends on BR2_PACKAGE_TIMPS_CONTROL
-	default n
+	default y
 	help
+	  On by default once its three dependencies are met - a browser is
+	  the only client most people actually have for talk-back (few run
+	  an ONVIF client or NVR that speaks the RTSP backchannel), and this
+	  only compiles the endpoint in. It stays dormant at runtime until
+	  audio.talk_ws is set in timps.conf, so enabling this is not a
+	  one-way door.
+
 	  Serve the audio backchannel to a browser over a WebSocket at
 	  wss://<camera>:<http_port>/talk, in addition to the ONVIF/RTSP
 	  path the backchannel already offers. The page captures the


### PR DESCRIPTION
BR2_PACKAGE_TIMPS_TLS and BR2_PACKAGE_TIMPS_CONTROL are both already
default y, so BC_WS's three `depends on` lines collapse to "BACKCHANNEL
is on" in practice. Since a browser is the only backchannel client most
people actually have (few run an ONVIF client or NVR that speaks the
RTSP backchannel), leaving BC_WS at default n meant enabling BACKCHANNEL
silently shipped a talk-back feature that only NVR software could reach.

default y here (not select, not a preset) keeps the existing depends-on
chain as the sole gate - BC_WS still only becomes visible/selectable
once its three prerequisites hold, so this doesn't touch the safe
pattern this option's own help text already documents avoiding (a
second select on BR2_PACKAGE_MBEDTLS caused a real "recursive
dependency detected" break in thingino-motors' WS_TLS option).

Not a runtime change: audio.talk_ws in timps.conf still defaults to 0,
so the endpoint stays dormant until explicitly turned on - only the
compile-time inclusion default moves.

Verified: on a build with only BACKCHANNEL explicitly set (TLS/CONTROL
at their own defaults), a fresh olddefconfig now resolves BC_WS to y.