### PR TITLE
package/timps: sync package to current state

### DIFF
--- a/package/timps/README.md
+++ b/package/timps/README.md
@@ -151,6 +151,61 @@ are set in timps.conf. Without a token (endpoint unavailable) the old
 behavior remains: open `http://<ip>:8880/` once to cache Basic credentials,
 or leave timps's HTTP auth empty — the 401 hint in the status line stays.
 
+## Preview-page talk button (browser mic → camera speaker)
+
+`files/www/a/preview-talk.js` adds a microphone button to the preview page's
+control row (`#ms-talk` in `preview.html`, with its own `#ms-talk-status`
+line so it never clobbers the player's status text). Pressed, it captures the
+visitor's microphone, G.711 mu-law-encodes it in the page and streams 20 ms
+binary frames over a WebSocket to `wss://<host>:8880/talk`, where timps
+decodes them into the same `IMP_AO` speaker path the ONVIF/RTSP backchannel
+uses — a browser cannot speak RTSP/RTP, which is the entire reason that
+endpoint exists. Pressed again (or on `pagehide`) it sends a real close frame
+(1000) so `talk_ws.c` runs `bc_release()` immediately instead of waiting out
+its stale-owner timeout.
+
+The script is installed unconditionally with the rest of `files/www/a/*`
+(WebUI + `_CONTROL` builds) and the button is **runtime**-gated, hidden not
+disabled, exactly like `/a/preview-motion.js`: it takes the per-boot token
+from `/x/timps-token.cgi` (or the shared `window.timpsTokenInfo` promise),
+probes `GET /control` and reveals itself only when
+`caps.backchannel.talk_ws == 1` — which the daemon reports only when the
+feature is compiled **and** `audio.talk_ws = 1` **and** the backchannel
+pipeline came up at boot. The probe retries with exponential backoff (1 s to
+30 s) rather than giving up on one transient failure. Three further gates are
+permanent for the page load and skip the probe entirely: `timps-token.cgi`
+reporting `tls: false` (`/talk` answers 426 on a plaintext listener), no
+`navigator.mediaDevices.getUserMedia` (refused outside a secure context), and
+no `AudioContext`. Unlike the motion overlay this reveal is one-way:
+`audio.talk_ws` is restart-only, so once `/control` says the endpoint is
+served it stays served for the life of the page.
+
+Rate handling is worth knowing about when reading the code: the page asks for
+an 8 kHz `AudioContext` (mu-law's native rate) but never assumes it got one —
+iOS Safari commonly forces 48 kHz — so it reads `ctx.sampleRate` back, checks
+it against timps' accepted list (8000/16000/24000/32000/44100/48000; `TALK_RATES`
+in `talk_ws.c`, kept in sync by hand) and passes it as `?rate=`. Capture runs
+through a `ScriptProcessorNode` terminated in a muted gain node (a
+`ScriptProcessorNode` only runs while connected to a destination, and routing
+the mic to the page's own speakers would be an instant feedback loop);
+`getUserMedia` is asked for browser-side `echoCancellation` so the camera's
+own audio playing out of those speakers is not sent back — the camera-side
+half of that is timps' `audio.aec`. Client-side backpressure drops the queue
+past ~200 ms of `bufferedAmount`, on top of the server's own drop-if-behind
+guard. Close codes are reported in the status line: 1008 = another talker
+holds the speaker, 1001 = idle timeout.
+
+Kconfig: `BR2_PACKAGE_TIMPS_BC_WS` (off by default) sets `USE_BC_WS=1` in
+`timps.mk`. It `depends on` `BR2_PACKAGE_TIMPS_BACKCHANNEL`,
+`BR2_PACKAGE_TIMPS_TLS` and `BR2_PACKAGE_TIMPS_CONTROL` — TLS because
+`getUserMedia()` needs a secure context, `_CONTROL` because the per-boot
+token machinery a `WebSocket` constructor depends on (it cannot set request
+headers, so `?token=` is its only credential) compiles only there. mbedTLS is
+deliberately **not** `select`ed here: `_TLS` already selects it, and a second
+select for the same package is what produced the "recursive dependency
+detected" breakage documented in thingino-motors' WS_TLS option. Costs ~8 KB
+of text (RFC 6455 framing, SHA-1, the endpoint itself) and no new library.
+
 ## No snapshot proxy CGIs
 
 All previews are fully self-contained: the main preview page plays timps's

--- a/package/timps/files/www/a/timps-control-bar.js
+++ b/package/timps/files/www/a/timps-control-bar.js
@@ -56,12 +56,38 @@
       : { record: { active: 0 } };
     timpsApiReady()
       .then(function (api) {
-        return api.set(payload);
-      })
-      .then(function () {
-        window.updateRecordingState({
-          ch0: !!want && channel === 0,
-          ch1: !!want && channel === 1,
+        return api.set(payload).then(function () {
+          window.updateRecordingState({
+            ch0: !!want && channel === 0,
+            ch1: !!want && channel === 1,
+          });
+          // A start request that /control ACCEPTS can still never actually
+          // record - e.g. record.min_free_mb unreachable on this card - and
+          // that only surfaces later, out of band, on the next segment-open
+          // attempt in the record thread. Poll once, short delay: if the
+          // daemon still isn't recording and just logged why, the click
+          // didn't do what the now-"active" button claims - correct both.
+          if (want) {
+            setTimeout(function () {
+              api.get().then(function (info) {
+                var rec = info && info.record;
+                if (!rec || rec.recording) return;
+                var fresh =
+                  rec.last_error &&
+                  rec.last_error_age_s != null &&
+                  rec.last_error_age_s >= 0 &&
+                  rec.last_error_age_s < 5;
+                if (!fresh) return;
+                window.updateRecordingState({ ch0: false, ch1: false });
+                if (button) button.classList.remove("active");
+                if (typeof window.showAlert === "function")
+                  window.showAlert(
+                    "danger",
+                    "Recording did not start: " + rec.last_error,
+                  );
+              });
+            }, 2000);
+          }
         });
       })
       .catch(function (err) {

--- a/package/timps/files/www/a/tool-record.js
+++ b/package/timps/files/www/a/tool-record.js
@@ -57,6 +57,19 @@
     bits.push(rec.recording ? "recording now" : "idle");
     if (rec.free_mb != null && rec.free_mb >= 0) bits.push(rec.free_mb + " MB free");
     if (rec.recording && rec.file) bits.push(rec.file);
+    // A write/prune failure (e.g. min_free_mb unreachable on this card) never
+    // flips "recording" true - without this, active=1 was accepted, nothing
+    // explains why nothing is actually being written. Only shown while
+    // recent (60s) so an old, since-resolved error doesn't stick around.
+    if (
+      !rec.recording &&
+      rec.last_error &&
+      rec.last_error_age_s != null &&
+      rec.last_error_age_s >= 0 &&
+      rec.last_error_age_s < 60
+    ) {
+      bits.push("last error: " + rec.last_error);
+    }
     statusEl.textContent = bits.join(" · ");
   }
 

--- a/package/timps/files/www/motors-ui/motors.webui.json
+++ b/package/timps/files/www/motors-ui/motors.webui.json
@@ -32,6 +32,7 @@
   "cgi": [
     "/x/json-motor.cgi",
     "/x/json-motor-params.cgi",
+    "/x/json-motor-stream.cgi",
     "/x/json-motor-token.cgi",
     "/x/json-motors-config.cgi"
   ],

--- a/package/timps/files/www/motors-ui/preview-motors.js
+++ b/package/timps/files/www/motors-ui/preview-motors.js
@@ -1,11 +1,19 @@
 /* PTZ joystick for the preview page.
  *
- * Two transports: CGI (/x/json-motor.cgi, always available) and WS
+ * Two CONTROL transports: CGI (/x/json-motor.cgi, always available) and WS
  * (motors-daemon, only when built with BR2_PACKAGE_THINGINO_MOTORS_WS -
  * window.thinginoUIConfig.device.motorsWs). The build flag alone doesn't
  * guarantee a usable socket (daemon config, https mixed-content), so
  * everything here checks "is the socket open right now" and falls back
  * to CGI per call.
+ *
+ * Two POSITION transports, for the same reason and chosen the same way: the
+ * socket's own "status" pushes while it is open, and otherwise the
+ * /x/json-motor-stream.cgi SSE stream that every build ships. The CGI
+ * control path deliberately does NOT echo position back per move (see
+ * json-motor.cgi's own comment - it used to, and it cost a second `motors`
+ * process on every 90ms jog), so without one of these two the readout has no
+ * source at all. motorPositionStream below keeps exactly one of them live.
  */
 
 function runMotorCmd(args) {
@@ -29,6 +37,11 @@ const MOTOR_WS_TOKEN_URL = "/x/json-motor-token.cgi";
 const MOTOR_WS_CONNECT_TIMEOUT_MS = 4000;
 // After this many failed attempts, stay on CGI for the rest of the page's life.
 const MOTOR_WS_MAX_ATTEMPTS = 3;
+
+// Assigned by motorPositionStream below, once it exists. Called from every
+// place the socket's state can change so exactly one position transport is
+// ever running; a no-op until then, which covers the module-load window.
+let syncPositionTransport = function () {};
 
 const motorWs = (function () {
   let socket = null;
@@ -130,6 +143,9 @@ const motorWs = (function () {
             /* the send below will report it */
           }
         }
+        // Socket owns position from here; drop the SSE stream if it was
+        // covering for it.
+        syncPositionTransport();
         resolve(ws);
       };
       ws.onerror = () => {
@@ -138,6 +154,10 @@ const motorWs = (function () {
       };
       ws.onclose = () => {
         if (socket === ws) socket = null;
+        // Nothing is pushing position any more - hand it back to the SSE
+        // stream immediately rather than waiting for the 15s reconnect
+        // backstop to give up.
+        syncPositionTransport();
       };
       ws.onmessage = onMessage;
     });
@@ -284,15 +304,92 @@ async function moveMotor(dir, steps = 100, d = "g") {
   }
 }
 
+// --- live position -----------------------------------------------------
+
+// Joystick mode's DOM readout (bindPositionReadout's closure), or null in the
+// modes that draw no position. Module-level so every transport can reach it
+// through the single funnel below instead of each wiring up its own.
+let motorPositionRenderer = null;
+
+// THE funnel. Every source of a position - the WS status/hello pushes, the
+// SSE stream, and json-motor.cgi's d=j one-shot - lands here, so the DOM
+// readout and window.motorPosition can never disagree about which transport
+// is live.
 function updatePositionDisplay(xpos, ypos) {
-  if (xpos === undefined) return;
+  if (xpos === undefined || ypos === undefined) return;
+  // `motors -j` (and therefore the CGI and the SSE stream) reports these as
+  // JSON strings; the WS frames report numbers. Normalize, or the readout
+  // arithmetic below silently concatenates instead of adding.
+  const x = Number(xpos);
+  const y = Number(ypos);
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return;
   // Expose for other plugins/view models (e.g. the settings modal's
-  // "capture current position" button) - kept in sync from BOTH transports
-  // below (the CGI one-shot response and every WS position push), so a
-  // reader always gets the latest value without polling json-motor.cgi d=j
-  // itself. bindPositionReadout()'s own DOM bars are separate and unaffected.
-  window.motorPosition = { xpos, ypos };
+  // "capture current position" button), so a reader always gets the latest
+  // value without polling json-motor.cgi d=j itself.
+  window.motorPosition = { xpos: x, ypos: y };
+  if (motorPositionRenderer) motorPositionRenderer(x, y);
 }
+
+// SSE position stream - the transport every build has, and the only one a
+// non-timps streamer gets (BR2_PACKAGE_THINGINO_MOTORS_WS defaults on only
+// when timps is the streamer). Runs whenever the socket isn't up, which
+// covers all four cases uniformly: no WS in this build at all, WS built but
+// the connect attempts are spent, WS never reachable on this page (https://
+// with no daemon cert), and a socket that opened and later died.
+const motorPositionStream = (function () {
+  let es = null;
+  let warned = false;
+
+  function stop() {
+    if (!es) return;
+    try {
+      es.close();
+    } catch (err) {
+      /* already gone */
+    }
+    es = null;
+  }
+
+  function start() {
+    if (es || !("EventSource" in window)) return;
+    try {
+      es = new EventSource("/x/json-motor-stream.cgi");
+    } catch (err) {
+      es = null; // blocked (CSP) or unsupported; nothing else to try
+      return;
+    }
+    es.addEventListener("message", (ev) => {
+      let data;
+      try {
+        data = JSON.parse(ev.data);
+      } catch (err) {
+        return; // malformed frame
+      }
+      // The CGI emits {"error":"..."} frames when `motors` is missing or
+      // unreadable; those carry no position and must not clear the readout.
+      if (!data || data.xpos === undefined) return;
+      updatePositionDisplay(data.xpos, data.ypos);
+    });
+    es.onerror = () => {
+      // EventSource reconnects on its own (the CGI even sends a retry:
+      // hint), so there is nothing to do but say so once.
+      if (!warned) {
+        warned = true;
+        console.warn("motors: position stream interrupted, retrying");
+      }
+    };
+  }
+
+  // Exactly one live-position source at a time.
+  function sync() {
+    if (motorWs.isOpen()) stop();
+    else start();
+  }
+
+  return { sync, stop };
+})();
+
+syncPositionTransport = motorPositionStream.sync;
 
 // upstream's keyboard-jog (Shift+arrow) feature is deliberately not ported
 // here, same decision as this morning's merge: it depends on a
@@ -318,7 +415,55 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   // Not awaited: a slow/absent listener must not delay binding the controls.
-  motorWs.connect();
+  // The position transport IS decided on the result though - starting the SSE
+  // stream first and cancelling it a moment later would spawn a CGI process
+  // per page load on every WS build for nothing. connect() resolves
+  // immediately (with null) when the build has no WS path at all, so the
+  // CGI-only case pays no delay for this.
+  motorWs.connect().then(syncPositionTransport);
+
+  // A bfcache restore (browser back/forward) revives this exact DOM/JS state
+  // without re-running DOMContentLoaded, so the socket connect() above never
+  // fires again - the WebSocket that was open before navigating away is
+  // already closed by the browser, and nothing would otherwise reconnect it.
+  // connect() itself is a no-op if a socket is already open, so this is safe
+  // to call on every non-bfcache pageshow too.
+  // A bfcache restore also closed the EventSource, so sync afterwards either
+  // way: it reopens the stream if the socket didn't come back.
+  window.addEventListener("pageshow", (ev) => {
+    if (ev.persisted) motorWs.connect().then(syncPositionTransport);
+  });
+
+  // Belt and braces: some browsers evict a long-backgrounded tab into the
+  // same bfcache path (observed: Edge's tab-freeze after ~20 min hidden)
+  // without reliably firing pageshow's persisted flag on the way back.
+  // visibilitychange fires whenever the tab regains focus regardless of
+  // *why* the socket died - idle discard, a network blip, the daemon
+  // restarting - so this is the actual catch-all; the pageshow listener
+  // above just covers the common case a little earlier.
+  document.addEventListener("visibilitychange", () => {
+    if (!document.hidden) motorWs.connect().then(syncPositionTransport);
+  });
+
+  // ...and a periodic backstop, for the same reason preview.html grew one: a
+  // long-backgrounded tab may come back without either of the two handlers
+  // above firing at all (the socket's onclose can land while hidden, after
+  // the last visibilitychange), leaving PTZ silently on the CGI fallback -
+  // or on nothing - until the user switches tabs again. Only while visible;
+  // connect() is a no-op when a socket is already open, so this costs one
+  // readyState read every 15s. Not armed at all on a build without the WS
+  // control path, where connect() is a permanent no-op; and it only logs on
+  // an actual recovery, so a camera whose listener is simply absent (the
+  // attempts cap in connect() ends that quickly) stays quiet.
+  if (motorWs.enabledAtBuild()) {
+    setInterval(() => {
+      if (document.hidden || motorWs.isOpen()) return;
+      motorWs.connect().then((ws) => {
+        syncPositionTransport();
+        if (ws) console.info("motors: PTZ socket was down while visible - reconnected");
+      });
+    }, 15000);
+  }
 
   // A bfcache restore (browser back/forward) revives this exact DOM/JS state
   // without re-running DOMContentLoaded, so the socket connect() above never
@@ -362,7 +507,6 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   let timer;
 
-  let renderPosition = null; // joystick mode's live pan/tilt readout, or null
   let activeControlMode = null;
   let modeAbort = null; // owns every listener the active mode registered
 
@@ -476,8 +620,15 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   // Live pan/tilt readout, joystick mode only - a held stick runs toward a
-  // limit the video gives no warning of. 200ms cadence (matches the
-  // socket's own); the CSS transition smooths it further for free.
+  // limit the video gives no warning of. 200ms cadence over the socket
+  // (matches its own); ~1s over the SSE stream, which is what the CGI-only
+  // build has always offered. The CSS transition smooths either for free.
+  //
+  // Takes plain x/y rather than a WS frame: the SSE stream has no frame
+  // shape to speak of, and the travel limits are better sourced here anyway
+  // - the daemon's reported limits when there is a daemon, and the
+  // configured steps_pan/steps_tilt otherwise (a frame's own x_max is 0 when
+  // unknown, which used to collapse the bar to zero width).
   function bindPositionReadout() {
     const wrap = $("#motor-pos");
     const barX = $("#motor-pos-x");
@@ -487,14 +638,14 @@ document.addEventListener("DOMContentLoaded", async function () {
 
     motorWs.subscribe(200);
 
-    return function render(frame) {
-      if (typeof frame.x !== "number" || typeof frame.y !== "number") return;
-      const xMax = frame.x_max || motorWs.limits.x;
-      const yMax = frame.y_max || motorWs.limits.y;
-      if (barX) barX.style.width = xMax ? (frame.x / xMax) * 100 + "%" : "0";
+    return function render(x, y) {
+      const params = window.motorParams || {};
+      const xMax = motorWs.limits.x || Number(params.steps_pan) || 0;
+      const yMax = motorWs.limits.y || Number(params.steps_tilt) || 0;
+      if (barX) barX.style.width = xMax ? (x / xMax) * 100 + "%" : "0";
       // tilt's bar is vertical (preview-motors.css), filled by height
-      if (barY) barY.style.height = yMax ? (frame.y / yMax) * 100 + "%" : "0";
-      if (text) text.textContent = frame.x + " / " + frame.y;
+      if (barY) barY.style.height = yMax ? (y / yMax) * 100 + "%" : "0";
+      if (text) text.textContent = x + " / " + y;
     };
   }
 
@@ -583,9 +734,10 @@ document.addEventListener("DOMContentLoaded", async function () {
     let flushTimer = null;
     let cgiInterval = null;
 
+    // Position is NOT handled here any more: onMessage() already funnels
+    // every frame's x/y through updatePositionDisplay(), which is what draws
+    // the readout now. This listener is only for the error frames below.
     motorWs.setFrameListener((frame) => {
-      if (renderPosition && (frame.type === "status" || frame.type === "hello"))
-        renderPosition(frame);
       // Daemon predates the vector command: give up on the socket
       // permanently (not per-press) and finish the gesture on the CGI.
       if (
@@ -770,7 +922,8 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (motorEl) motorEl.classList.remove("stick-mode");
 
     activeControlMode = mode;
-    renderPosition = mode === "joystick" ? bindPositionReadout() : null;
+    motorPositionRenderer =
+      mode === "joystick" ? bindPositionReadout() : null;
 
     if (mode === "joystick") {
       bindJoystickControls(signal);

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -672,6 +672,30 @@ TARGET_FINALIZE_HOOKS += TIMPS_PURGE_STOCK_WEBUI
 # ships from upstream (CGI transport, motorsWs stays false) or from the WS
 # fork (motorsWs flipped true below, wss:// if WS_TLS is also on - the JS
 # itself picks ws:// vs wss:// at runtime from the page's own protocol).
+#
+# WHY A FINALIZE HOOK AND NOT A PLAIN INSTALL (tried, reverted 2026-09-04):
+# moving this bundle into package/thingino-motors/ and letting that package
+# install it at normal install time does produce a correct image today, but it
+# only wins the BR2_PER_PACKAGE_DIRECTORIES merge by accident: it depends on no
+# other package that pulls in thingino-webui sorting after thingino-motors and
+# carrying a competing copy of these paths. That is the same fragile property
+# that produced the original overlay-clobber bug (see TIMPS_REAPPLY_WEBUI_
+# OVERLAY's comment above), so it is not something to rely on a second time.
+# Running from the GLOBAL target-finalize phase - after the per-package merge -
+# makes our copy win by construction rather than by sort order.
+#
+# The bundle deliberately lives HERE and not in package/thingino-motors/:
+# thingino-motors is shared infrastructure we keep in sync with upstream, and
+# this UI (WebSocket PTZ, analog stick, live position readout) is a timps-only
+# elaboration we are not pushing into Paul's deliberately simpler package.
+# thingino-motors therefore stays exactly as upstream ships it.
+#
+# One file is NOT reapplied here on purpose: x/json-motor-stream.cgi, the SSE
+# position source preview-motors.js falls back to when the WebSocket path is
+# off or unreachable. That script is upstream's, unmodified, and thingino-motors
+# already installs it - forking it would be pure divergence. The hook is gated
+# on BR2_PACKAGE_THINGINO_MOTORS below, so that package is always present.
+#
 # ifeq/endif can't nest inside a define...endef recipe body (it's just text
 # handed to the shell, not re-parsed as Make) - so the WS-only lines are a
 # separate variable, conditionally defined here and referenced unconditionally
@@ -686,7 +710,10 @@ define TIMPS_REAPPLY_MOTORS_WS_CMDS
 endef
 endif
 
-ifeq ($(BR2_PACKAGE_THINGINO_MOTORS),y)
+# Gated on the streamer choice as well as on motors: these files are timps's
+# fork of the motors UI, so a build where timps is not the selected streamer
+# must keep upstream thingino-motors' own version untouched.
+ifeq ($(BR2_PACKAGE_THINGINO_MOTORS)$(BR2_PACKAGE_THINGINO_STREAMER_TIMPS),yy)
 define TIMPS_REAPPLY_MOTORS_UI
 	$(INSTALL) -D -m 0644 $(TIMPS_PKGDIR)/files/www/motors-ui/config-motors.html \
 		$(TARGET_DIR)/var/www/config-motors.html


### PR DESCRIPTION
## Summary
- Hardens the `TIMPS_REAPPLY_MOTORS_UI` finalize-hook gate (now also keyed on the streamer choice, not just on `BR2_PACKAGE_THINGINO_MOTORS`), with an expanded comment documenting why a finalize hook is used instead of a plain package-time install (a prior attempt to move the motors UI bundle into `package/thingino-motors/` only won the `BR2_PER_PACKAGE_DIRECTORIES` merge by sort-order accident and was reverted).
- Adds the SSE position-stream fallback (`/x/json-motor-stream.cgi`) to `preview-motors.js` for when the WebSocket PTZ path is off or unreachable.
- Surfaces recorder write/prune failures in the WebUI: the control bar now polls once after a start request and corrects the button state if recording never actually began, and the record tool's status line shows the last error.
- README/version bookkeeping.

## Test plan
- [x] Verified `TIMPS_REAPPLY_MOTORS_UI` gate resolves correctly for timps/non-timps streamer builds via `printvars`
- [x] Live-tested SSE position fallback against a running device (physical PTZ movement reflected correctly with WS off)
- [x] Verified record-error surfacing against a device with `record.min_free_mb` unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)