### PR TITLE
package/timps: auto-enable audio.backchannel/talk_ws when compiled in

### DIFF
--- a/package/timps/files/timps.conf
+++ b/package/timps/files/timps.conf
@@ -86,6 +86,17 @@ http.tls_key    = /etc/ssl/private/timps.key
 # rtsp.tls      = 1                       # additionally run an RTSPS listener
 # rtsp.tls_port = 322                     # RTSPS port
 
+# ---- audio backchannel (client -> camera speaker) ----
+# ONVIF/RTSP client -> speaker (USE_BACKCHANNEL builds) and, on top of that,
+# a browser microphone over wss://<cam>:<http_port>/talk (USE_BC_WS builds,
+# needs audio.backchannel=1 too). S95timps/timps.mk auto-enables whichever
+# of these two lines its matching Kconfig option was actually built with -
+# see the http.https block above for the same install-time-default idea
+# applied to TLS. Comment a line back out after a build to opt back out
+# without rebuilding.
+# audio.backchannel = 1                   # ONVIF/RTSP client -> speaker
+# audio.talk_ws     = 1                   # + browser mic over /talk (needs TLS)
+
 # ---- SRT output (USE_SRT builds, libsrt) ----
 # Off by default: the SRT listener is unauthenticated, so don't open udp/9000
 # out of the box. Set to 1 only on trusted networks (and only matters in

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -267,6 +267,20 @@ define TIMPS_INSTALL_TARGET_CMDS
 			$(TARGET_DIR)/etc/timps.conf; \
 	fi
 
+	# Same idea as http.https above: a compiled-in feature that needs a
+	# runtime opt-in too meant BACKCHANNEL/BC_WS builds shipped silent
+	# unless someone knew to hand-edit timps.conf. Each line only flips
+	# when ITS OWN Kconfig option is on, so a BACKCHANNEL-only build (no
+	# BC_WS) still gets just the ONVIF/RTSP side enabled.
+	if [ "$(BR2_PACKAGE_TIMPS_BACKCHANNEL)" = "y" ]; then \
+		$(SED) 's|^# audio.backchannel .*|audio.backchannel = 1                   # ONVIF/RTSP client -> speaker|' \
+			$(TARGET_DIR)/etc/timps.conf; \
+	fi
+	if [ "$(BR2_PACKAGE_TIMPS_BC_WS)" = "y" ]; then \
+		$(SED) 's|^# audio.talk_ws .*|audio.talk_ws     = 1                   # + browser mic over /talk (needs TLS)|' \
+			$(TARGET_DIR)/etc/timps.conf; \
+	fi
+
 	# Install init script
 	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/S95timps \
 		$(TARGET_DIR)/etc/init.d/S95timps


### PR DESCRIPTION
Follow-up to #1585. BACKCHANNEL/BC_WS being compiled in doesn't mean the
feature is reachable: both also need a separate runtime opt-in
(audio.backchannel / audio.talk_ws in timps.conf, both default 0,
restart-required) that the shipped timps.conf template didn't even
mention. A build with BC_WS on shipped a talk button that never appears
in the WebUI, because GET /control only reports the capability once the
runtime flag is set too - easy to end up with the feature compiled in
and silently unreachable.

Same mechanism as #1584's http.https default: each line only flips when
its own matching Kconfig option is on, so a BACKCHANNEL-only build (no
BC_WS) still gets just the ONVIF/RTSP side enabled.

Worth flagging explicitly since it's a different kind of default than
#1584: that one only makes existing transport more secure by default.
This one activates a new capability (an authenticated client can drive
the camera's speaker) as soon as the matching build option is on. Given
BC_WS's own default just moved to y (#1585), leaving it compiled-in-but-
silent seemed like the more confusing state to ship - but flagging the
tradeoff here in case there's a reason to prefer requiring the explicit
runtime opt-in even so.

Verified on real hardware (wuuk_y0510_t31x_sc4336p_ssv6158): fresh flash
with only the Kconfig options on, no manual timps.conf edit, GET
/control reports caps.backchannel.talk_ws=1 on first boot.