### PR TITLE
timps: drop the redundant HTTP_REDIRECT gate on the http.https=1 auto-write

### DIFF
--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -263,16 +263,30 @@ define TIMPS_INSTALL_TARGET_CMDS
 	# leaving it commented meant every TLS+WebUI image needed a manual
 	# post-flash edit before HTTPS actually worked.
 	#
-	# Also require BR2_PACKAGE_THINGINO_UHTTPD_HTTP_REDIRECT=y: that's what
-	# makes uhttpd actually redirect port 80 to 443 (see S60uhttpd's -q
-	# flag). Without it, http.https=1 makes timps's one preview port
-	# TLS-only while the WebUI keeps serving plain HTTP on :80 with no
-	# redirect - a page loaded over http:// then tries to fetch the stream
-	# over https:// with a self-signed cert and fails outright (no
-	# interstitial is possible for a subresource fetch). Gating on the
-	# redirect being wired up keeps page and stream on the same scheme.
-	if [ "$(BR2_PACKAGE_TIMPS_TLS)" = "y" ] && [ "$(BR2_PACKAGE_THINGINO_UHTTPD_TLS)" = "y" ] && [ "$(BR2_PACKAGE_THINGINO_UHTTPD_HTTP_REDIRECT)" = "y" ]; then \
-		$(SED) 's|^# http.https .*|http.https    = 1                       # serve the HTTP port over TLS|' \
+	# The value shipped is 1, which since timps v1.9.11 means BOTH schemes on
+	# the one port (per-connection, by a first-byte peek), not TLS-only - that
+	# is now 2. So an http:// WebUI page and an https:// one both reach the
+	# preview port with their own scheme, and the old mixed-content failure
+	# (http:// page, https:// subresource fetch, self-signed cert, no possible
+	# interstitial) cannot happen from this default any more.
+	#
+	# This used to ALSO require BR2_PACKAGE_THINGINO_UHTTPD_HTTP_REDIRECT=y,
+	# back when 1 meant TLS-only and the preview therefore had to be kept on
+	# whatever single scheme uhttpd ended up serving. Dropped, for three
+	# reasons: the tri-state removed the mismatch it guarded against; the
+	# symbol is force-selected alongside UHTTPD_TLS by
+	# BR2_PACKAGE_THINGINO_WEBSERVER_UHTTPD, so the condition could never be
+	# false when the one above it was true; and it had the failure backwards -
+	# redirect=n means :80 is not redirected, NOT that :443 is gone, so
+	# suppressing http.https=1 there is what left an https:// page facing a
+	# plaintext-only preview port (and no cert generated, since S95timps keys
+	# ensure_tls_certs() off this same value).
+	#
+	# Writing 1 is purely additive on any TLS-capable build - plaintext keeps
+	# working - so there is no image on which not writing it is the safer
+	# choice.
+	if [ "$(BR2_PACKAGE_TIMPS_TLS)" = "y" ] && [ "$(BR2_PACKAGE_THINGINO_UHTTPD_TLS)" = "y" ]; then \
+		$(SED) 's|^# http.https .*|http.https    = 1                       # 0 plain, 1 http+https on one port, 2 TLS only|' \
 			$(TARGET_DIR)/etc/timps.conf; \
 	fi
 


### PR DESCRIPTION
## Summary

Follow-up to **#1626**. That PR added a third condition to the `http.https=1` auto-write in `package/timps/timps.mk`:

```make
if [ "$(BR2_PACKAGE_TIMPS_TLS)" = "y" ] && [ "$(BR2_PACKAGE_THINGINO_UHTTPD_TLS)" = "y" ] && [ "$(BR2_PACKAGE_THINGINO_UHTTPD_HTTP_REDIRECT)" = "y" ]; then
```

It should not have survived the tri-state change in the same PR. This drops it and rewrites the (now stale) rationale comment. One file, comment plus one condition.

## Why it should go

**1. Its premise is gone.** The gate was written when `http.https=1` meant *TLS-only*: an `http://` WebUI page would then fetch the preview over `https://` and die on the self-signed cert with no possible interstitial (browsers don't prompt for subresources). Requiring the `:80 → :443` redirect kept page and stream on one scheme. Since v1.9.11, `1` means **both** schemes on the one port, picked per connection by a first-byte `MSG_PEEK` — the page's scheme is now irrelevant, so the mismatch the gate existed to prevent can't occur.

**2. The condition can never be false when the one before it is true.** `package/thingino-webserver/Config.in`'s uhttpd choice selects both symbols together:

```
config BR2_PACKAGE_THINGINO_WEBSERVER_UHTTPD
	select BR2_PACKAGE_THINGINO_UHTTPD_TLS
	select BR2_PACKAGE_THINGINO_UHTTPD_HTTP_REDIRECT
```

A Kconfig `select` forces the symbol to `y` and can't be turned off downstream, so on every image where `UHTTPD_TLS=y` the redirect symbol is `y` too. The gate is dead code that reads as if it means something.

**3. Where it *could* fire, it has the failure backwards.** `HTTP_REDIRECT=n` means ":80 is not redirected" — it does **not** mean ":443 is gone". uhttpd still serves HTTPS on a TLS image. So on such an image the gate suppresses `http.https=1`, which leaves an `https://` WebUI page facing a plaintext-only preview port and getting mixed-content-blocked — and, because `S95timps`'s `ensure_tls_certs()` keys off this same value, with no cert generated either. The gate manufactures the class of breakage it was written to prevent.

**4. Writing `1` is purely additive.** Plaintext keeps being served on that port; the only change is that TLS also works there. Given `TIMPS_TLS=y && UHTTPD_TLS=y`, there is no image on which *not* writing it is the safer choice.

## Considered and rejected

Keeping the gate for `audio.talk_ws=1` (which requires TLS on the http port): on a non-redirected `http://` page the browser has no secure context and can't reach the microphone at all, so nothing is gained — and with `http.https=0` `talk_ws` is disabled outright, which is worse for a user who reaches the same camera over `https://` by choice.

## Note for a separate change

Point 2 has a consequence beyond this file: `BR2_PACKAGE_THINGINO_UHTTPD_HTTP_REDIRECT` is documented as a user-facing opt-out (`bool "Redirect HTTP to HTTPS"`, `default y`) but the `select` makes it non-disableable on any uhttpd image. Turning it off in a config fragment is silently ignored. Not touched here — flagging it since #1625 is the PR that makes that symbol do anything at all.

## Test plan

- [ ] CI / maintainer review

No behavioural change on any current image (point 2), so this is a no-op in practice plus an accurate comment; the behaviour it unblocks only appears if the `select` above is ever relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
