### PR TITLE
package/timps: shfmt-format timps-irprobe

### DIFF
--- a/package/timps/files/timps-irprobe
+++ b/package/timps/files/timps-irprobe
@@ -10,8 +10,11 @@
 # idempotent.
 for t in ir940 ir850 ir; do
 	if [ -n "$(light $t gpio 2>/dev/null)" ]; then
-		[ "$1" = off ] && ( sleep 60; light $t on ) >/dev/null 2>&1 &
+		[ "$1" = off ] && (
+			sleep 60
+			light $t on
+		) >/dev/null 2>&1 &
 		exec light $t "$1"
 	fi
 done
-exit 1   # no switchable illuminator: timps logs the failure and skips the probe
+exit 1 # no switchable illuminator: timps logs the failure and skips the probe


### PR DESCRIPTION
## Summary
- `package/timps/files/timps-irprobe` has failed `shfmt -i 0 -ci` since it was introduced in #1507, which merged with a red `format` check.
- This applies the same formatting fix already made on `master` in #1598, so the file is now identical (and CI-clean) on both branches.

## Test plan
- [x] `shfmt -i 0 -ci -d package/timps/files/timps-irprobe` now reports no diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)