### PR TITLE
wifi: coordinate captive portal webserver handoff

### DIFF
--- a/package/thingino-uhttpd/files/S60uhttpd
+++ b/package/thingino-uhttpd/files/S60uhttpd
@@ -6,6 +6,7 @@
 DAEMON="uhttpd"
 PIDFILE="/var/run/uhttpd.pid"
 PORTAL_MODE_FLAG="/run/portal_mode"
+PORTAL_PENDING_FLAG="/run/portal_pending"
 
 UHTTPD_DOCROOT="${UHTTPD_DOCROOT:-/var/www}"
 UHTTPD_PORTAL_DOCROOT="${UHTTPD_PORTAL_DOCROOT:-/var/www-portal}"
@@ -45,6 +46,11 @@ build_uhttpd_args() {
 
 start() {
 	local display_hostname
+
+	if [ -f "$PORTAL_PENDING_FLAG" ] && [ ! -f "$PORTAL_MODE_FLAG" ]; then
+		echo "Portal decision pending, deferring uhttpd"
+		return 0
+	fi
 
 	display_hostname="$(hostname 2>/dev/null)"
 	[ -z "$display_hostname" ] && display_hostname="localhost"

--- a/package/thingino-webui/files/S90httpd
+++ b/package/thingino-webui/files/S90httpd
@@ -4,6 +4,7 @@
 DAEMON="/usr/sbin/httpd"
 PIDFILE="/var/run/httpd.pid"
 PORTAL_MODE_FLAG="/run/portal_mode"
+PORTAL_PENDING_FLAG="/run/portal_pending"
 
 start_daemon() {
 	start-stop-daemon -S -b -m -p "$PIDFILE" -x "$DAEMON" -- $@
@@ -27,6 +28,11 @@ else
 fi
 
 start() {
+	if [ -f "$PORTAL_PENDING_FLAG" ] && [ ! -f "$PORTAL_MODE_FLAG" ]; then
+		echo "Portal decision pending, deferring HTTPD"
+		return 0
+	fi
+
 	echo -c 15 "Starting HTTPD"
 
 	# shellcheck disable=SC2086

--- a/package/wifi/files/S38wpa_supplicant.in
+++ b/package/wifi/files/S38wpa_supplicant.in
@@ -231,12 +231,19 @@ prepare_portal() {
 		}
 	WPAEOF
 
+	echo "Set $PORTAL_MODE_FLAG"
+	touch "$PORTAL_MODE_FLAG"
+	rm -f "$PORTAL_PENDING_FLAG"
+	echo "Moving web server to the portal interface"
+	for webserver_init in /etc/init.d/S60uhttpd /etc/init.d/S90httpd; do
+		[ -x "$webserver_init" ] || continue
+		"$webserver_init" restart
+		break
+	done
+
 	echo "Start wpa_supplicant"
 	# shellcheck disable=SC2086 # DAEMON_ARGS holds flags that must word-split
 	start-stop-daemon -S -x $DAEMON_FULL -- $DAEMON_ARGS -c "$PORTAL_CONF" 2>&1
-
-	echo "Set $PORTAL_MODE_FLAG"
-	touch "$PORTAL_MODE_FLAG"
 
 	echo "Portal prepared at $(ts)"
 }
@@ -489,14 +496,8 @@ case "$1" in
 		start
 		;;
 	portal_confirmed)
-		rm -f "$PORTAL_PENDING_FLAG"
 		prescan_for_portal
 		prepare_portal
-		if pgrep -x uhttpd >/dev/null 2>&1 && \
-			! pgrep -f "uhttpd -h /var/www-portal" >/dev/null 2>&1; then
-			echo "Moving uhttpd to the portal interface"
-			/etc/init.d/S60uhttpd restart
-		fi
 		finish_portal
 		;;
 	*)

--- a/package/wifi/files/S40wired-gateway
+++ b/package/wifi/files/S40wired-gateway
@@ -3,6 +3,14 @@
 
 WLAN_MODULE_NAME="@WLAN_MODULE_NAME@"
 
+start_webserver() {
+	for webserver_init in /etc/init.d/S60uhttpd /etc/init.d/S90httpd; do
+		[ -x "$webserver_init" ] || continue
+		"$webserver_init" start
+		break
+	done
+}
+
 unload_wlan_module() {
 	[ -n "$WLAN_MODULE_NAME" ] || return 0
 
@@ -44,6 +52,7 @@ watch_wired_uplink() {
 					/etc/init.d/S38wpa_supplicant stop
 					/etc/init.d/S36wireless stop
 					unload_wlan_module
+					start_webserver
 					exit 0
 				fi
 			done


### PR DESCRIPTION
## Summary

- retain `/run/portal_pending` until the wired-versus-portal decision is complete
- defer both uhttpd and BusyBox HTTP while portal selection or radio prescan is pending
- atomically set portal mode before clearing pending state, then start the selected webserver
- start the normal webserver explicitly when a wired uplink wins

This prevents the normal WebUI from winning a concurrent init race and redirecting provisioning clients to `/preview.html`.

## Validation

- `sh -n` on all four changed init scripts
- `shfmt -d -i 0 -ci` on all four changed init scripts
- `shellcheck -s sh` on all four changed init scripts
- ASCII-only source checks
- `git diff --check`

Draft pending hardware verification on a Wansview Q7.