### PR TITLE
timps webui: gate pages on session before first paint

### DIFF
--- a/package/timps/WEBUI-NOTES.md
+++ b/package/timps/WEBUI-NOTES.md
@@ -122,6 +122,64 @@ How the override works, and why it is safe:
   ("load", initAll)`, which is later still, so `initAll`'s click handlers
   already call the timps implementations.
 
+## a/timps-auth-gate.js
+
+### File header: why a second, earlier session check
+
+Core `main.js` already checks `/x/session-status.cgi` and redirects an
+unauthenticated visitor to `/login.html`, but it does that from
+`window.addEventListener("load", ...)` plus a 100 ms timeout - i.e. after
+every subresource has settled. The stock pages pull Bootstrap CSS/JS from
+jsdelivr and Montserrat from Google Fonts, so on a camera VLAN with no
+internet route `load` only fires once those requests hit their TCP timeout.
+Until then the visitor sits looking at a fully rendered `preview.html` -
+nav bar, empty video box, every control widget. Nothing leaks (the session
+cookie is `HttpOnly`, and `session-status.cgi`, `timps-token.cgi`, the
+snapshot CGIs and the stream all 401 on their own), but it looks like the
+camera let them in.
+
+This file closes that window without forking `main.js`:
+- It is a plugin-manifest "scripts" entry, so `assemble_plugins.py` injects
+  it as a plain `<script src>` before `</head>` - no `defer`, no `async`
+  (see `make_script_tag()`), so it is parser-blocking and runs before
+  `<body>` is parsed. There is therefore no moment at which page content
+  could paint before the gate is armed.
+- Arming is `document.documentElement.style.visibility = "hidden"`, and
+  revealing restores the previous inline value (normally `""`) rather than
+  writing `visible`, so it never overrides page CSS and there is no second
+  flash. `visibility` and not `display:none` so the themed page background
+  still paints - a blank dark page, not a white one.
+- The `HttpOnly` cookie is not readable from JS, so there is no way to know
+  the answer without the round trip. `credentials: "same-origin"` is fetch's
+  default for a same-origin URL and is spelled out here only to document
+  that the cookie does ride along (HttpOnly blocks JS *reads*, not sending).
+
+Fail-open, deliberately: a 1500 ms `setTimeout` reveals the page no matter
+what, and an `AbortController` on the same deadline drops the request. A
+network error, a 5xx, a non-JSON body or a missing `authenticated` key all
+reveal too. The gate never becomes the reason a camera looks bricked - a
+genuinely unauthenticated session still gets caught by `main.js`'s slower
+check on exactly today's timeline. 1500 ms is ~50x the measured LAN
+round trip (25-34 ms), so the timeout is a backstop, not a budget.
+
+Only a definitive answer redirects: HTTP 401/403, or `authenticated:false`.
+The target matches `main.js`'s `redirectToLogin()` (a bare `/login.html`;
+core keeps no return-to parameter, so neither does this). It uses
+`location.replace()` rather than assigning `location.href`, because this
+fires before paint: an `href` assignment would push a history entry for a
+page the user never saw, and Back from `/login.html` would land on it and
+be thrown forward again.
+
+Skipped pages (`SKIP`) are exactly the ones core does not gate: `/login.html`
+and `/401.html` (`redirectToLogin()` bails on both, to avoid a loop),
+`/wait.html` (the reboot splash - the CGI is down by design there, and a
+reboot must not end at the login form), `/gphotos-auth-callback.html` (an
+OAuth landing page that has to relay its code, and redirecting would lose
+it), and `/` + `/index.html` (an empty `<meta http-equiv="refresh">` stub
+with nothing to hide, whose refresh would race the gate). `wait.html`,
+`gphotos-auth-callback.html` and `login.html` do not load `main.js` at all;
+the injection is per-page-unconditional, hence the explicit list.
+
 ## a/streamer-osd.js
 
 ### File header: full data-flow spec (Phase 1, data-driven OSD items)

--- a/package/timps/files/timps.webui.json
+++ b/package/timps/files/timps.webui.json
@@ -110,7 +110,8 @@
     }
   ],
   "scripts": [
-    "/a/timps-control-bar.js"
+    "/a/timps-control-bar.js",
+    "/a/timps-auth-gate.js"
   ],
   "styles": [
     "/a/timps.css"

--- a/package/timps/files/www/a/timps-auth-gate.js
+++ b/package/timps/files/www/a/timps-auth-gate.js
@@ -1,0 +1,81 @@
+/* timps-auth-gate.js - pre-paint session gate. Injected into <head> by
+ * assemble_plugins.py, so it runs before <body> is parsed: it hides the
+ * document, asks /x/session-status.cgi, then reveals or leaves for
+ * /login.html. Fails OPEN - any error, non-JSON, 5xx or timeout reveals the
+ * page and defers to main.js's own load-time check. See WEBUI-NOTES.md. */
+(function () {
+  "use strict";
+
+  /* Pages main.js does not gate either: the login form, the 401 page, the
+   * reboot splash, the Google Photos OAuth landing, and the empty
+   * meta-refresh stub at /. */
+  var SKIP = {
+    "/": 1,
+    "/index.html": 1,
+    "/login.html": 1,
+    "/401.html": 1,
+    "/wait.html": 1,
+    "/gphotos-auth-callback.html": 1,
+  };
+
+  if (SKIP[window.location.pathname]) return;
+  if (window.__timpsAuthGate) return;
+  if (typeof window.fetch !== "function") return; /* nothing to gate with */
+  window.__timpsAuthGate = true;
+
+  var REVEAL_MS = 1500; /* same-origin CGI measures ~30 ms on a LAN */
+  var root = document.documentElement;
+  var prev = root.style.visibility;
+  var settled = false;
+  var timer = null;
+
+  function reveal() {
+    if (settled) return;
+    settled = true;
+    if (timer) clearTimeout(timer);
+    root.style.visibility = prev;
+  }
+
+  function toLogin() {
+    if (settled) return;
+    settled = true;
+    if (timer) clearTimeout(timer);
+    /* replace(), not href=: this fires before paint, so a history entry for
+     * a never-shown page would make Back bounce straight forward again. */
+    window.location.replace("/login.html");
+  }
+
+  root.style.visibility = "hidden";
+  timer = setTimeout(reveal, REVEAL_MS);
+
+  try {
+    var ctl = typeof AbortController === "function" ? new AbortController() : null;
+    if (ctl) setTimeout(function () { ctl.abort(); }, REVEAL_MS);
+
+    fetch("/x/session-status.cgi", {
+      cache: "no-store",
+      credentials: "same-origin", /* HttpOnly session cookie rides along */
+      signal: ctl ? ctl.signal : undefined,
+    })
+      .then(function (res) {
+        if (res.status === 401 || res.status === 403) {
+          toLogin();
+          return null;
+        }
+        if (!res.ok) return null; /* 5xx etc - fail open */
+        return res.json();
+      })
+      .then(function (data) {
+        if (!data || typeof data.authenticated === "undefined") {
+          reveal();
+        } else if (data.authenticated) {
+          reveal();
+        } else {
+          toLogin();
+        }
+      })
+      .catch(reveal);
+  } catch (e) {
+    reveal();
+  }
+})();


### PR DESCRIPTION
## Summary

Same fix as #1639 (against `ciao`), ported to `master` - identical 3-file diff, applies cleanly, no master-specific adaptation needed (`package/timps/` and the `thingino-webui` plugin-manifest mechanism it depends on are structurally the same on both branches).

Unauthenticated users briefly see a fully-rendered `preview.html` before client-side JS redirects them to `/login.html`. Cosmetic (every real data endpoint already 401s correctly), but visually janky, and worse on a camera VLAN with no internet egress since the existing check only runs on the page's `load` event, which blocks on external CDN resources that silently blackhole.

Adds a pre-paint session gate, scoped entirely to `package/timps`:

- **`package/timps/files/www/a/timps-auth-gate.js`** (new): injected into `<head>` on every page via the existing WebUI-plugin manifest mechanism, runs before `<body>` is parsed. Hides the page, asks `/x/session-status.cgi`, reveals or redirects to `/login.html`.
- **Fails open**: any error/timeout (1.5s backstop, ~50x the measured LAN round trip) reveals the page and defers to the existing slower `load`-time check - that fallback is untouched.
- **Explicit skip list**: `login.html`, `401.html`, `wait.html`, `gphotos-auth-callback.html`, `/`/`index.html`.
- **`package/timps/files/timps.webui.json`**: registers the script, kept after `timps-control-bar.js` per its `DOMContentLoaded`-ordering requirement.

No changes to `main.js`, the login flow, or session validation - only changes *when* an already-correct auth decision becomes visible.

## Verified

Same verification as #1639 (sandboxed logic test across 17 branches, real `assemble_plugins.py` injection confirmed, live test-camera flash confirming the script is served and injected fleet-page-wide, not preview-only) - see that PR for full detail. This PR additionally confirms the cherry-pick applies byte-for-byte identically onto `master` with zero conflicts.

## Test plan

- [x] Cherry-pick applies cleanly onto `master`, identical diff to #1639
- [x] Verified live on a test camera (shared with #1639 - the underlying files are branch-independent)
- [ ] CI / maintainer review

🤖 Generated with [Claude Code](https://claude.com/claude-code)
