### PR TITLE
package/timps: tri-state audio.talk_ws, and BC_WS buildable without TLS

### DIFF
--- a/package/timps/Config.in
+++ b/package/timps/Config.in
@@ -192,16 +192,17 @@ config BR2_PACKAGE_TIMPS_BC_AAC
 config BR2_PACKAGE_TIMPS_BC_WS
 	bool "Browser-microphone backchannel (WebSocket talk endpoint)"
 	depends on BR2_PACKAGE_TIMPS_BACKCHANNEL
-	depends on BR2_PACKAGE_TIMPS_TLS
 	depends on BR2_PACKAGE_TIMPS_CONTROL
-	default y
+	default y if BR2_PACKAGE_TIMPS_TLS
 	help
-	  On by default once its three dependencies are met - a browser is
-	  the only client most people actually have for talk-back (few run
-	  an ONVIF client or NVR that speaks the RTSP backchannel), and this
-	  only compiles the endpoint in. It stays dormant at runtime until
-	  audio.talk_ws is set in timps.conf, so enabling this is not a
-	  one-way door.
+	  On by default on TLS builds, where it works out of the box - a
+	  browser is the only client most people actually have for talk-back
+	  (few run an ONVIF client or NVR that speaks the RTSP backchannel),
+	  and this only compiles the endpoint in. It stays dormant at runtime
+	  until audio.talk_ws is set in timps.conf, so enabling this is not a
+	  one-way door. Without TLS it is buildable but off by default, since
+	  it then needs both a manual audio.talk_ws=2 and a browser-side
+	  secure-context override to be of any use (see below).
 
 	  Serve the audio backchannel to a browser over a WebSocket at
 	  wss://<camera>:<http_port>/talk, in addition to the ONVIF/RTSP
@@ -217,13 +218,33 @@ config BR2_PACKAGE_TIMPS_BC_WS
 	  Enabling this compiles three extra source files into timpsd (the
 	  RFC 6455 framing, SHA-1, and the talk endpoint itself) and costs
 	  roughly 8KB of text. No new library: the framing rides on the
-	  connection httpd.c has already TLS-terminated, and mu-law decode
-	  is the pure-C g711.c that the backchannel already builds.
+	  connection httpd.c hands it (already TLS-terminated, or a plain
+	  socket), and mu-law decode is the pure-C g711.c that the
+	  backchannel already builds.
 
-	  TLS is a hard requirement, not a preference: getUserMedia() is
-	  refused outside a secure context, so a plain-http:// preview page
-	  can never obtain a microphone to send. Hence "depends on
-	  BR2_PACKAGE_TIMPS_TLS" rather than a runtime warning.
+	  TLS is strongly recommended but no longer a build dependency.
+	  Which transports are served is a runtime decision, audio.talk_ws
+	  in timps.conf:
+
+	    0  off (the default until something sets it)
+	    1  on, TLS REQUIRED - /talk answers 426 on a plaintext port.
+	       This is what BR2_PACKAGE_TIMPS_TLS builds get preset to, and
+	       what "on" has always meant. In a build without TLS it can
+	       never be satisfied, so timpsd logs a warning at startup and
+	       behaves as if it were 0.
+	    2  on, TLS preferred but not required - wss:// when the port is
+	       TLS, and a plain ws:// upgrade accepted when it is not.
+
+	  Value 2 exists because the real constraint is the BROWSER, not the
+	  camera: getUserMedia() is refused outside a secure context, so a
+	  plain-http:// preview page normally cannot obtain a microphone at
+	  all. An operator can lift that themselves for a camera they own
+	  (Chrome's unsafely-treat-insecure-origin-as-secure, a trusted
+	  tunnel, localhost), and 2 is how they tell timpsd so. Understand
+	  the tradeoff before setting it: the microphone audio and the
+	  per-boot token that authorizes it then cross the network in the
+	  clear. Prefer TLS wherever it is an option; 2 is never enabled
+	  automatically, only by hand.
 
 	  The control endpoint is an equally hard requirement, for the
 	  auth story: a browser's WebSocket constructor cannot set request

--- a/package/timps/files/timps.conf
+++ b/package/timps/files/timps.conf
@@ -94,8 +94,20 @@ http.tls_key    = /etc/ssl/private/timps.key
 # see the http.https block above for the same install-time-default idea
 # applied to TLS. Comment a line back out after a build to opt back out
 # without rebuilding.
+#
+# audio.talk_ws takes three values:
+#   0  off
+#   1  on, TLS required - /talk answers 426 on a plaintext port. The value
+#      the package presets, and the only one enabled automatically.
+#   2  on, TLS preferred but not required - wss:// when http.https=1, and a
+#      plain ws:// upgrade accepted when it is not. Set this BY HAND only,
+#      and only if you understand that the microphone audio and its token
+#      then travel in the clear. The browser still refuses getUserMedia()
+#      outside a secure context, so this is only useful together with a
+#      secure-context override (e.g. chrome://flags/#unsafely-treat-
+#      insecure-origin-as-secure) or a trusted tunnel.
 # audio.backchannel = 1                   # ONVIF/RTSP client -> speaker
-# audio.talk_ws     = 1                   # + browser mic over /talk (needs TLS)
+# audio.talk_ws     = 1                   # + browser mic over /talk (1 = TLS required, 2 = also allow ws://)
 
 # ---- SRT output (USE_SRT builds, libsrt) ----
 # Off by default: the SRT listener is unauthenticated, so don't open udp/9000

--- a/package/timps/files/timps.conf
+++ b/package/timps/files/timps.conf
@@ -86,6 +86,17 @@ http.tls_key    = /etc/ssl/private/timps.key
 # rtsp.tls      = 1                       # additionally run an RTSPS listener
 # rtsp.tls_port = 322                     # RTSPS port
 
+# ---- audio backchannel (client -> camera speaker) ----
+# ONVIF/RTSP client -> speaker (USE_BACKCHANNEL builds) and, on top of that,
+# a browser microphone over wss://<cam>:<http_port>/talk (USE_BC_WS builds,
+# needs audio.backchannel=1 too). S95timps/timps.mk auto-enables whichever
+# of these two lines its matching Kconfig option was actually built with -
+# see the http.https block above for the same install-time-default idea
+# applied to TLS. Comment a line back out after a build to opt back out
+# without rebuilding.
+# audio.backchannel = 1                   # ONVIF/RTSP client -> speaker
+# audio.talk_ws     = 1                   # + browser mic over /talk (needs TLS)
+
 # ---- SRT output (USE_SRT builds, libsrt) ----
 # Off by default: the SRT listener is unauthenticated, so don't open udp/9000
 # out of the box. Set to 1 only on trusted networks (and only matters in

--- a/package/timps/files/www/a/preview-talk.js
+++ b/package/timps/files/www/a/preview-talk.js
@@ -7,17 +7,25 @@
  * uses. A browser cannot speak RTSP/RTP, which is the whole reason this
  * transport exists.
  *
- * Fails soft throughout, exactly like preview-motion.js: no token, no HTTPS, or
- * a build without the endpoint just leaves the button hidden. The button is
- * HIDDEN rather than disabled - a greyed control invites "why doesn't this
- * work", a missing one asks nothing.
+ * Fails soft throughout, exactly like preview-motion.js: no token, no secure
+ * context, or a build without the endpoint just leaves the button hidden. The
+ * button is HIDDEN rather than disabled - a greyed control invites "why
+ * doesn't this work", a missing one asks nothing.
  *
- * Requires all four of:
- *   - caps.backchannel.talk_ws == 1 from GET /control (feature compiled AND
- *     audio.talk_ws set AND the backchannel pipeline up at boot)
- *   - a TLS timps listener: getUserMedia() is refused outside a secure
- *     context, and a wss:// URL is the only thing an https:// page may open
- *   - navigator.mediaDevices.getUserMedia
+ * Requires all three of:
+ *   - caps.backchannel.talk_ws != 0 from GET /control. That field is timps'
+ *     already-decided answer, not a raw config value: 0 = it would not serve
+ *     /talk at all right now, 1 = serving, TLS required, 2 = serving, plain
+ *     ws:// accepted too. audio.talk_ws=1 on a plaintext port reports 0
+ *     (/talk would 426), so there is nothing left here to second-guess -
+ *     the only thing this file still derives is the SCHEME, from the same
+ *     timps-token.cgi "tls" field that already picks http:// vs https://.
+ *   - navigator.mediaDevices.getUserMedia. This is the one the camera cannot
+ *     fix from its side: browsers refuse it outside a secure context, so on a
+ *     plain-http:// page it is simply absent unless the operator granted the
+ *     origin one (chrome://flags/#unsafely-treat-insecure-origin-as-secure, a
+ *     trusted tunnel, localhost). Hence the check stays, and hence talk_ws=2
+ *     is only ever useful to someone who has already done that.
  *   - AudioContext with createScriptProcessor
  *
  * ScriptProcessorNode is deprecated in favour of AudioWorklet and runs on the
@@ -48,9 +56,10 @@
   const MAX_BUFFERED = 10 * WS_MAX_PAYLOAD;
   const PROBE_MAX_BACKOFF_MS = 30000;
 
-  let base = null;    // https://<host>:<port>
-  let wsBase = null;  // wss://<host>:<port>
+  let base = null;    // http(s)://<host>:<port>
+  let wsBase = null;  // ws(s)://<host>:<port>, same scheme family as `base`
   let token = null;
+  let tls = false;    // timps' http.https, per /x/timps-token.cgi
   let stopped = false; // set on pagehide; stops the probe retry loop
 
   // live session state, all null/idle between presses
@@ -289,8 +298,13 @@
     });
     if (!res.ok) throw new Error("HTTP " + res.status);
     const data = await res.json();
-    return !!(data && data.caps && data.caps.backchannel &&
-              data.caps.backchannel.talk_ws);
+    const mode = (data && data.caps && data.caps.backchannel &&
+                  data.caps.backchannel.talk_ws) | 0;
+    if (!mode) return false;
+    // mode 1 is TLS-only. timps already reports 0 for "=1 but plaintext port",
+    // so this only catches a mismatch (a stale daemon, a hand-edited proxy) -
+    // cheap enough to keep rather than trust the other end completely.
+    return mode >= 2 || tls;
   }
 
   async function init() {
@@ -311,15 +325,20 @@
     let host = location.hostname || "127.0.0.1";
     if (host.indexOf(":") >= 0 && host[0] !== "[") host = "[" + host + "]"; // raw IPv6
     const port = info.port || 8880;
-    base = (info.tls ? "https" : "http") + "://" + host + ":" + port;
-    wsBase = "wss://" + host + ":" + port;
+    tls = !!info.tls;
+    base = (tls ? "https" : "http") + "://" + host + ":" + port;
+    // Same scheme family as `base`, never hardcoded: an https:// page may only
+    // open wss:// (mixed content), and a plaintext timps listener only speaks
+    // ws://. probe() refuses to show the button for any combination timps
+    // would not actually serve.
+    wsBase = (tls ? "wss" : "ws") + "://" + host + ":" + port;
 
     window.addEventListener("pagehide", () => { stopped = true; stop(""); });
 
     // Hard gates, all permanent for this page load - no point probing without
-    // them. /talk answers 426 on a plaintext listener, and getUserMedia is
-    // undefined outside a secure context, so either one means "never".
-    if (!info.tls) return;
+    // them. getUserMedia is undefined outside a secure context, which is why
+    // audio.talk_ws=2 alone is not enough on a plain-http:// page: the
+    // operator must also have granted this origin one.
     if (!window.WebSocket) return;
     if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) return;
     if (!(window.AudioContext || window.webkitAudioContext)) return;

--- a/package/timps/files/www/preview.html
+++ b/package/timps/files/www/preview.html
@@ -164,9 +164,10 @@
               <i class="bi bi-grid-3x3"></i>
             </button>
             <!-- push-to-talk (browser mic -> camera speaker): hidden until
-                 /a/preview-talk.js confirms caps.backchannel.talk_ws AND that
-                 timps is reachable over TLS (getUserMedia needs a secure
-                 context, and only wss:// is openable from an https:// page) -->
+                 /a/preview-talk.js confirms caps.backchannel.talk_ws is non-zero
+                 (timps' own resolved verdict: 1 = TLS-only, 2 = ws:// allowed
+                 too) and that this browser exposes getUserMedia at all, which
+                 outside a secure context it will not -->
             <button type="button" class="btn btn-outline-secondary" id="ms-talk"
               title="Talk to the camera (microphone -&gt; camera speaker)" style="display:none">
               <i class="bi bi-mic"></i>

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -276,8 +276,13 @@ define TIMPS_INSTALL_TARGET_CMDS
 		$(SED) 's|^# audio.backchannel .*|audio.backchannel = 1                   # ONVIF/RTSP client -> speaker|' \
 			$(TARGET_DIR)/etc/timps.conf; \
 	fi
+	# Preset the STRICT mode (1 = TLS required) and only that: it is the
+	# safe default and the only one that works unattended. The permissive
+	# mode (2 = plain ws:// also accepted) trades the microphone stream and
+	# its token for reachability on a plaintext camera, so it stays a
+	# deliberate hand edit - never something an image ships pre-enabled.
 	if [ "$(BR2_PACKAGE_TIMPS_BC_WS)" = "y" ]; then \
-		$(SED) 's|^# audio.talk_ws .*|audio.talk_ws     = 1                   # + browser mic over /talk (needs TLS)|' \
+		$(SED) 's|^# audio.talk_ws .*|audio.talk_ws     = 1                   # + browser mic over /talk (1 = TLS required, 2 = also allow ws://)|' \
 			$(TARGET_DIR)/etc/timps.conf; \
 	fi
 

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -267,6 +267,20 @@ define TIMPS_INSTALL_TARGET_CMDS
 			$(TARGET_DIR)/etc/timps.conf; \
 	fi
 
+	# Same idea as http.https above: a compiled-in feature that needs a
+	# runtime opt-in too meant BACKCHANNEL/BC_WS builds shipped silent
+	# unless someone knew to hand-edit timps.conf. Each line only flips
+	# when ITS OWN Kconfig option is on, so a BACKCHANNEL-only build (no
+	# BC_WS) still gets just the ONVIF/RTSP side enabled.
+	if [ "$(BR2_PACKAGE_TIMPS_BACKCHANNEL)" = "y" ]; then \
+		$(SED) 's|^# audio.backchannel .*|audio.backchannel = 1                   # ONVIF/RTSP client -> speaker|' \
+			$(TARGET_DIR)/etc/timps.conf; \
+	fi
+	if [ "$(BR2_PACKAGE_TIMPS_BC_WS)" = "y" ]; then \
+		$(SED) 's|^# audio.talk_ws .*|audio.talk_ws     = 1                   # + browser mic over /talk (needs TLS)|' \
+			$(TARGET_DIR)/etc/timps.conf; \
+	fi
+
 	# Install init script
 	$(INSTALL) -D -m 0755 $(TIMPS_PKGDIR)/files/S95timps \
 		$(TARGET_DIR)/etc/init.d/S95timps


### PR DESCRIPTION
> **Stacked on #1587** (same lines in `timps.mk`/`timps.conf`); the diff shows that commit too until #1587 merges.
>
> **Not mergeable on its own yet:** it needs the matching timps daemon change, so `TIMPS_VERSION` has to move off `v1.9.6` first. Happy to push the tag and add the bump commit here on request.

Makes `/talk` (browser mic -> camera speaker) usable on a camera that is not serving TLS, without loosening anything that exists today.

### Why

`BR2_PACKAGE_TIMPS_BC_WS` currently `depends on BR2_PACKAGE_TIMPS_TLS`, and timpsd answers `426` on any plaintext connection to `/talk`. The reasoning was that `getUserMedia()` is refused outside a secure context, so a plain-`http://` page could never obtain a microphone anyway.

That is true of the browser's *default* policy, not of the operator. Someone who owns the camera can grant its origin a secure context by hand (`chrome://flags/#unsafely-treat-insecure-origin-as-secure`, a trusted tunnel, localhost) — and then the browser is willing while the daemon is the only thing still refusing.

### What changes

`audio.talk_ws` becomes a tri-state instead of a bool:

| value | `/talk` |
| --- | --- |
| `0` | not served |
| `1` | served over TLS only — plaintext gets `426`. **Unchanged meaning**, still what the package presets |
| `2` | `wss://` when the port is TLS, **and** plain `ws://` when it is not |

`1` is deliberately not made more permissive: anything already carrying `audio.talk_ws = 1` keeps exactly today's secure-only behaviour, and `2` is never enabled automatically — only by hand, after reading what it costs (the mic stream and its `?token=` then cross the network in the clear).

- **`Config.in`**: drop `depends on BR2_PACKAGE_TIMPS_TLS`; `default y if BR2_PACKAGE_TIMPS_TLS` so TLS builds behave exactly as before and TLS-less ones do not silently gain ~8KB of text for a feature they would still have to hand-enable. Help text rewritten around the tri-state.
- **`timps.mk`**: preset comment now names both values; the preset itself stays `1`.
- **`timps.conf`**: documents `0`/`1`/`2` and the secure-context caveat.
- **`preview-talk.js`**: derives the WebSocket scheme from the `tls` field it already reads from `timps-token.cgi` instead of hardcoding `wss://`, and gates the mic button on the resolved `caps.backchannel.talk_ws` (`0`/`1`/`2`) that timpsd now reports. The `navigator.mediaDevices` check stays as a client-side fail-soft — that one the camera genuinely cannot fix.

On the daemon side (separate repo): `ws.c` terminates nothing itself and every mbedTLS-facing line was already behind `#ifdef USE_TLS`, so `USE_BC_WS=1 USE_TLS=0` links cleanly once the `$(error)` is removed — nothing in the WebSocket or talk path needed changing. `audio.talk_ws=1` in a TLS-less build is unsatisfiable, so `httpd_start()` logs one warning naming `=2` as the fix and `/control` reports `talk_ws:0` so the WebUI hides the button rather than offering a broken one.

### Tested

On a T31 (wuuk_y0510, `BC_WS=y`, `TLS=y`), all five combinations over SSH + curl:

| `http.https` | `audio.talk_ws` | `caps.backchannel.talk_ws` | `/talk` |
| --- | --- | --- | --- |
| 1 | 1 | `1` | `101` + hello frame |
| 0 | 1 | `0` | `426`, plus the startup warning |
| 0 | 2 | `2` | `101` + hello frame (`http://` `Origin` accepted) |
| 0 | 0 | `0` | `404` |
| 1 | 2 | `2` | `101` |

Also compiled `USE_BC_WS=1 USE_TLS=0` for MIPS with zero warnings. Binary cost of the daemon change: +416 bytes text (mostly the warning string), data/bss unchanged.
