### PR TITLE
thingino-motors: define the WS/WS_TLS Kconfig symbols on master

### DIFF
--- a/package/thingino-motors/Config.in
+++ b/package/thingino-motors/Config.in
@@ -8,3 +8,41 @@ config BR2_PACKAGE_THINGINO_MOTORS_DW9714_ONLY
 	bool "DW9714 Focus Control"
 	help
 	  Enable support for DW9714 VCM, includes control script
+
+config BR2_PACKAGE_THINGINO_MOTORS_WS
+	bool "WebSocket PTZ control path"
+	depends on BR2_PACKAGE_THINGINO_MOTORS
+	depends on !BR2_PACKAGE_THINGINO_MOTORS_DW9714_ONLY
+	depends on BR2_TOOLCHAIN_HAS_THREADS
+	default y if BR2_PACKAGE_THINGINO_STREAMER_TIMPS
+	help
+	  Serve PTZ control over a WebSocket listener in motors-daemon
+	  (ws://<camera>:8089/ws), replacing one CGI round trip per move
+	  with a persistent connection. Costs ~25KB of text, -lpthread.
+	  Falls back to the CGI path if the socket can't be opened.
+
+	  Defaults on when timps is the streamer. Not selected outright:
+	  select would bypass this symbol's own depends chain, same
+	  failure class as WS_TLS below.
+
+	  Switches thingino-motors.mk's source to Lu-Fi's fork, where this
+	  unmerged feature lives - endorsed by the upstream maintainer as
+	  the way to gate it without forcing every build onto a fork.
+
+config BR2_PACKAGE_THINGINO_MOTORS_WS_TLS
+	bool "wss:// (TLS) on the WebSocket PTZ listener"
+	depends on BR2_PACKAGE_THINGINO_MOTORS_WS
+	# depends on, not select: select closed a real Kconfig dependency
+	# cycle against the uhttpd TLS default (regression 2026-08-29).
+	depends on BR2_PACKAGE_MBEDTLS
+	default y if BR2_PACKAGE_THINGINO_UHTTPD_TLS_MBEDTLS
+	help
+	  Also accept TLS-wrapped connections on the same port (ws:// and
+	  wss:// share it; the daemon peeks at the first byte). Needed if
+	  the web UI is served over https:// - otherwise the browser
+	  blocks plain ws:// as mixed content and PTZ silently falls back
+	  to one CGI round trip per command.
+
+	  Reuses S95timps' certificate, no new one is minted. Costs ~9KB
+	  of text plus ~21KB heap per connected TLS client (default max 4
+	  clients).

--- a/package/thingino-motors/thingino-motors.mk
+++ b/package/thingino-motors/thingino-motors.mk
@@ -8,12 +8,6 @@ ifneq ($(filter y,$(BR2_PACKAGE_THINGINO_MOTORS_WS) $(if $(BR2_PACKAGE_THINGINO_
 THINGINO_MOTORS_SITE = https://github.com/Lu-Fi/thingino-motors.git
 THINGINO_MOTORS_SITE_BRANCH = thingino-motors-websocket
 THINGINO_MOTORS_VERSION = caa4bf3d9f5a9fb8b72f8e0d42bd044177dfeb56
-# Everything below keyed on this, not on BR2_PACKAGE_THINGINO_MOTORS_WS
-# directly: the build-command/version-stamp additions are fork-specific and
-# must never touch upstream's own daemon build, even in the DW9714-only edge
-# case where WS itself is off but the filter above could still (it can't
-# today, but wouldn't be obvious from re-reading just this block) end up here.
-THINGINO_MOTORS_USE_FORK = y
 else
 THINGINO_MOTORS_SITE = https://github.com/thingino/thingino-motors.git
 THINGINO_MOTORS_SITE_BRANCH = main
@@ -24,9 +18,11 @@ THINGINO_MOTORS_LICENSE_FILES = LICENSE
 
 THINGINO_MOTORS_DEPENDENCIES += thingino-jct
 
-# Everything in this block is fork-only: it must never change a plain
-# upstream-daemon build's command line, so it all lives inside USE_FORK.
-ifeq ($(THINGINO_MOTORS_USE_FORK),y)
+# Everything in this block only matters for the WS build (version stamp,
+# extra sources/libs/defs, the size-optimization flags below) - gated on the
+# same BR2_PACKAGE_THINGINO_MOTORS_WS the SITE choice above already keys off,
+# so it never touches a plain upstream-daemon build's command line.
+ifeq ($(BR2_PACKAGE_THINGINO_MOTORS_WS),y)
 
 # `motors --version` and the "version" key in `motors -j` answer "which build
 # is this camera actually running" - snapshot with := here, because
@@ -44,24 +40,21 @@ endif
 # Single quotes make it survive as a C string literal through the recipe.
 THINGINO_MOTORS_VERSION_DEF = -DMOTORS_BUILD_VERSION='"$(THINGINO_MOTORS_BUILD_VERSION)"'
 
-# Compiled directly via $(TARGET_CC); SRCS/LIBS/DEFS collect what WS/TLS add.
-# $(@D) is only valid in a recipe, so these stay recursively expanded (+=).
-THINGINO_MOTORS_DAEMON_SRCS = $(@D)/src/motor-daemon.c
-THINGINO_MOTORS_DAEMON_LIBS = -ljct -lm
-THINGINO_MOTORS_DAEMON_DEFS =
-
-ifeq ($(BR2_PACKAGE_THINGINO_MOTORS_WS),y)
-THINGINO_MOTORS_DAEMON_SRCS += \
+# Compiled directly via $(TARGET_CC). $(@D) is only valid in a recipe, so
+# these stay recursively expanded (+=). WS is already guaranteed y by the
+# ifeq above, so no need to re-check it here.
+THINGINO_MOTORS_DAEMON_SRCS = \
+	$(@D)/src/motor-daemon.c \
 	$(@D)/src/sha1.c \
 	$(@D)/src/sha256.c \
 	$(@D)/src/ws.c \
 	$(@D)/src/ws_token.c \
 	$(@D)/src/motor-ws.c
-THINGINO_MOTORS_DAEMON_LIBS += -lpthread
+THINGINO_MOTORS_DAEMON_LIBS = -ljct -lm -lpthread
 # motor-daemon.c starts the listener only under #ifdef MOTORS_WS.
-THINGINO_MOTORS_DAEMON_DEFS += -DMOTORS_WS
+THINGINO_MOTORS_DAEMON_DEFS = -DMOTORS_WS
 
-# Nested in WS: TLS wraps the listener, nothing to wrap without it.
+# TLS wraps the WS listener, nothing to wrap without it.
 ifeq ($(BR2_PACKAGE_THINGINO_MOTORS_WS_TLS),y)
 THINGINO_MOTORS_DEPENDENCIES += mbedtls
 THINGINO_MOTORS_DAEMON_SRCS += $(@D)/src/ws_tls.c
@@ -69,8 +62,7 @@ THINGINO_MOTORS_DAEMON_SRCS += $(@D)/src/ws_tls.c
 THINGINO_MOTORS_DAEMON_LIBS += -lmbedtls -lmbedx509 -lmbedcrypto
 THINGINO_MOTORS_DAEMON_DEFS += -DMOTORS_WS_TLS
 endif
-endif
-endif # THINGINO_MOTORS_USE_FORK
+endif # BR2_PACKAGE_THINGINO_MOTORS_WS
 
 define THINGINO_MOTORS_INSTALL_JSON_CMDS
 	# Stage defaults for later merge by thingino-core
@@ -119,9 +111,9 @@ define THINGINO_MOTORS_INSTALL_WWW_CMDS
 endef
 endif
 
-ifeq ($(THINGINO_MOTORS_USE_FORK),y)
+ifeq ($(BR2_PACKAGE_THINGINO_MOTORS_WS),y)
 # -ffunction-sections/-fdata-sections + --gc-sections: per-function dead-code
-# stripping. Measured -7680 B (-12.2%) on the WS build. Fork-only, same as
+# stripping. Measured -7680 B (-12.2%) on the WS build. WS-only, same as
 # the variables it references - the plain upstream daemon build below is
 # untouched, byte for byte, from what thingino/thingino-motors ships.
 define THINGINO_MOTORS_BUILD_CMDS

--- a/package/thingino-motors/thingino-motors.mk
+++ b/package/thingino-motors/thingino-motors.mk
@@ -8,6 +8,12 @@ ifneq ($(filter y,$(BR2_PACKAGE_THINGINO_MOTORS_WS) $(if $(BR2_PACKAGE_THINGINO_
 THINGINO_MOTORS_SITE = https://github.com/Lu-Fi/thingino-motors.git
 THINGINO_MOTORS_SITE_BRANCH = thingino-motors-websocket
 THINGINO_MOTORS_VERSION = caa4bf3d9f5a9fb8b72f8e0d42bd044177dfeb56
+# Everything below keyed on this, not on BR2_PACKAGE_THINGINO_MOTORS_WS
+# directly: the build-command/version-stamp additions are fork-specific and
+# must never touch upstream's own daemon build, even in the DW9714-only edge
+# case where WS itself is off but the filter above could still (it can't
+# today, but wouldn't be obvious from re-reading just this block) end up here.
+THINGINO_MOTORS_USE_FORK = y
 else
 THINGINO_MOTORS_SITE = https://github.com/thingino/thingino-motors.git
 THINGINO_MOTORS_SITE_BRANCH = main
@@ -17,6 +23,10 @@ THINGINO_MOTORS_LICENSE = MIT
 THINGINO_MOTORS_LICENSE_FILES = LICENSE
 
 THINGINO_MOTORS_DEPENDENCIES += thingino-jct
+
+# Everything in this block is fork-only: it must never change a plain
+# upstream-daemon build's command line, so it all lives inside USE_FORK.
+ifeq ($(THINGINO_MOTORS_USE_FORK),y)
 
 # `motors --version` and the "version" key in `motors -j` answer "which build
 # is this camera actually running" - snapshot with := here, because
@@ -60,6 +70,7 @@ THINGINO_MOTORS_DAEMON_LIBS += -lmbedtls -lmbedx509 -lmbedcrypto
 THINGINO_MOTORS_DAEMON_DEFS += -DMOTORS_WS_TLS
 endif
 endif
+endif # THINGINO_MOTORS_USE_FORK
 
 define THINGINO_MOTORS_INSTALL_JSON_CMDS
 	# Stage defaults for later merge by thingino-core
@@ -108,12 +119,21 @@ define THINGINO_MOTORS_INSTALL_WWW_CMDS
 endef
 endif
 
+ifeq ($(THINGINO_MOTORS_USE_FORK),y)
 # -ffunction-sections/-fdata-sections + --gc-sections: per-function dead-code
-# stripping. Measured -7680 B (-12.2%) on the WS build.
+# stripping. Measured -7680 B (-12.2%) on the WS build. Fork-only, same as
+# the variables it references - the plain upstream daemon build below is
+# untouched, byte for byte, from what thingino/thingino-motors ships.
 define THINGINO_MOTORS_BUILD_CMDS
 	$(TARGET_CC) $(TARGET_LDFLAGS) -Os -s -ffunction-sections -fdata-sections $(THINGINO_MOTORS_VERSION_DEF) $(@D)/src/motor.c -o $(@D)/motors -ljct -Wl,--gc-sections
 	$(TARGET_CC) $(TARGET_LDFLAGS) -Os -s -ffunction-sections -fdata-sections $(THINGINO_MOTORS_DAEMON_DEFS) $(THINGINO_MOTORS_DAEMON_SRCS) -o $(@D)/motors-daemon $(THINGINO_MOTORS_DAEMON_LIBS) -Wl,--gc-sections
 endef
+else
+define THINGINO_MOTORS_BUILD_CMDS
+	$(TARGET_CC) $(TARGET_LDFLAGS) -Os -s $(@D)/src/motor.c -o $(@D)/motors -ljct
+	$(TARGET_CC) $(TARGET_LDFLAGS) -Os -s $(@D)/src/motor-daemon.c -o $(@D)/motors-daemon -ljct -lm
+endef
+endif
 
 define THINGINO_MOTORS_INSTALL_TARGET_CMDS
 	$(INSTALL) -D -m 0755 $(@D)/motors \

--- a/package/thingino-motors/thingino-motors.mk
+++ b/package/thingino-motors/thingino-motors.mk
@@ -18,6 +18,49 @@ THINGINO_MOTORS_LICENSE_FILES = LICENSE
 
 THINGINO_MOTORS_DEPENDENCIES += thingino-jct
 
+# `motors --version` and the "version" key in `motors -j` answer "which build
+# is this camera actually running" - snapshot with := here, because
+# $(eval $(generic-package)) below rewrites THINGINO_MOTORS_VERSION to the
+# literal "custom" whenever an OVERRIDE_SRCDIR is set.
+THINGINO_MOTORS_PINNED_VERSION := $(THINGINO_MOTORS_VERSION)
+ifneq ($(call qstrip,$(THINGINO_MOTORS_OVERRIDE_SRCDIR)),)
+THINGINO_MOTORS_GIT_DESCRIBE := $(shell git -C $(call qstrip,$(THINGINO_MOTORS_OVERRIDE_SRCDIR)) describe --tags --always --dirty 2>/dev/null)
+endif
+ifneq ($(THINGINO_MOTORS_GIT_DESCRIBE),)
+THINGINO_MOTORS_BUILD_VERSION = $(THINGINO_MOTORS_GIT_DESCRIBE)
+else
+THINGINO_MOTORS_BUILD_VERSION = $(THINGINO_MOTORS_PINNED_VERSION)
+endif
+# Single quotes make it survive as a C string literal through the recipe.
+THINGINO_MOTORS_VERSION_DEF = -DMOTORS_BUILD_VERSION='"$(THINGINO_MOTORS_BUILD_VERSION)"'
+
+# Compiled directly via $(TARGET_CC); SRCS/LIBS/DEFS collect what WS/TLS add.
+# $(@D) is only valid in a recipe, so these stay recursively expanded (+=).
+THINGINO_MOTORS_DAEMON_SRCS = $(@D)/src/motor-daemon.c
+THINGINO_MOTORS_DAEMON_LIBS = -ljct -lm
+THINGINO_MOTORS_DAEMON_DEFS =
+
+ifeq ($(BR2_PACKAGE_THINGINO_MOTORS_WS),y)
+THINGINO_MOTORS_DAEMON_SRCS += \
+	$(@D)/src/sha1.c \
+	$(@D)/src/sha256.c \
+	$(@D)/src/ws.c \
+	$(@D)/src/ws_token.c \
+	$(@D)/src/motor-ws.c
+THINGINO_MOTORS_DAEMON_LIBS += -lpthread
+# motor-daemon.c starts the listener only under #ifdef MOTORS_WS.
+THINGINO_MOTORS_DAEMON_DEFS += -DMOTORS_WS
+
+# Nested in WS: TLS wraps the listener, nothing to wrap without it.
+ifeq ($(BR2_PACKAGE_THINGINO_MOTORS_WS_TLS),y)
+THINGINO_MOTORS_DEPENDENCIES += mbedtls
+THINGINO_MOTORS_DAEMON_SRCS += $(@D)/src/ws_tls.c
+# libmbedx509/libmbedcrypto too: --gc-sections won't pull them in transitively.
+THINGINO_MOTORS_DAEMON_LIBS += -lmbedtls -lmbedx509 -lmbedcrypto
+THINGINO_MOTORS_DAEMON_DEFS += -DMOTORS_WS_TLS
+endif
+endif
+
 define THINGINO_MOTORS_INSTALL_JSON_CMDS
 	# Stage defaults for later merge by thingino-core
 	$(INSTALL) -D -m 0644 $(THINGINO_MOTORS_PKGDIR)/files/motors.json \
@@ -65,9 +108,11 @@ define THINGINO_MOTORS_INSTALL_WWW_CMDS
 endef
 endif
 
+# -ffunction-sections/-fdata-sections + --gc-sections: per-function dead-code
+# stripping. Measured -7680 B (-12.2%) on the WS build.
 define THINGINO_MOTORS_BUILD_CMDS
-	$(TARGET_CC) $(TARGET_LDFLAGS) -Os -s $(@D)/src/motor.c -o $(@D)/motors -ljct
-	$(TARGET_CC) $(TARGET_LDFLAGS) -Os -s $(@D)/src/motor-daemon.c -o $(@D)/motors-daemon -ljct -lm
+	$(TARGET_CC) $(TARGET_LDFLAGS) -Os -s -ffunction-sections -fdata-sections $(THINGINO_MOTORS_VERSION_DEF) $(@D)/src/motor.c -o $(@D)/motors -ljct -Wl,--gc-sections
+	$(TARGET_CC) $(TARGET_LDFLAGS) -Os -s -ffunction-sections -fdata-sections $(THINGINO_MOTORS_DAEMON_DEFS) $(THINGINO_MOTORS_DAEMON_SRCS) -o $(@D)/motors-daemon $(THINGINO_MOTORS_DAEMON_LIBS) -Wl,--gc-sections
 endef
 
 define THINGINO_MOTORS_INSTALL_TARGET_CMDS


### PR DESCRIPTION
## Summary
#1597 switched `thingino-motors.mk`'s `SITE`/`VERSION` conditional to the WebSocket-PTZ fork when timps or the WS toggle is selected, and `package/timps/timps.mk` already reapplies the WS-enabled webui and installs `json-motor-token.cgi` whenever `BR2_PACKAGE_THINGINO_MOTORS_WS=y` — but `Config.in` never actually defined that symbol on `master`, and `thingino-motors.mk`'s build command never branched on it either.

Net effect: a timps build on `master` checks out the WS fork's source but then silently compiles it with no WebSocket support at all (plain `motor-daemon.c`, no `ws.c`, no `-DMOTORS_WS`), and the webui manifest stays `"motorsWs": false`. #1597 and #1598's WS wiring was inert on `master`.

This ports `Config.in`'s `_WS`/`_WS_TLS` symbols and `thingino-motors.mk`'s `DAEMON_SRCS`/`LIBS`/`DEFS` + `--gc-sections` build wiring from `ciao` verbatim (already shipping there), so both branches build the WS daemon identically.

## Test plan
- [x] `printvars VARS="BR2_PACKAGE_THINGINO_MOTORS_WS BR2_PACKAGE_THINGINO_MOTORS_WS_TLS THINGINO_MOTORS_DAEMON_SRCS THINGINO_MOTORS_DAEMON_DEFS"` on a timps-selected master build now resolves `BR2_PACKAGE_THINGINO_MOTORS_WS=y` (was previously unset/empty), pulls in `ws.c`/`ws_token.c`/`motor-ws.c`/`ws_tls.c`, and sets `-DMOTORS_WS -DMOTORS_WS_TLS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)