### PR TITLE
prudynt-t: fix invalid JSON in tool-record.cgi (video object never closed)

### DIFF
--- a/package/prudynt-t/files/www/x/tool-record.cgi
+++ b/package/prudynt-t/files/www/x/tool-record.cgi
@@ -233,7 +233,7 @@ build_state_payload() {
     "limit": $video_limit,
     "min_free_mb": $video_min_free_mb,
     "mount": "$(json_escape "$vr_mount")"
-
+  },
   "mounts": $mounts_json_str,
   "messages": {
     "strftime_hint": "$(json_escape "$STR_SUPPORTS_STRFTIME")"


### PR DESCRIPTION
## Summary
- Fixes #1620: `/x/tool-record.cgi` has emitted invalid JSON since 51fd90e2b deleted the `"timelapse"` block from the response heredoc along with the `"},"` that closed `"video"`, leaving a stray blank line.
- Every response therefore fails to parse in the browser at a fixed `line 14 column 3` (the byte position varies only with the length of the interpolated hostname/path/mount strings - 294 in the original report, 280 in #1620, both the same document).
- One-line fix: restore the missing `},` closing the `"video"` object, matching what `tool-record.js` already expects (`data.video`, `data.mounts`, `data.messages`, `data.debug` as siblings).

## Test plan
- [x] `sh -n` on the CGI passes
- [x] Reproduced the broken heredoc's JSON output with representative placeholder values in Python and confirmed `json.loads()` fails exactly as reported; with the fix applied the same document parses cleanly
- [ ] Live device check on `/tool-record.html` (I don't have a camera running an affected build handy - happy to re-verify against one if useful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)