### PR TITLE
linux-kopt: re-register THINGINO_KOPT_PREPARE_KERNEL post-patch (fixes #1637)

### DIFF
--- a/linux/linux-ext-thingino-kopt.mk
+++ b/linux/linux-ext-thingino-kopt.mk
@@ -1,5 +1,10 @@
 LINUX_EXTENSIONS += thingino-kopt
 
+# Run the LED header/patch hook after patches: the cumulative thingino
+# kernel patch ships its own board_base.c, which overwrites the changes
+# made by the PRE_PATCH hook.
+LINUX_POST_PATCH_HOOKS += THINGINO_KOPT_PREPARE_KERNEL
+
 THINGINO_LED_CONFIG = $(BR2_CONFIG)
 THINGINO_LED_HEADER = $(LINUX_DIR)/arch/mips/xburst/soc-$(SOC_FAMILY)/chip-$(SOC_FAMILY)/isvp/common/thingino_leds.h
 THINGINO_LED_BOARD_BASE = $(LINUX_DIR)/arch/mips/xburst/soc-$(SOC_FAMILY)/chip-$(SOC_FAMILY)/isvp/common/board_base.c


### PR DESCRIPTION
Fixes #1637.

`94867f9ac` ("linux: per-device dts from the camera profile dir") dropped the
`LINUX_POST_PATCH_HOOKS += THINGINO_KOPT_PREPARE_KERNEL` registration while keeping the
`THINGINO_KOPT_PREPARE_KERNEL` macro definition. As a result `generate_kernel_led_header.sh`
and `patch_kernel_leds_board_base.sh` never ran, so no `leds-gpio` platform device was
registered — `/sys/class/leds/` stayed empty and every LED path (`led`, S00blink, S99led,
WebUI startup indicator) was dead.

This restores the registration. It belongs on **`LINUX_POST_PATCH_HOOKS`**, not
`LINUX_PRE_BUILD_HOOKS`: the cumulative 3.10.14 kernel patch rewrites `board_base.c`, so the
LED board patch must run after the patches are applied (the same reason it was originally
moved post-patch in `651710404`).

Verification:
- `git grep -n THINGINO_KOPT_PREPARE_KERNEL` → exactly one definition + one `LINUX_POST_PATCH_HOOKS` registration.
- `linux/linux-ext-thingino-kopt.mk` is ASCII-only; one file, one hunk.

Diagnosed and fixed by the Thingino workspace **Firmware** agent (self-hosted Multica).
