### PR TITLE
thingino-motors: switch to the WS fork when timps or WS is selected

### DIFF
--- a/package/thingino-motors/thingino-motors.mk
+++ b/package/thingino-motors/thingino-motors.mk
@@ -1,7 +1,18 @@
+# Fork (WebSocket PTZ, not yet upstream) when WS is wanted or timps is the
+# streamer; upstream otherwise. Keyed on timps too so a timps build never
+# falls back to plain upstream just because the WS toggle is stale/off - but
+# not on a DW9714-only build, where WS is unavailable anyway (Config.in's
+# !DW9714_ONLY depends on), so there's nothing to gain from the fork there.
 THINGINO_MOTORS_SITE_METHOD = git
+ifneq ($(filter y,$(BR2_PACKAGE_THINGINO_MOTORS_WS) $(if $(BR2_PACKAGE_THINGINO_MOTORS_DW9714_ONLY),,$(BR2_PACKAGE_THINGINO_STREAMER_TIMPS))),)
+THINGINO_MOTORS_SITE = https://github.com/Lu-Fi/thingino-motors.git
+THINGINO_MOTORS_SITE_BRANCH = thingino-motors-websocket
+THINGINO_MOTORS_VERSION = caa4bf3d9f5a9fb8b72f8e0d42bd044177dfeb56
+else
 THINGINO_MOTORS_SITE = https://github.com/thingino/thingino-motors.git
 THINGINO_MOTORS_SITE_BRANCH = main
 THINGINO_MOTORS_VERSION = dcfdc27473d23a528e7bb57407fbc242de9b7053
+endif
 THINGINO_MOTORS_LICENSE = MIT
 THINGINO_MOTORS_LICENSE_FILES = LICENSE
 


### PR DESCRIPTION
master's `package/thingino-motors` always points at plain upstream `thingino/thingino-motors` regardless of streamer choice - unlike `ciao`, which already has this exact conditional (you track the fork pin there yourself). Without it, a timps build on `master` silently gets a motors daemon without the WebSocket PTZ listener that the webui plugin manifest advertises (`BR2_PACKAGE_THINGINO_MOTORS_WS`).

Ports the same conditional from `ciao` verbatim - fork+WS branch when `BR2_PACKAGE_THINGINO_MOTORS_WS` or the timps streamer is selected, plain upstream otherwise.

Verified via `printvars`: `BR2_PACKAGE_THINGINO_STREAMER_TIMPS=y` resolves `THINGINO_MOTORS_SITE` to the fork/WS branch; full build succeeds. No webui files touched - this is purely the daemon source selection.