### PR TITLE
timps: make timps-token.cgi follow the tri-state http.https (WebUI side of #1626)

### DIFF
--- a/package/timps/README.md
+++ b/package/timps/README.md
@@ -258,8 +258,15 @@ per-stream `audio_enabled`, and the remaining `prudyntctl events` consumers
 
 timps generates a random **per-boot token** and writes it to
 `/run/timps.token` (0640). `timps-token.cgi` (WebUI session auth via
-`auth.sh`) serves it as `{"token":"...","port":8880}` (port/token-file path
-read from `/etc/timps.conf`). With it a WebUI page can skip the localhost
+`auth.sh`) serves it as `{"token":"...","port":8880,"scheme":"..."}`
+(port/token-file path read from `/etc/timps.conf`). `scheme` mirrors the
+`http.https` tri-state — `"http"` (0), `"both"` (1) or `"https"` (2) — and is
+what the JS must use to build the URL: on `"both"` timps answers either scheme
+on that one port, so the page follows **its own** `location.protocol` rather
+than guessing, which is what lets an http:// and an https:// WebUI page both
+reach the preview without a mixed-content block. A legacy `"tls"` bool is
+still emitted (true for 1 and 2) for JS that predates `scheme`.
+With it a WebUI page can skip the localhost
 bridge CGIs and call timps **directly from the browser**: fetch the token
 once, then `fetch('http://<host>:8880/control', {method:'POST', headers:
 {'X-Timps-Token': token}, body: json})` — timps answers the CORS preflight

--- a/package/timps/files/www/a/preview-motion.js
+++ b/package/timps/files/www/a/preview-motion.js
@@ -21,7 +21,21 @@
   const btn = document.getElementById("ms-motion");
   if (!video || !canvas || !btn) return;
 
-  let base = null;   // http://<host>:<port>
+  // http.https tri-state, as reported by timps-token.cgi's "scheme" field.
+  // "both" = plain HTTP and HTTPS on the one timps port, so follow the PAGE's
+  // scheme: an https:// page may not fetch http:// (mixed content), and an
+  // http:// page cannot clear a self-signed cert on a subresource fetch.
+  // Falls back to the older "tls" bool when the CGI predates "scheme".
+  function timpsScheme(info) {
+    if (!info) return "http";
+    if (info.scheme === "both") {
+      return window.location.protocol === "https:" ? "https" : "http";
+    }
+    if (info.scheme === "https" || info.scheme === "http") return info.scheme;
+    return info.tls ? "https" : "http";
+  }
+
+  let base = null;   // http(s)://<host>:<port>
   let token = null;
   let es = null;     // EventSource (push mode)
   let esErrors = 0;  // consecutive errors since the last successful open
@@ -275,7 +289,7 @@
     token = info.token;
     let host = location.hostname || "127.0.0.1";
     if (host.indexOf(":") >= 0 && host[0] !== "[") host = "[" + host + "]"; // raw IPv6
-    base = (info.tls ? "https" : "http") + "://" + host + ":" + (info.port || 8880);
+    base = timpsScheme(info) + "://" + host + ":" + (info.port || 8880);
 
     // Bind teardown before the probe below can start waiting on the network.
     window.addEventListener("pagehide", () => {

--- a/package/timps/files/www/a/preview-talk.js
+++ b/package/timps/files/www/a/preview-talk.js
@@ -19,7 +19,8 @@
  *     ws:// accepted too. audio.talk_ws=1 on a plaintext port reports 0
  *     (/talk would 426), so there is nothing left here to second-guess -
  *     the only thing this file still derives is the SCHEME, from the same
- *     timps-token.cgi "tls" field that already picks http:// vs https://.
+ *     timps-token.cgi "scheme" field that already picks http:// vs https://
+ *     (and, when timps serves both on the one port, the page's own).
  *   - navigator.mediaDevices.getUserMedia. This is the one the camera cannot
  *     fix from its side: browsers refuse it outside a secure context, so on a
  *     plain-http:// page it is simply absent unless the operator granted the
@@ -59,7 +60,21 @@
   let base = null;    // http(s)://<host>:<port>
   let wsBase = null;  // ws(s)://<host>:<port>, same scheme family as `base`
   let token = null;
-  let tls = false;    // timps' http.https, per /x/timps-token.cgi
+  let tls = false;    // true once the scheme we actually dial is https/wss
+
+  // http.https tri-state, as reported by timps-token.cgi's "scheme" field.
+  // "both" = plain HTTP and HTTPS on the one timps port, so follow the PAGE's
+  // scheme: an https:// page may only open wss:// (mixed content), and an
+  // http:// page cannot clear a self-signed cert on a WebSocket handshake.
+  // Falls back to the older "tls" bool when the CGI predates "scheme".
+  function timpsScheme(info) {
+    if (!info) return "http";
+    if (info.scheme === "both") {
+      return window.location.protocol === "https:" ? "https" : "http";
+    }
+    if (info.scheme === "https" || info.scheme === "http") return info.scheme;
+    return info.tls ? "https" : "http";
+  }
   let stopped = false; // set on pagehide; stops the probe retry loop
 
   // live session state, all null/idle between presses
@@ -325,8 +340,9 @@
     let host = location.hostname || "127.0.0.1";
     if (host.indexOf(":") >= 0 && host[0] !== "[") host = "[" + host + "]"; // raw IPv6
     const port = info.port || 8880;
-    tls = !!info.tls;
-    base = (tls ? "https" : "http") + "://" + host + ":" + port;
+    const sch = timpsScheme(info);
+    tls = sch === "https";
+    base = sch + "://" + host + ":" + port;
     // Same scheme family as `base`, never hardcoded: an https:// page may only
     // open wss:// (mixed content), and a plaintext timps listener only speaks
     // ws://. probe() refuses to show the button for any combination timps

--- a/package/timps/files/www/a/timps-api.js
+++ b/package/timps/files/www/a/timps-api.js
@@ -33,6 +33,7 @@
             token: data && data.token ? String(data.token) : "",
             port: data && data.port ? parseInt(data.port, 10) : DEFAULT_PORT,
             tls: !!(data && data.tls),
+            scheme: data && data.scheme ? String(data.scheme) : "",
           };
           return info;
         });
@@ -40,11 +41,24 @@
     return infoPending;
   }
 
+  // http.https is a tri-state; timps-token.cgi reports it as "scheme".
+  // "both" = plain HTTP and HTTPS on the one timps port, so follow the PAGE's
+  // scheme: an https:// page may not fetch http:// (mixed content), and an
+  // http:// page cannot get past a self-signed cert on a subresource fetch.
+  // Falls back to the older "tls" bool when the CGI predates "scheme".
+  function schemeOf(i) {
+    if (!i) return "http";
+    if (i.scheme === "both") {
+      return window.location.protocol === "https:" ? "https" : "http";
+    }
+    if (i.scheme === "https" || i.scheme === "http") return i.scheme;
+    return i.tls ? "https" : "http";
+  }
+
   function base() {
     var host = window.location.hostname || "127.0.0.1";
     if (host.indexOf(":") >= 0 && host.charAt(0) !== "[") host = "[" + host + "]"; // IPv6
-    var scheme = (info && info.tls) ? "https" : "http";
-    return scheme + "://" + host + ":" + (info ? info.port : DEFAULT_PORT);
+    return schemeOf(info) + "://" + host + ":" + (info ? info.port : DEFAULT_PORT);
   }
 
   // one /control round trip with the token header; retries ONCE with a

--- a/package/timps/files/www/a/timps-preview.js
+++ b/package/timps/files/www/a/timps-preview.js
@@ -38,11 +38,26 @@ function fetchTimpsMediaInfo(force = false) {
           token: data && data.token ? String(data.token) : "",
           port: data && data.port ? parseInt(data.port, 10) : 8880,
           tls: !!(data && data.tls),
+          scheme: data && data.scheme ? String(data.scheme) : "",
         };
         return timpsMediaInfo;
       });
   }
   return timpsMediaPending;
+}
+
+// http.https tri-state, as reported by timps-token.cgi's "scheme" field.
+// "both" = plain HTTP and HTTPS on the one timps port, so follow the PAGE's
+// scheme: an https:// page may not load an http:// <img> (mixed content), and
+// an http:// page cannot clear a self-signed cert on a subresource. Falls back
+// to the older "tls" bool when the CGI predates "scheme".
+function timpsMediaScheme(info) {
+  if (!info) return "http";
+  if (info.scheme === "both") {
+    return window.location.protocol === "https:" ? "https" : "http";
+  }
+  if (info.scheme === "https" || info.scheme === "http") return info.scheme;
+  return info.tls ? "https" : "http";
 }
 
 // kind "live" -> /stream.mjpeg, "still" -> /snapshot.jpg; chn is the numeric
@@ -51,7 +66,7 @@ function fetchTimpsMediaInfo(force = false) {
 function timpsMediaUrl(kind, chn, host) {
   const h = wrapIpv6Host(host || window.location.hostname || "127.0.0.1");
   const port = timpsMediaInfo ? timpsMediaInfo.port : 8880;
-  const scheme = timpsMediaInfo && timpsMediaInfo.tls ? "https" : "http";
+  const scheme = timpsMediaScheme(timpsMediaInfo);
   const path = kind === "still" ? "/snapshot.jpg" : "/stream.mjpeg";
   let url = `${scheme}://${h}:${port}${path}?chn=${chn}`;
   if (timpsMediaInfo && timpsMediaInfo.token) {

--- a/package/timps/files/www/preview.html
+++ b/package/timps/files/www/preview.html
@@ -293,6 +293,19 @@
         .then((r) => (r.ok ? r.json() : null))
         .catch(() => null);
     }
+    // http.https tri-state, as reported by timps-token.cgi's "scheme" field.
+    // "both" = plain HTTP and HTTPS on the one timps port, so follow the
+    // PAGE's scheme: an https:// page may not fetch http:// (mixed content),
+    // and an http:// page cannot clear a self-signed cert on a fetch(). Falls
+    // back to the older "tls" bool when the CGI predates "scheme".
+    function timpsScheme(info) {
+      if (!info) return "http";
+      if (info.scheme === "both") {
+        return window.location.protocol === "https:" ? "https" : "http";
+      }
+      if (info.scheme === "https" || info.scheme === "http") return info.scheme;
+      return info.tls ? "https" : "http";
+    }
     window.timpsTokenInfo = window.timpsTokenInfo || fetchTimpsTokenInfo();
     // The token is per timps BOOT: if timpsd restarts under a running player,
     // every request with the old token comes back 401 and the preview is stuck
@@ -574,7 +587,7 @@
       if (statsEs || !window.EventSource) return;
       const info = await window.timpsTokenInfo;
       if (statsCard.style.display === "none") return; // toggled off while awaiting the token
-      const b = info ? (info.tls ? "https" : "http") + "://" + host + ":" + (info.port || MS_PORT) : base;
+      const b = info ? timpsScheme(info) + "://" + host + ":" + (info.port || MS_PORT) : base;
       const tok = info && info.token ? "&token=" + encodeURIComponent(info.token) : "";
       statsEs = new EventSource(b + "/events?stream=stats" + tok);
       statsEs.addEventListener("stats", (ev) => {
@@ -689,7 +702,7 @@
     // and the "&token=..." suffix both the stream fetch and /control use.
     async function endpoint() {
       const info = await window.timpsTokenInfo;
-      if (info) base = (info.tls ? "https" : "http") + "://" + host + ":" + (info.port || MS_PORT);
+      if (info) base = timpsScheme(info) + "://" + host + ":" + (info.port || MS_PORT);
       return { base: base, tok: info && info.token ? "&token=" + encodeURIComponent(info.token) : "" };
     }
 

--- a/package/timps/files/www/x/timps-token.cgi
+++ b/package/timps/files/www/x/timps-token.cgi
@@ -3,8 +3,9 @@
 # Hand the per-boot timps /control token to the authenticated WebUI session.
 # timps writes a fresh random token to /run/timps.token (0640) on every start;
 # with it a browser page can drive timps DIRECTLY (no local bridge CGI):
-#   const {token, port} = await (await fetch('/x/timps-token.cgi')).json();
-#   fetch(`http://${location.hostname}:${port}/control`, {method:'POST',
+#   const {token, port, scheme} = await (await fetch('/x/timps-token.cgi')).json();
+#   const s = scheme === 'both' ? location.protocol.replace(':','') : scheme;
+#   fetch(`${s}://${location.hostname}:${port}/control`, {method:'POST',
 #         headers:{'X-Timps-Token': token}, body:'{"image":{...}}'});
 # Only the per-boot token is exposed here - a configured http.token secret
 # never reaches the file (timps keeps it in memory only).
@@ -21,10 +22,35 @@ tf=$(sed -n 's/^[[:space:]]*http\.token_file[[:space:]]*=[[:space:]]*"\{0,1\}\([
 [ -n "$tf" ] && TOKEN_FILE="$tf"
 port=$(sed -n 's/^[[:space:]]*http\.port[[:space:]]*=[[:space:]]*\([0-9]\{1,\}\).*/\1/p' "$CONF" 2>/dev/null | head -n1)
 [ -z "$port" ] && port=8880
-# whether timps serves the HTTP port over TLS (http.https): the browser must
-# then use https:// for the media/control URLs.
-https=$(sed -n 's/^[[:space:]]*http\.https[[:space:]]*=[[:space:]]*\([0-9A-Za-z]*\).*/\1/p' "$CONF" 2>/dev/null | head -n1)
-case "$https" in 1 | true | yes | on) tls=true ;; *) tls=false ;; esac
+# http.https is a TRI-STATE since timps v1.9.11, not a boolean:
+#   0  plaintext only                      -> scheme "http"
+#   1  http AND https on the SAME port, picked per connection by a first-byte
+#      peek (true/yes/on parse as 1)        -> scheme "both"
+#   2  TLS only, plaintext gets a 426       -> scheme "https"
+#
+# "scheme" is the field the WebUI JS should use. On "both" it must follow the
+# PAGE's own protocol rather than a fixed guess: an https:// WebUI page may not
+# fetch an http:// subresource (mixed content), and an http:// page hitting
+# https:// dies on the self-signed cert with no possible interstitial. Since
+# timps answers either scheme on that one port, following the page always works.
+#
+# "tls" is kept for JS that predates "scheme" (a cached page, a partial
+# upgrade): true for either on-value, i.e. the old "use https://" meaning.
+https=$(sed -n 's/^[[:space:]]*http\.https[[:space:]]*=[[:space:]]*\([0-9A-Za-z]*\).*/\1/p' "$CONF" 2>/dev/null | head -n1 | tr '[:upper:]' '[:lower:]')
+case "$https" in
+	1 | true | yes | on)
+		scheme=both
+		tls=true
+		;;
+	2)
+		scheme=https
+		tls=true
+		;;
+	*)
+		scheme=http
+		tls=false
+		;;
+esac
 
 echo "Content-Type: application/json"
 echo "Cache-Control: no-store"
@@ -35,7 +61,7 @@ token=""
 [ -r "$TOKEN_FILE" ] && token=$(head -n1 "$TOKEN_FILE" 2>/dev/null | tr -cd '0-9A-Za-z')
 
 if [ -n "$token" ]; then
-	printf '{"token":"%s","port":%s,"tls":%s}\n' "$token" "$port" "$tls"
+	printf '{"token":"%s","port":%s,"tls":%s,"scheme":"%s"}\n' "$token" "$port" "$tls" "$scheme"
 else
-	printf '{"error":"no token available","port":%s,"tls":%s}\n' "$port" "$tls"
+	printf '{"error":"no token available","port":%s,"tls":%s,"scheme":"%s"}\n' "$port" "$tls" "$scheme"
 fi


### PR DESCRIPTION
## Summary

Follow-up to **#1626** (shipped templates synced with the tri-state `http.https`) and **#1627** (the v1.9.11 bump that actually makes the binary understand `2`).

Those two fixed the *packaging* side. `timps-token.cgi` is the missing piece: it is the file the **browser-facing WebUI preview actually calls** to learn how to reach timps, and it still treats `http.https` as a boolean.

## The bug

`timps-token.cgi` reads `http.https` and collapses it to a bool:

```sh
case "$https" in 1 | true | yes | on) tls=true ;; *) tls=false ;; esac
```

Two problems:

1. **`2` falls into `*`** — a TLS-only camera is reported to the WebUI as plaintext, so the preview builds `http://host:8880/...` against a port that now answers plaintext with `426 Upgrade Required`. Preview simply doesn't load.
2. **`1` forces `https://`** — but since v1.9.11 `1` means *both* schemes on the one port, chosen per connection by a first-byte `MSG_PEEK`. Hardcoding `https://` from an `http://` WebUI page means the subresource fetch hits the self-signed cert with **no possible interstitial** (browsers don't prompt for subresources), so it fails outright — which is exactly the failure the same-port dual-mode was introduced to eliminate.

So without this, the dual-mode fix from #1626/#1627 can't actually be exploited by the WebUI.

## The fix

`timps-token.cgi` now emits a tri-state `scheme` field alongside the existing `tls` bool:

| `http.https` | `scheme` | `tls` (legacy) |
|---|---|---|
| 0 / unset | `"http"` | `false` |
| 1 / true / yes / on | `"both"` | `true` |
| 2 | `"https"` | `true` |

and the JS consumers (`timps-api.js`, `timps-preview.js`, `preview-motion.js`, `preview-talk.js`, `preview.html`) use it: on `"both"` they follow the **page's own** `location.protocol` instead of guessing, so an `http://` WebUI page and an `https://` one each reach the preview port with their own scheme. `"http"`/`"https"` stay pinned as before.

The old `tls` bool is still emitted (true for both 1 and 2) so any JS that predates `scheme` — a cached page, a partially-updated overlay — keeps its old meaning rather than breaking.

`README.md` documents the new field.

## Scope

Seven files, all under `package/timps/files/www/` plus the package README. No Kconfig, no `.mk`, no build-system change.

## Test plan

- [ ] On-camera verification of `1` (dual-mode) reachable over both `http://` and `https://` from one image — in progress on our side
- [ ] On-camera verification that `2` (TLS-only) no longer reports itself as plaintext
- [ ] CI / maintainer review

Reviewed by reading against the v1.9.11 `httpd.c` dual-mode path; `0` is unchanged by construction (the `*` branch is the pre-existing one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
