### PR TITLE
motors: fix TCU select and SDK motor.ko collision for tmi8152 boards

### DIFF
--- a/package/ingenic-sdk/Config.in
+++ b/package/ingenic-sdk/Config.in
@@ -107,13 +107,20 @@ config BR2_INGENIC_SDK_PWM
 
 config BR2_INGENIC_SDK_MOTOR
 	bool "Motor driver"
-	default y if BR2_PACKAGE_THINGINO_MOTORS
+	# Keyed on the capability flags, not BR2_PACKAGE_THINGINO_MOTORS:
+	# tmi8152 boards select that package but ship their own drop-in
+	# motor.ko, which collides by name with this one in modules.dep.
+	# The flags below cover exactly the driver types this module
+	# implements.
+	default y if BR2_THINGINO_MOTORS_TCU || BR2_THINGINO_MOTORS_SPI
 	select BR2_INGENIC_SDK_TCU_ALLOC if BR2_INGENIC_SDK_K310
 	help
 	  The SDK's PTZ motor kernel module. This is the kernel side; the
 	  standalone thingino-motors package is the userspace utility that
-	  drives it. Defaults on when that package is selected. On 3.10 it
-	  needs the TCU allocator, pulled in automatically.
+	  drives it. Defaults on for boards with TCU/GPIO or ms419xx-SPI
+	  motors; boards driving their motors through spi-tmi8152 supply
+	  their own motor.ko and leave this off. On 3.10 it needs the TCU
+	  allocator, pulled in automatically.
 
 config BR2_INGENIC_SDK_TCU_ALLOC
 	bool "TCU channel allocator"

--- a/package/thingino-motors/Config.in
+++ b/package/thingino-motors/Config.in
@@ -1,6 +1,9 @@
 config BR2_PACKAGE_THINGINO_MOTORS
 	bool "thingino-motors"
-	select BR2_THINGINO_MOTORS_TCU if !BR2_THINGINO_MOTORS_SPI
+	# Three motor drivers exist, not two: TCU/GPIO, ms419xx-SPI
+	# (BR2_THINGINO_MOTORS_SPI) and spi-tmi8152. TCU is the fallback
+	# only when neither of the other two drives the motors.
+	select BR2_THINGINO_MOTORS_TCU if !BR2_THINGINO_MOTORS_SPI && !BR2_PACKAGE_SPI_TMI8152
 	help
 	  Userspace programs to manage motor hardware
 


### PR DESCRIPTION
## Summary
- `BR2_PACKAGE_THINGINO_MOTORS`'s `select BR2_THINGINO_MOTORS_TCU if !BR2_THINGINO_MOTORS_SPI` doesn't account for the third motor driver type, `spi-tmi8152` - it unconditionally claims TCU support on those boards too.
- `BR2_INGENIC_SDK_MOTOR` defaults on for any board selecting `BR2_PACKAGE_THINGINO_MOTORS`, regardless of which driver it actually uses. On a tmi8152 board this builds the SDK's own `motor.ko` alongside tmi8152's own drop-in `motor.ko` - same module name, and `depmod` silently drops one (which one survives is essentially incidental, not deterministic).
- Both fixed by keying `BR2_INGENIC_SDK_MOTOR`'s default off the TCU/SPI capability flags instead of the userspace package selection, and excluding tmi8152 from the TCU auto-select.

## Test plan
- [x] Kconfig-only check (`make CAMERA=tplink_tapo_c500_t23n_sc2336p_atbm6012bx defconfig`, a tmi8152 board): `BR2_THINGINO_MOTORS_TCU` and `BR2_INGENIC_SDK_MOTOR` both correctly absent.
- [x] Regression check on a TCU board (`cinnado_d1_t23n_sc2336_atbm6012bx`): `BR2_THINGINO_MOTORS_TCU=y` and `BR2_INGENIC_SDK_MOTOR=y` unchanged.
- [x] Full build + flash verified on real tplink_tapo_c500 hardware (our `ciao`-branch preset, same underlying fix): only `extra/motor.ko` (tmi8152) present, correct `modules.dep` dependency, motor homes and moves correctly on boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)