### PR TITLE
package/timps: tighten audio.talk_ws/backchannel sed to avoid dup match

### DIFF
--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -273,7 +273,7 @@ define TIMPS_INSTALL_TARGET_CMDS
 	# when ITS OWN Kconfig option is on, so a BACKCHANNEL-only build (no
 	# BC_WS) still gets just the ONVIF/RTSP side enabled.
 	if [ "$(BR2_PACKAGE_TIMPS_BACKCHANNEL)" = "y" ]; then \
-		$(SED) 's|^# audio.backchannel .*|audio.backchannel = 1                   # ONVIF/RTSP client -> speaker|' \
+		$(SED) 's|^# audio.backchannel *=.*|audio.backchannel = 1                   # ONVIF/RTSP client -> speaker|' \
 			$(TARGET_DIR)/etc/timps.conf; \
 	fi
 	# Preset the STRICT mode (1 = TLS required) and only that: it is the
@@ -282,7 +282,7 @@ define TIMPS_INSTALL_TARGET_CMDS
 	# its token for reachability on a plaintext camera, so it stays a
 	# deliberate hand edit - never something an image ships pre-enabled.
 	if [ "$(BR2_PACKAGE_TIMPS_BC_WS)" = "y" ]; then \
-		$(SED) 's|^# audio.talk_ws .*|audio.talk_ws     = 1                   # + browser mic over /talk (1 = TLS required, 2 = also allow ws://)|' \
+		$(SED) 's|^# audio.talk_ws *=.*|audio.talk_ws     = 1                   # + browser mic over /talk (1 = TLS required, 2 = also allow ws://)|' \
 			$(TARGET_DIR)/etc/timps.conf; \
 	fi
 


### PR DESCRIPTION
Follow-up to #1587. The install-time sed pattern `^# audio.talk_ws .*`
matches any commented line starting with "# audio.talk_ws " - which
includes the descriptive comment line "# audio.talk_ws takes three
values:" a few lines above the actual config line, not just the intended
"# audio.talk_ws     = 1  ..." line. On a build with BR2_PACKAGE_TIMPS_BC_WS=y
and no camera-specific overlay replacing the whole file, the shipped
timps.conf ends up with the comment header line ALSO rewritten into a
second, duplicate `audio.talk_ws = 1` line before the real one.

Tightening the pattern to `^# audio.talk_ws *=.*` (and the sibling
audio.backchannel one, for the same reason, defensively - it doesn't
currently have a colliding comment line but the fix pattern is identical
and cheap) anchors on the actual key=value shape, so it only ever matches
the one real config line.

Caught while testing on a fresh, unmodified upstream/ciao clone with no
camera overlay - our own fleet's per-camera overlays fully replace
timps.conf, which happened to mask this for every camera we'd tested on
before now. Verified the fix resolves to exactly one match in the shipped
template, and confirmed on real hardware (wuuk_y0510_t31x_sc4336p_ssv6158)
that a fresh build now ships a single, correct audio.talk_ws line.