### PR TITLE
configs: restore Wansview Q7 Wi-Fi enable GPIO

### DIFF
--- a/configs/cameras/wansview_q7_t23n_sc2336_atbm6012bx/thingino.json
+++ b/configs/cameras/wansview_q7_t23n_sc2336_atbm6012bx/thingino.json
@@ -7,6 +7,10 @@
     "speaker": {
       "pin": 39,
       "active_low": true
+    },
+    "wlan": {
+      "pin": 47,
+      "active_low": true
     }
   },
   "motors": {


### PR DESCRIPTION
## Summary

- restore the Wansview Q7 Wi-Fi enable line as GPIO 47, active-low
- preserve the behavior of the former gpio_wlan=47o setting
- allow the USB radio to enumerate before the configuration portal starts

## Root cause

The per-camera JSON migration omitted the Q7 WLAN entry. The later legacy cleanup removed gpio_wlan=47o from the environment file, leaving the radio enable line unconfigured. Both ATBM6012B and ATBM6012BX images therefore reached the same portal-down failure before driver selection could help.

## Audit

Reviewed upstream history for every non-empty gpio_wlan deletion that left a live Wi-Fi profile. Q7 was the only profile with neither a remaining legacy declaration nor a JSON replacement. Also compared 135 legacy WLAN sequences with their replacement JSON semantics; no other migration regression was found.

## Validation

- scripts/validate-json.sh passes for the changed profile
- git diff --check passes
- hardware verification pending

Expected serial log after rebuilding:

    Set GPIO 47 to 0

The WLAN interface should then appear and the Thingino configuration portal should start.