### PR TITLE
package/timps: keep shipped templates in sync with tri-state http.https

### DIFF
--- a/package/timps/files/S95timps
+++ b/package/timps/files/S95timps
@@ -41,7 +41,14 @@ UHTTPD_KEY=/etc/ssl/private/uhttpd.key
 # missing (e.g. after a flash), and a copy taken once would silently go stale
 # and desynchronise the two ports again - which is the exact bug this avoids.
 ensure_tls_certs() {
-	[ "$(conf_get http.https)" = "1" ] || [ "$(conf_get rtsp.tls)" = "1" ] || return 0
+	# http.https is a tri-state: 1 = http+https on the one port, 2 = TLS only.
+	# Both need a cert, and a missing one fails CLOSED (httpd.c): the listener
+	# is not bound at all, so http.https=2 without this would kill the HTTP
+	# port outright. rtsp.tls is still a plain boolean.
+	case "$(conf_get http.https)" in
+		1 | 2) ;;
+		*) [ "$(conf_get rtsp.tls)" = "1" ] || return 0 ;;
+	esac
 	crt=$(conf_get http.tls_cert)
 	key=$(conf_get http.tls_key)
 	[ -n "$crt" ] && [ -n "$key" ] || return 0

--- a/package/timps/files/S96onvif_discovery
+++ b/package/timps/files/S96onvif_discovery
@@ -88,12 +88,16 @@ timps_rtsp_endpoint() {
 	echo "${ep#/}"
 }
 
+# http.https is a TRI-STATE, not a boolean: 0 = plaintext, 1 = http and https
+# together on the one port, 2 = TLS only (plaintext gets 426 Upgrade Required).
+# Deliberately not timps_bool_default(), which is shared with the genuinely
+# boolean keys and would report "http" for 2 - the URIs advertised to ONVIF
+# clients would then all be refused by the daemon.
 timps_http_scheme() {
-	if [ "$(timps_bool_default http.https false)" = "true" ]; then
-		echo "https"
-	else
-		echo "http"
-	fi
+	case "$(timps_conf_get http.https | tr 'A-Z' 'a-z')" in
+		1 | 2 | true | yes | on) echo "https" ;;
+		*) echo "http" ;;
+	esac
 }
 
 timps_http_port() {

--- a/package/timps/files/agent-adapter
+++ b/package/timps/files/agent-adapter
@@ -42,9 +42,11 @@ agent_timps_port() {
 	printf '%s' "$port"
 }
 
+# Tri-state: 0 = plaintext, 1 = http and https on the one port, 2 = TLS only
+# (plaintext answered with 426). Both on-values speak https.
 agent_timps_scheme() {
 	case "$(agent_conf_get http.https | tr 'A-Z' 'a-z')" in
-		1 | true | yes | on) printf 'https' ;;
+		1 | 2 | true | yes | on) printf 'https' ;;
 		*) printf 'http' ;;
 	esac
 }

--- a/package/timps/files/timps.conf
+++ b/package/timps/files/timps.conf
@@ -59,8 +59,10 @@ rtsp.pass    = thingino
 # ---- HTTP preview (fMP4 + JPEG/MJPEG) ----
 # NOTE: the WebUI proxies /mjpeg and /onvif/image.cgi are wired to
 # http://127.0.0.1:8880 at build time. If you change http.port (or set
-# http.https=1, which turns this port TLS-only), those two loopback proxies in
-# /etc/httpd.conf stop working until you repoint them to the new port/scheme.
+# http.https=2, which refuses plaintext on this port), those two loopback
+# proxies in /etc/httpd.conf stop working until you repoint them to the new
+# port/scheme. http.https=1 leaves them working: that value serves plain HTTP
+# and HTTPS side by side on the one port - see the TLS block below.
 http.enabled     = 1
 http.port        = 8880
 http.preview_chn = 1
@@ -80,7 +82,28 @@ http.token_file  = /run/timps.token
 # in the image, a timps-own self-signed pair is generated at these paths
 # instead. Point them at a real cert to use your own - an existing, non-empty
 # pair is always left alone.
-# http.https    = 1                       # serve the HTTP port over TLS
+#
+# NOTE: http.https is a TRI-STATE, and 1 means something WIDER than it did
+# before v1.9.11 - read this before assuming the old behaviour:
+#   0  plaintext only (default). No TLS on the http port at all.
+#   1  BOTH schemes on the SAME port. Each connection is classified by its
+#      first byte (0x16 = a TLS handshake record; every HTTP method starts
+#      with a letter), so http://<ip>:8880/ and https://<ip>:8880/ both work
+#      and nothing has to agree in advance on which one to use. This used to
+#      mean TLS-ONLY, and that was the bug: the preview stream is fetched by
+#      a WebUI page whose scheme is decided by a DIFFERENT server (uhttpd on
+#      :80/:443). Page on http:// + stream on https:// fails outright, because
+#      a self-signed cert cannot be click-through-trusted for a subresource
+#      fetch (Safari just says "Load failed"); page on https:// + stream on
+#      http:// is blocked as mixed content. Serving both makes the page's
+#      scheme irrelevant.
+#   2  TLS only: a plaintext request is answered with 426 Upgrade Required and
+#      the connection closed. This is the old meaning of 1, kept as a
+#      deliberate opt-in for a port that must never carry cleartext (note that
+#      Basic-auth headers and http.token are exactly what it protects).
+# Either on-value still fails CLOSED if the cert/key cannot be loaded: the
+# listener is not bound at all rather than silently downgraded to plaintext.
+# http.https    = 1                       # 0 plain, 1 http+https on one port, 2 TLS only
 http.tls_cert   = /etc/ssl/certs/timps.crt
 http.tls_key    = /etc/ssl/private/timps.key
 # rtsp.tls      = 1                       # additionally run an RTSPS listener

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -262,7 +262,16 @@ define TIMPS_INSTALL_TARGET_CMDS
 	# only links the shared cert pair when it sees this already set, so
 	# leaving it commented meant every TLS+WebUI image needed a manual
 	# post-flash edit before HTTPS actually worked.
-	if [ "$(BR2_PACKAGE_TIMPS_TLS)" = "y" ] && [ "$(BR2_PACKAGE_THINGINO_UHTTPD_TLS)" = "y" ]; then \
+	#
+	# Also require BR2_PACKAGE_THINGINO_UHTTPD_HTTP_REDIRECT=y: that's what
+	# makes uhttpd actually redirect port 80 to 443 (see S60uhttpd's -q
+	# flag). Without it, http.https=1 makes timps's one preview port
+	# TLS-only while the WebUI keeps serving plain HTTP on :80 with no
+	# redirect - a page loaded over http:// then tries to fetch the stream
+	# over https:// with a self-signed cert and fails outright (no
+	# interstitial is possible for a subresource fetch). Gating on the
+	# redirect being wired up keeps page and stream on the same scheme.
+	if [ "$(BR2_PACKAGE_TIMPS_TLS)" = "y" ] && [ "$(BR2_PACKAGE_THINGINO_UHTTPD_TLS)" = "y" ] && [ "$(BR2_PACKAGE_THINGINO_UHTTPD_HTTP_REDIRECT)" = "y" ]; then \
 		$(SED) 's|^# http.https .*|http.https    = 1                       # serve the HTTP port over TLS|' \
 			$(TARGET_DIR)/etc/timps.conf; \
 	fi


### PR DESCRIPTION
## Summary

Companion to #1625 (uhttpd redirect wiring). timps' `http.https` config key changed from a boolean to a **tri-state**:

| value | meaning |
| --- | --- |
| `0` | plaintext only |
| `1` | HTTP **and** HTTPS on the same port, chosen per connection by a `MSG_PEEK` of the first byte (`0x16` = TLS ClientHello) |
| `2` | TLS only; a plaintext request gets `426 Upgrade Required` |

These **four** commits keep the shipped `package/timps` files in sync with that change:

1. **Generate TLS certs for strict mode (`http.https=2`) too** — previously only `=1` triggered cert generation, so strict mode failed to start the HTTP port at all (it fails closed on a missing cert).
2. **Scheme detection now treats `2` as `https`** alongside `1`, in ONVIF discovery and the agent adapter.
3. **Shipped `timps.conf` comments** updated to describe the tri-state meaning instead of the old boolean one.
4. **Gate the `http.https=1` auto-write on uhttpd's redirect option** — this is the piece that was split out of #1625.

## ⚠️ Requires timps ≥ v1.9.11

The tri-state only exists in timps **v1.9.11**. `ciao` pins **v1.9.10**, whose `pbool()` parses `"2"` as **0** — so with this merged but the old binary still pinned, `http.https = 2` is silently served as **plaintext**.

**#1627** bumps `TIMPS_VERSION` to `v1.9.11` and should land to complete this.

## Test plan

- [x] Full rebuild + OTA flash.
- [x] `http.https = 1`: both `http://cam:8880/snapshot.jpg` and `https://cam:8880/snapshot.jpg` return a JPEG from the one port.
- [x] `http.https = 2`: plaintext gets `426 Upgrade Required`; only `https://` is served.
- [x] `http.https = 0`: plaintext only, unchanged.
- [x] Certs are generated for `=2`, not just `=1` (the daemon starts instead of failing closed).
- [ ] CI / maintainer review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
