### PR TITLE
docs: HTTP_REDIRECT was never automatic, and isn't by default now either

### DIFF
--- a/package/thingino-uhttpd/Config.in
+++ b/package/thingino-uhttpd/Config.in
@@ -16,7 +16,7 @@ config BR2_PACKAGE_THINGINO_UHTTPD
 	  Features:
 	  - Native HTTPS support with wolfSSL or mbedTLS encryption
 	  - Session-based authentication and security
-	  - Automatic HTTP to HTTPS redirection
+	  - Optional HTTP to HTTPS redirection (opt-in, off by default)
 	  - RESTful API endpoints for automation
 
 	  https://wiki.openwrt.org/doc/howto/http.uhttpd

--- a/package/thingino-uhttpd/doc/README.md
+++ b/package/thingino-uhttpd/doc/README.md
@@ -16,10 +16,12 @@ This package provides a uHTTPd web server with optional HTTPS support for thingi
 Enables TLS/HTTPS support. Enabled by default. Provides:
 - HTTPS on port 443 with modern TLS protocols
 - SSL/TLS encryption for secure web access
-- Automatic HTTP to HTTPS redirection
 
 ### BR2_PACKAGE_THINGINO_UHTTPD_HTTP_REDIRECT
 Enables automatic redirection from HTTP (port 80) to HTTPS (port 443).
+Off by default (opt-in) - enabling it does not change the WebUI's
+own default behavior, only cameras that explicitly turn it on will
+redirect.
 
 ### BR2_PACKAGE_THINGINO_UHTTPD_LUA
 Enables Lua scripting support in the uhttpd binary.

--- a/package/thingino-webserver/README.md
+++ b/package/thingino-webserver/README.md
@@ -17,7 +17,7 @@ The following web servers are supported:
 - Optional TLS/HTTPS support with mbedTLS or wolfSSL
 - Optional Lua scripting support
 - Session-based authentication
-- Auto HTTP to HTTPS redirection
+- Optional HTTP to HTTPS redirection (opt-in, off by default)
 
 ### nginx
 - Full-featured HTTP server and reverse proxy


### PR DESCRIPTION
## Summary

`BR2_PACKAGE_THINGINO_UHTTPD_HTTP_REDIRECT` has never actually redirected anything since it was introduced (`a7b6843e4`, 2025-12-05) - no init script has ever passed uhttpd's `-q` flag or read the option's value, on `master` or `ciao`, in any revision. #1633 fixes the wiring and, in the same PR, sets the option's default to `n` (previously `y`) so that fixing a dead option doesn't silently turn on a new default behavior for the whole user base. This PR updates the three places that still describe redirect as an automatic/default feature, independent of that specific fix - they were already inaccurate before today (the option never worked), and would still be inaccurate after (it now works, but only when explicitly enabled).

## Relation to #1633

This is a docs-only change with no functional risk, kept separate from #1633 on purpose. #1633 combines what were originally three separate PRs (#1625, #1629, #1630 - now closed, superseded) into one, because none of the three pieces was independently safe to merge on its own - see #1633's description for the full explanation of why, and of the merge-order hazard that motivated combining them.

## Test plan

- [x] Verified against upstream `ciao` history (`git log --follow -p`) that no init script revision, ever, has referenced this option or passed `-q`
- [x] Confirmed empirically on two cameras still running a pre-fix build: `uhttpd` process has no `-q`, plain `http://` returns `200`
- [ ] CI / maintainer review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
