### PR TITLE
sysupgrade: add timps.conf and onvif.json to cfg-backup.list

### DIFF
--- a/overlay/etc/cfg-backup.list
+++ b/overlay/etc/cfg-backup.list
@@ -24,6 +24,8 @@
 
 # Thingino application configs
 /etc/thingino.json
+/etc/timps.conf
+/etc/onvif.json
 
 # You can add more paths below, one per line:
 # /etc/prudynt.json


### PR DESCRIPTION
## Summary
A timps user reported that an OTA upgrade doesn't preserve `/etc/timps.conf`. `overlay/etc/cfg-backup.list` is a flat, hand-maintained manifest with no per-package registration mechanism - both timps (persists settings written via its `/control` API) and onvif (its own runtime-written config) write a config file under `/etc` that was never added to the list, not even as a commented-out suggestion. A full `ota`/`ota-full` reflash wipes the `data`/overlay partition outright, so with these files missing from the manifest there's nothing to restore from afterward either.

A plain rootfs-only `ota-upgrade` doesn't lose the file today (its squashfs image carries no appended data segment, so the `data` partition is left untouched) - the gap only bites on a full reflash - but the fix is the same either way: the pre-flash `cfg-backup` snapshot needs to actually contain the file.

## Test plan
- [x] Verified `/etc/timps.conf` and `/etc/onvif.json` are not present anywhere in the current `cfg-backup.list`, commented or otherwise
- [x] One-line-per-file addition alongside the existing `/etc/thingino.json` entry, no other changes needed (no per-package `.mk` registers into this list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)