### PR TITLE
package/timps: port the http.https tri-state to master (v1.9.8 -> v1.9.11)

### DIFF
--- a/package/timps/README.md
+++ b/package/timps/README.md
@@ -257,8 +257,15 @@ per-stream `audio_enabled`, and the remaining `prudyntctl events` consumers
 
 timps generates a random **per-boot token** and writes it to
 `/run/timps.token` (0640). `timps-token.cgi` (WebUI session auth via
-`auth.sh`) serves it as `{"token":"...","port":8880}` (port/token-file path
-read from `/etc/timps.conf`). With it a WebUI page can skip the localhost
+`auth.sh`) serves it as `{"token":"...","port":8880,"scheme":"..."}`
+(port/token-file path read from `/etc/timps.conf`). `scheme` mirrors the
+`http.https` tri-state — `"http"` (0), `"both"` (1) or `"https"` (2) — and is
+what the JS must use to build the URL: on `"both"` timps answers either scheme
+on that one port, so the page follows **its own** `location.protocol` rather
+than guessing, which is what lets an http:// and an https:// WebUI page both
+reach the preview without a mixed-content block. A legacy `"tls"` bool is
+still emitted (true for 1 and 2) for JS that predates `scheme`.
+With it a WebUI page can skip the localhost
 bridge CGIs and call timps **directly from the browser**: fetch the token
 once, then `fetch('http://<host>:8880/control', {method:'POST', headers:
 {'X-Timps-Token': token}, body: json})` — timps answers the CORS preflight

--- a/package/timps/files/S95timps
+++ b/package/timps/files/S95timps
@@ -41,7 +41,14 @@ UHTTPD_KEY=/etc/ssl/private/uhttpd.key
 # missing (e.g. after a flash), and a copy taken once would silently go stale
 # and desynchronise the two ports again - which is the exact bug this avoids.
 ensure_tls_certs() {
-	[ "$(conf_get http.https)" = "1" ] || [ "$(conf_get rtsp.tls)" = "1" ] || return 0
+	# http.https is a tri-state: 1 = http+https on the one port, 2 = TLS only.
+	# Both need a cert, and a missing one fails CLOSED (httpd.c): the listener
+	# is not bound at all, so http.https=2 without this would kill the HTTP
+	# port outright. rtsp.tls is still a plain boolean.
+	case "$(conf_get http.https)" in
+		1 | 2) ;;
+		*) [ "$(conf_get rtsp.tls)" = "1" ] || return 0 ;;
+	esac
 	crt=$(conf_get http.tls_cert)
 	key=$(conf_get http.tls_key)
 	[ -n "$crt" ] && [ -n "$key" ] || return 0

--- a/package/timps/files/S96onvif_discovery
+++ b/package/timps/files/S96onvif_discovery
@@ -88,12 +88,16 @@ timps_rtsp_endpoint() {
 	echo "${ep#/}"
 }
 
+# http.https is a TRI-STATE, not a boolean: 0 = plaintext, 1 = http and https
+# together on the one port, 2 = TLS only (plaintext gets 426 Upgrade Required).
+# Deliberately not timps_bool_default(), which is shared with the genuinely
+# boolean keys and would report "http" for 2 - the URIs advertised to ONVIF
+# clients would then all be refused by the daemon.
 timps_http_scheme() {
-	if [ "$(timps_bool_default http.https false)" = "true" ]; then
-		echo "https"
-	else
-		echo "http"
-	fi
+	case "$(timps_conf_get http.https | tr 'A-Z' 'a-z')" in
+		1 | 2 | true | yes | on) echo "https" ;;
+		*) echo "http" ;;
+	esac
 }
 
 timps_http_port() {

--- a/package/timps/files/agent-adapter
+++ b/package/timps/files/agent-adapter
@@ -42,9 +42,11 @@ agent_timps_port() {
 	printf '%s' "$port"
 }
 
+# Tri-state: 0 = plaintext, 1 = http and https on the one port, 2 = TLS only
+# (plaintext answered with 426). Both on-values speak https.
 agent_timps_scheme() {
 	case "$(agent_conf_get http.https | tr 'A-Z' 'a-z')" in
-		1 | true | yes | on) printf 'https' ;;
+		1 | 2 | true | yes | on) printf 'https' ;;
 		*) printf 'http' ;;
 	esac
 }

--- a/package/timps/files/timps.conf
+++ b/package/timps/files/timps.conf
@@ -59,8 +59,10 @@ rtsp.pass    = thingino
 # ---- HTTP preview (fMP4 + JPEG/MJPEG) ----
 # NOTE: the WebUI proxies /mjpeg and /onvif/image.cgi are wired to
 # http://127.0.0.1:8880 at build time. If you change http.port (or set
-# http.https=1, which turns this port TLS-only), those two loopback proxies in
-# /etc/httpd.conf stop working until you repoint them to the new port/scheme.
+# http.https=2, which refuses plaintext on this port), those two loopback
+# proxies in /etc/httpd.conf stop working until you repoint them to the new
+# port/scheme. http.https=1 leaves them working: that value serves plain HTTP
+# and HTTPS side by side on the one port - see the TLS block below.
 http.enabled     = 1
 http.port        = 8880
 http.preview_chn = 1
@@ -80,7 +82,28 @@ http.token_file  = /run/timps.token
 # in the image, a timps-own self-signed pair is generated at these paths
 # instead. Point them at a real cert to use your own - an existing, non-empty
 # pair is always left alone.
-# http.https    = 1                       # serve the HTTP port over TLS
+#
+# NOTE: http.https is a TRI-STATE, and 1 means something WIDER than it did
+# before v1.9.11 - read this before assuming the old behaviour:
+#   0  plaintext only (default). No TLS on the http port at all.
+#   1  BOTH schemes on the SAME port. Each connection is classified by its
+#      first byte (0x16 = a TLS handshake record; every HTTP method starts
+#      with a letter), so http://<ip>:8880/ and https://<ip>:8880/ both work
+#      and nothing has to agree in advance on which one to use. This used to
+#      mean TLS-ONLY, and that was the bug: the preview stream is fetched by
+#      a WebUI page whose scheme is decided by a DIFFERENT server (uhttpd on
+#      :80/:443). Page on http:// + stream on https:// fails outright, because
+#      a self-signed cert cannot be click-through-trusted for a subresource
+#      fetch (Safari just says "Load failed"); page on https:// + stream on
+#      http:// is blocked as mixed content. Serving both makes the page's
+#      scheme irrelevant.
+#   2  TLS only: a plaintext request is answered with 426 Upgrade Required and
+#      the connection closed. This is the old meaning of 1, kept as a
+#      deliberate opt-in for a port that must never carry cleartext (note that
+#      Basic-auth headers and http.token are exactly what it protects).
+# Either on-value still fails CLOSED if the cert/key cannot be loaded: the
+# listener is not bound at all rather than silently downgraded to plaintext.
+# http.https    = 1                       # 0 plain, 1 http+https on one port, 2 TLS only
 http.tls_cert   = /etc/ssl/certs/timps.crt
 http.tls_key    = /etc/ssl/private/timps.key
 # rtsp.tls      = 1                       # additionally run an RTSPS listener

--- a/package/timps/files/www/a/preview-motion.js
+++ b/package/timps/files/www/a/preview-motion.js
@@ -21,7 +21,21 @@
   const btn = document.getElementById("ms-motion");
   if (!video || !canvas || !btn) return;
 
-  let base = null;   // http://<host>:<port>
+  // http.https tri-state, as reported by timps-token.cgi's "scheme" field.
+  // "both" = plain HTTP and HTTPS on the one timps port, so follow the PAGE's
+  // scheme: an https:// page may not fetch http:// (mixed content), and an
+  // http:// page cannot clear a self-signed cert on a subresource fetch.
+  // Falls back to the older "tls" bool when the CGI predates "scheme".
+  function timpsScheme(info) {
+    if (!info) return "http";
+    if (info.scheme === "both") {
+      return window.location.protocol === "https:" ? "https" : "http";
+    }
+    if (info.scheme === "https" || info.scheme === "http") return info.scheme;
+    return info.tls ? "https" : "http";
+  }
+
+  let base = null;   // http(s)://<host>:<port>
   let token = null;
   let es = null;     // EventSource (push mode)
   let esErrors = 0;  // consecutive errors since the last successful open
@@ -275,7 +289,7 @@
     token = info.token;
     let host = location.hostname || "127.0.0.1";
     if (host.indexOf(":") >= 0 && host[0] !== "[") host = "[" + host + "]"; // raw IPv6
-    base = (info.tls ? "https" : "http") + "://" + host + ":" + (info.port || 8880);
+    base = timpsScheme(info) + "://" + host + ":" + (info.port || 8880);
 
     // Bind teardown before the probe below can start waiting on the network.
     window.addEventListener("pagehide", () => {

--- a/package/timps/files/www/a/preview-talk.js
+++ b/package/timps/files/www/a/preview-talk.js
@@ -19,7 +19,8 @@
  *     ws:// accepted too. audio.talk_ws=1 on a plaintext port reports 0
  *     (/talk would 426), so there is nothing left here to second-guess -
  *     the only thing this file still derives is the SCHEME, from the same
- *     timps-token.cgi "tls" field that already picks http:// vs https://.
+ *     timps-token.cgi "scheme" field that already picks http:// vs https://
+ *     (and, when timps serves both on the one port, the page's own).
  *   - navigator.mediaDevices.getUserMedia. This is the one the camera cannot
  *     fix from its side: browsers refuse it outside a secure context, so on a
  *     plain-http:// page it is simply absent unless the operator granted the
@@ -59,7 +60,21 @@
   let base = null;    // http(s)://<host>:<port>
   let wsBase = null;  // ws(s)://<host>:<port>, same scheme family as `base`
   let token = null;
-  let tls = false;    // timps' http.https, per /x/timps-token.cgi
+  let tls = false;    // true once the scheme we actually dial is https/wss
+
+  // http.https tri-state, as reported by timps-token.cgi's "scheme" field.
+  // "both" = plain HTTP and HTTPS on the one timps port, so follow the PAGE's
+  // scheme: an https:// page may only open wss:// (mixed content), and an
+  // http:// page cannot clear a self-signed cert on a WebSocket handshake.
+  // Falls back to the older "tls" bool when the CGI predates "scheme".
+  function timpsScheme(info) {
+    if (!info) return "http";
+    if (info.scheme === "both") {
+      return window.location.protocol === "https:" ? "https" : "http";
+    }
+    if (info.scheme === "https" || info.scheme === "http") return info.scheme;
+    return info.tls ? "https" : "http";
+  }
   let stopped = false; // set on pagehide; stops the probe retry loop
 
   // live session state, all null/idle between presses
@@ -325,8 +340,9 @@
     let host = location.hostname || "127.0.0.1";
     if (host.indexOf(":") >= 0 && host[0] !== "[") host = "[" + host + "]"; // raw IPv6
     const port = info.port || 8880;
-    tls = !!info.tls;
-    base = (tls ? "https" : "http") + "://" + host + ":" + port;
+    const sch = timpsScheme(info);
+    tls = sch === "https";
+    base = sch + "://" + host + ":" + port;
     // Same scheme family as `base`, never hardcoded: an https:// page may only
     // open wss:// (mixed content), and a plaintext timps listener only speaks
     // ws://. probe() refuses to show the button for any combination timps

--- a/package/timps/files/www/a/timps-api.js
+++ b/package/timps/files/www/a/timps-api.js
@@ -33,6 +33,7 @@
             token: data && data.token ? String(data.token) : "",
             port: data && data.port ? parseInt(data.port, 10) : DEFAULT_PORT,
             tls: !!(data && data.tls),
+            scheme: data && data.scheme ? String(data.scheme) : "",
           };
           return info;
         });
@@ -40,11 +41,24 @@
     return infoPending;
   }
 
+  // http.https is a tri-state; timps-token.cgi reports it as "scheme".
+  // "both" = plain HTTP and HTTPS on the one timps port, so follow the PAGE's
+  // scheme: an https:// page may not fetch http:// (mixed content), and an
+  // http:// page cannot get past a self-signed cert on a subresource fetch.
+  // Falls back to the older "tls" bool when the CGI predates "scheme".
+  function schemeOf(i) {
+    if (!i) return "http";
+    if (i.scheme === "both") {
+      return window.location.protocol === "https:" ? "https" : "http";
+    }
+    if (i.scheme === "https" || i.scheme === "http") return i.scheme;
+    return i.tls ? "https" : "http";
+  }
+
   function base() {
     var host = window.location.hostname || "127.0.0.1";
     if (host.indexOf(":") >= 0 && host.charAt(0) !== "[") host = "[" + host + "]"; // IPv6
-    var scheme = (info && info.tls) ? "https" : "http";
-    return scheme + "://" + host + ":" + (info ? info.port : DEFAULT_PORT);
+    return schemeOf(info) + "://" + host + ":" + (info ? info.port : DEFAULT_PORT);
   }
 
   // one /control round trip with the token header; retries ONCE with a

--- a/package/timps/files/www/a/timps-preview.js
+++ b/package/timps/files/www/a/timps-preview.js
@@ -38,11 +38,26 @@ function fetchTimpsMediaInfo(force = false) {
           token: data && data.token ? String(data.token) : "",
           port: data && data.port ? parseInt(data.port, 10) : 8880,
           tls: !!(data && data.tls),
+          scheme: data && data.scheme ? String(data.scheme) : "",
         };
         return timpsMediaInfo;
       });
   }
   return timpsMediaPending;
+}
+
+// http.https tri-state, as reported by timps-token.cgi's "scheme" field.
+// "both" = plain HTTP and HTTPS on the one timps port, so follow the PAGE's
+// scheme: an https:// page may not load an http:// <img> (mixed content), and
+// an http:// page cannot clear a self-signed cert on a subresource. Falls back
+// to the older "tls" bool when the CGI predates "scheme".
+function timpsMediaScheme(info) {
+  if (!info) return "http";
+  if (info.scheme === "both") {
+    return window.location.protocol === "https:" ? "https" : "http";
+  }
+  if (info.scheme === "https" || info.scheme === "http") return info.scheme;
+  return info.tls ? "https" : "http";
 }
 
 // kind "live" -> /stream.mjpeg, "still" -> /snapshot.jpg; chn is the numeric
@@ -51,7 +66,7 @@ function fetchTimpsMediaInfo(force = false) {
 function timpsMediaUrl(kind, chn, host) {
   const h = wrapIpv6Host(host || window.location.hostname || "127.0.0.1");
   const port = timpsMediaInfo ? timpsMediaInfo.port : 8880;
-  const scheme = timpsMediaInfo && timpsMediaInfo.tls ? "https" : "http";
+  const scheme = timpsMediaScheme(timpsMediaInfo);
   const path = kind === "still" ? "/snapshot.jpg" : "/stream.mjpeg";
   let url = `${scheme}://${h}:${port}${path}?chn=${chn}`;
   if (timpsMediaInfo && timpsMediaInfo.token) {

--- a/package/timps/files/www/preview.html
+++ b/package/timps/files/www/preview.html
@@ -293,6 +293,19 @@
         .then((r) => (r.ok ? r.json() : null))
         .catch(() => null);
     }
+    // http.https tri-state, as reported by timps-token.cgi's "scheme" field.
+    // "both" = plain HTTP and HTTPS on the one timps port, so follow the
+    // PAGE's scheme: an https:// page may not fetch http:// (mixed content),
+    // and an http:// page cannot clear a self-signed cert on a fetch(). Falls
+    // back to the older "tls" bool when the CGI predates "scheme".
+    function timpsScheme(info) {
+      if (!info) return "http";
+      if (info.scheme === "both") {
+        return window.location.protocol === "https:" ? "https" : "http";
+      }
+      if (info.scheme === "https" || info.scheme === "http") return info.scheme;
+      return info.tls ? "https" : "http";
+    }
     window.timpsTokenInfo = window.timpsTokenInfo || fetchTimpsTokenInfo();
     // The token is per timps BOOT: if timpsd restarts under a running player,
     // every request with the old token comes back 401 and the preview is stuck
@@ -574,7 +587,7 @@
       if (statsEs || !window.EventSource) return;
       const info = await window.timpsTokenInfo;
       if (statsCard.style.display === "none") return; // toggled off while awaiting the token
-      const b = info ? (info.tls ? "https" : "http") + "://" + host + ":" + (info.port || MS_PORT) : base;
+      const b = info ? timpsScheme(info) + "://" + host + ":" + (info.port || MS_PORT) : base;
       const tok = info && info.token ? "&token=" + encodeURIComponent(info.token) : "";
       statsEs = new EventSource(b + "/events?stream=stats" + tok);
       statsEs.addEventListener("stats", (ev) => {
@@ -689,7 +702,7 @@
     // and the "&token=..." suffix both the stream fetch and /control use.
     async function endpoint() {
       const info = await window.timpsTokenInfo;
-      if (info) base = (info.tls ? "https" : "http") + "://" + host + ":" + (info.port || MS_PORT);
+      if (info) base = timpsScheme(info) + "://" + host + ":" + (info.port || MS_PORT);
       return { base: base, tok: info && info.token ? "&token=" + encodeURIComponent(info.token) : "" };
     }
 

--- a/package/timps/files/www/x/timps-token.cgi
+++ b/package/timps/files/www/x/timps-token.cgi
@@ -3,8 +3,9 @@
 # Hand the per-boot timps /control token to the authenticated WebUI session.
 # timps writes a fresh random token to /run/timps.token (0640) on every start;
 # with it a browser page can drive timps DIRECTLY (no local bridge CGI):
-#   const {token, port} = await (await fetch('/x/timps-token.cgi')).json();
-#   fetch(`http://${location.hostname}:${port}/control`, {method:'POST',
+#   const {token, port, scheme} = await (await fetch('/x/timps-token.cgi')).json();
+#   const s = scheme === 'both' ? location.protocol.replace(':','') : scheme;
+#   fetch(`${s}://${location.hostname}:${port}/control`, {method:'POST',
 #         headers:{'X-Timps-Token': token}, body:'{"image":{...}}'});
 # Only the per-boot token is exposed here - a configured http.token secret
 # never reaches the file (timps keeps it in memory only).
@@ -21,10 +22,35 @@ tf=$(sed -n 's/^[[:space:]]*http\.token_file[[:space:]]*=[[:space:]]*"\{0,1\}\([
 [ -n "$tf" ] && TOKEN_FILE="$tf"
 port=$(sed -n 's/^[[:space:]]*http\.port[[:space:]]*=[[:space:]]*\([0-9]\{1,\}\).*/\1/p' "$CONF" 2>/dev/null | head -n1)
 [ -z "$port" ] && port=8880
-# whether timps serves the HTTP port over TLS (http.https): the browser must
-# then use https:// for the media/control URLs.
-https=$(sed -n 's/^[[:space:]]*http\.https[[:space:]]*=[[:space:]]*\([0-9A-Za-z]*\).*/\1/p' "$CONF" 2>/dev/null | head -n1)
-case "$https" in 1 | true | yes | on) tls=true ;; *) tls=false ;; esac
+# http.https is a TRI-STATE since timps v1.9.11, not a boolean:
+#   0  plaintext only                      -> scheme "http"
+#   1  http AND https on the SAME port, picked per connection by a first-byte
+#      peek (true/yes/on parse as 1)        -> scheme "both"
+#   2  TLS only, plaintext gets a 426       -> scheme "https"
+#
+# "scheme" is the field the WebUI JS should use. On "both" it must follow the
+# PAGE's own protocol rather than a fixed guess: an https:// WebUI page may not
+# fetch an http:// subresource (mixed content), and an http:// page hitting
+# https:// dies on the self-signed cert with no possible interstitial. Since
+# timps answers either scheme on that one port, following the page always works.
+#
+# "tls" is kept for JS that predates "scheme" (a cached page, a partial
+# upgrade): true for either on-value, i.e. the old "use https://" meaning.
+https=$(sed -n 's/^[[:space:]]*http\.https[[:space:]]*=[[:space:]]*\([0-9A-Za-z]*\).*/\1/p' "$CONF" 2>/dev/null | head -n1 | tr '[:upper:]' '[:lower:]')
+case "$https" in
+	1 | true | yes | on)
+		scheme=both
+		tls=true
+		;;
+	2)
+		scheme=https
+		tls=true
+		;;
+	*)
+		scheme=http
+		tls=false
+		;;
+esac
 
 echo "Content-Type: application/json"
 echo "Cache-Control: no-store"
@@ -35,7 +61,7 @@ token=""
 [ -r "$TOKEN_FILE" ] && token=$(head -n1 "$TOKEN_FILE" 2>/dev/null | tr -cd '0-9A-Za-z')
 
 if [ -n "$token" ]; then
-	printf '{"token":"%s","port":%s,"tls":%s}\n' "$token" "$port" "$tls"
+	printf '{"token":"%s","port":%s,"tls":%s,"scheme":"%s"}\n' "$token" "$port" "$tls" "$scheme"
 else
-	printf '{"error":"no token available","port":%s,"tls":%s}\n' "$port" "$tls"
+	printf '{"error":"no token available","port":%s,"tls":%s,"scheme":"%s"}\n' "$port" "$tls" "$scheme"
 fi

--- a/package/timps/timps.hash
+++ b/package/timps/timps.hash
@@ -1,2 +1,3 @@
 # Locally calculated
 sha256  6e13567c273e2083cde9a4e1c150fc3d176cd9287f8ba5aa21a024a13602f5d6  timps-v1.9.8-git4.tar.gz
+sha256  3f1f74a9eff9e26d60345c42b5d3aea770244e230f649ce5835b6fe2f576c195  timps-v1.9.11-git4.tar.gz

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -6,7 +6,7 @@
 
 TIMPS_SITE_METHOD = git
 TIMPS_SITE = https://github.com/Lu-Fi/timps
-TIMPS_VERSION = v1.9.8
+TIMPS_VERSION = v1.9.11
 TIMPS_LICENSE = MIT
 # Upstream ships no LICENSE file yet; add one and set TIMPS_LICENSE_FILES = LICENSE
 # once it exists so legal-info can capture it.

--- a/package/timps/timps.mk
+++ b/package/timps/timps.mk
@@ -262,8 +262,14 @@ define TIMPS_INSTALL_TARGET_CMDS
 	# only links the shared cert pair when it sees this already set, so
 	# leaving it commented meant every TLS+WebUI image needed a manual
 	# post-flash edit before HTTPS actually worked.
+	#
+	# Since v1.9.11 the value written here, 1, means http AND https on the
+	# one port (picked per connection by a first-byte peek), not TLS-only -
+	# so this no longer depends on the WebUI and timps agreeing on a scheme,
+	# and the shipped comment has to say so. 2 is the old TLS-only meaning
+	# and stays a deliberate hand edit.
 	if [ "$(BR2_PACKAGE_TIMPS_TLS)" = "y" ] && [ "$(BR2_PACKAGE_THINGINO_UHTTPD_TLS)" = "y" ]; then \
-		$(SED) 's|^# http.https .*|http.https    = 1                       # serve the HTTP port over TLS|' \
+		$(SED) 's|^# http.https .*|http.https    = 1                       # 0 plain, 1 http+https on one port, 2 TLS only|' \
 			$(TARGET_DIR)/etc/timps.conf; \
 	fi
 


### PR DESCRIPTION
Ports the timps `http.https` tri-state work from `ciao` to `master`. `master`'s
`TIMPS_VERSION` is three releases behind (v1.9.8), so its shipped scripts and
WebUI JS still treat `http.https` as a boolean.

**Scope: `package/timps/*` only.** This deliberately does **not** include the
uhttpd/webserver `HTTP_REDIRECT` work — that is tracked separately in #1633 and
nothing under `package/thingino-uhttpd/` or `package/thingino-webserver/` is
touched here.

### What `http.https` means from timps v1.9.11

It became a tri-state (`src/mp4/httpd.c` classifies each connection by its
first byte — `0x16` is a TLS record, every HTTP method starts with a letter):

| value | behaviour |
|---|---|
| `0` | plaintext only (default) |
| `1` | **both** HTTP and HTTPS on the *same* port |
| `2` | TLS only; a plaintext request gets `426 Upgrade Required` |

`1` used to mean TLS-only. That was the bug: the preview stream is fetched by a
WebUI page whose scheme is decided by a *different* server (uhttpd on :80/:443).
An `http://` page fetching `https://` cannot click-through a self-signed cert on
a subresource; an `https://` page fetching `http://` is blocked as mixed content.
Serving both on the one port makes the page's scheme irrelevant. `2` preserves
the old strict behaviour as a deliberate opt-in.

### Commits

Cherry-picked from the ciao-side originals, plus a version bump recreated for
master's starting point:

- `timps: generate TLS certs for strict http.https=2 too` — `S95timps`
  (from #1626). `2` needs a cert exactly as `1` does, and a missing cert fails
  *closed* in httpd.c (the listener is not bound at all), so without this
  `http.https=2` would kill the preview port outright.
- `timps: treat http.https=2 (strict TLS) as https in scheme detection` —
  `S96onvif_discovery`, `agent-adapter` (from #1626). The old boolean parse
  reported `http` for `2`, so every URI advertised to ONVIF clients would have
  been refused by the daemon.
- `timps: sync shipped timps.conf TLS comments with the tri-state http.https`
  (from #1626).
- `timps: make the WebUI follow the page scheme on http.https=1` —
  `timps-token.cgi` now emits a `"scheme"` field (`http`/`both`/`https`); the JS
  consumers use `location.protocol` on `both` and fall back to the legacy `tls`
  bool when the CGI predates `scheme` (from #1628).
- `package/timps: bump v1.9.8 -> v1.9.11` (shape of #1627, retargeted from
  v1.9.8 rather than v1.9.10).
- `package/timps: fix the auto-written http.https comment` — master-only; see
  below.

### Deliberate differences from ciao

1. **No `BR2_PACKAGE_THINGINO_UHTTPD_HTTP_REDIRECT` gate.** ciao's #1626 also
   narrowed the `http.https` auto-write in `timps.mk` to require that symbol.
   That gate exists to keep the WebUI page and the stream on the same scheme —
   which is precisely the problem the tri-state `1` removes, since timps now
   answers either scheme on that port. Adding it here would only disable TLS
   auto-enable on configs that do not select the redirect, for no remaining
   benefit, and it is the part of this series that belongs to #1633's subject
   matter.
2. **The auto-written comment text is corrected.** `timps.mk` seds
   `http.https = 1 # serve the HTTP port over TLS` into the shipped conf; with
   the new semantics that sentence is wrong, so it now matches `timps.conf`'s
   own wording (`0 plain, 1 http+https on one port, 2 TLS only`). Verified the
   `^# http.https .*` pattern still matches exactly one line of the new
   `timps.conf` (the `# http.https=2, ...` prose line has no space and is not
   hit).
3. **Only the v1.9.11 hash line is added**, not ciao's intermediate
   v1.9.9/v1.9.10 lines, which master never pinned.
4. Two unrelated ciao changes that happen to live in `package/timps/` are *not*
   included: the `telegram-cam-register` `--capath` → `--tls-use-os-certs`
   switch, and the README/`TIMPS_REAPPLY_WEBUI_OVERLAY` notes about prudynt-t
   shipping its own `preview.html`.

### Behaviour change worth flagging

On an image built with `BR2_PACKAGE_TIMPS_TLS=y` **and**
`BR2_PACKAGE_THINGINO_UHTTPD_TLS=y`, `timps.mk` already auto-writes
`http.https = 1`. Before this bump that yielded a TLS-only preview port; after
it, that port also accepts plaintext. That is the intended fix, but operators
who want the old strict behaviour must now set `http.https = 2` explicitly. The
shipped `timps.conf` documents this.

### Verification

- `v1.9.8` → `v1.9.11` diff reviewed for anything with hardware blast radius on
  the SoCs master builds that ciao does not. The relevant items are the T40/T41
  libimp header pin (`T40/1.3.1/en`, `T41/1.2.6/en`) and the T40/T41
  `IMP_OSD_SetPoolSize` fix. Both header sets are vendored inside the timps repo
  (`include/T40/1.3.1`, `include/T41/1.2.6`), so nothing firmware-side has to
  supply them, and they match master's own `ingenic-lib.mk` SDK pins (T40 1.3.1,
  T41 1.2.6) exactly. The dropped T21 `-ftls-model=local-exec` flag is safe: no
  `__thread` declarations remain in timps `src/` at v1.9.11.
- `package/timps/Config.in` is byte-identical between `master` and `ciao`, and
  the two branches' `package/timps/` file lists are identical, so nothing
  structural had to be adapted — all four consumer-script commits cherry-picked
  cleanly.
- Hash: `3f1f74a9…` checked against the actual buildroot-produced
  `timps-v1.9.11-git4.tar.gz` in a local `dl/` cache (the recorded v1.9.8 hash
  reproduces from the same cache, confirming the method).
- `shfmt -d -i 0 -ci` and `shellcheck -x` (0.11.0, the pinned CI versions) pass
  on all four changed `#!/bin/sh` files; `scripts/check-do-not-edit.sh` passes;
  the changed JS parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
