### PR TITLE
package/timps: bump to v1.9.7 (fixes BC_WS+no-TLS build error)

### DIFF
--- a/package/timps/timps.hash
+++ b/package/timps/timps.hash
@@ -1,2 +1,2 @@
 # Locally calculated
-sha256  5a08e72b71e9129b51f552e40205feb6bb6f395557cafa93dfb81fb5c814063b  timps-v1.9.6-git4.tar.gz
+sha256  c2ff906030cd063bf84dc338dfe5835dc78919369f72f07364d6b107b82414b1  timps-v1.9.7-git4.tar.gz

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,7 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.9.6
+TIMPS_VERSION = v1.9.7
 TIMPS_LICENSE = MIT
 # Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
 # once it exists so legal-info can capture it.


### PR DESCRIPTION
Follow-up to #1588. That PR dropped BC_WS's `depends on BR2_PACKAGE_TIMPS_TLS`,
but TIMPS_VERSION was left at v1.9.6 - whose own Makefile still has:

    ifeq ($(USE_BC_WS),1)
    ifneq ($(USE_TLS),1)
    $(error USE_BC_WS=1 requires USE_TLS=1 ...)

So on current ciao, BR2_PACKAGE_TIMPS_BC_WS=y + BR2_PACKAGE_TIMPS_TLS=n (now
Kconfig-legal after #1588) fails the build with that $(error). v1.9.7 removes
that guard (ws.c's mbedTLS-facing code is already fully `#ifdef USE_TLS`
gated, verified by compiling USE_BC_WS=1 USE_TLS=0 clean) and adds the
tri-state audio.talk_ws runtime key from #1588's own description.

Hash independently verified: fresh clone of Lu-Fi/timps at tag v1.9.7 (with
the `include` submodule), reproduced Buildroot's git download tarball,
sha256 matches byte-for-byte.

Verified on real hardware (wuuk_y0510_t31x_sc4336p_ssv6158, freshly rebuilt
with BR2_PACKAGE_TIMPS_TLS unset): timpsd links with zero mbedTLS references
(confirmed via readelf), binary shrinks 323688 -> 315324 bytes (-8364 B,
-2.6%), and a raw RFC 6455 handshake to /talk over plain ws:// (no TLS at
all, audio.talk_ws=2) succeeds with 101 Switching Protocols.