### PR TITLE
timps: timelapse playback + illuminator watchdog fix

### DIFF
--- a/package/timps/files/timps-irprobe
+++ b/package/timps/files/timps-irprobe
@@ -1,19 +1,31 @@
 #!/bin/sh
-# daynight.irprobe_cmd target: timps execs "<cmd> on|off" with no shell.
+# daynight.irprobe_cmd target: timps's silent day/night probe execs
+# "<cmd> on|off" (no shell) to blip the illuminator for one dark reading.
 #
 # The three names are light's infrared types, tried in that order because 940nm
 # is invisible and 850nm faintly red; `light` resolves the pin per camera from
 # thingino.json. Enumerating gpio.* instead would reach `white` and `flood`.
 #
-# "off" arms a detached watchdog first: the daemon has no failsafe, so if it
-# dies during the dark window the illuminator would stay off. A later "on" is
-# idempotent.
+# "off" arms a detached watchdog: the daemon has no failsafe, so if it dies
+# during the dark window the illuminator would stay off. It used to fire
+# unconditionally, which re-lit the illuminator ~60s into a night->day switch
+# that had already (correctly) turned it off - stamped and nonce-checked so
+# a newer "on"/"off" invalidates every older watchdog instead.
 for t in ir940 ir850 ir; do
 	if [ -n "$(light $t gpio 2>/dev/null)" ]; then
-		[ "$1" = off ] && (
-			sleep 60
-			light $t on
-		) >/dev/null 2>&1 &
+		stamp="/run/timps-irprobe.$t"
+		if [ "$1" = off ]; then
+			light $t off; rc=$?
+			if [ "$rc" -eq 0 ]; then
+				nonce=$$
+				echo "$nonce" >"$stamp"
+				( sleep 60
+				  [ "$(cat "$stamp" 2>/dev/null)" = "$nonce" ] && light $t on
+				) >/dev/null 2>&1 &
+			fi
+			exit "$rc"
+		fi
+		rm -f "$stamp"
 		exec light $t "$1"
 	fi
 done

--- a/package/timps/files/timps-irprobe
+++ b/package/timps/files/timps-irprobe
@@ -15,12 +15,14 @@ for t in ir940 ir850 ir; do
 	if [ -n "$(light $t gpio 2>/dev/null)" ]; then
 		stamp="/run/timps-irprobe.$t"
 		if [ "$1" = off ]; then
-			light $t off; rc=$?
+			light $t off
+			rc=$?
 			if [ "$rc" -eq 0 ]; then
 				nonce=$$
 				echo "$nonce" >"$stamp"
-				( sleep 60
-				  [ "$(cat "$stamp" 2>/dev/null)" = "$nonce" ] && light $t on
+				(
+					sleep 60
+					[ "$(cat "$stamp" 2>/dev/null)" = "$nonce" ] && light $t on
 				) >/dev/null 2>&1 &
 			fi
 			exit "$rc"

--- a/package/timps/files/timps.webui.json
+++ b/package/timps/files/timps.webui.json
@@ -103,6 +103,10 @@
           "href": "/tool-timelapse.html"
         },
         {
+          "label": "Timelapse Player",
+          "href": "/timelapse-player.html"
+        },
+        {
           "label": "Video Recorder",
           "href": "/tool-record.html"
         }
@@ -127,6 +131,7 @@
     "/x/timps-token.cgi",
     "/x/timps-imp.cgi",
     "/x/json-recordings.cgi",
+    "/x/json-timelapse.cgi",
     "/x/restart-prudynt.cgi",
     "/x/json-heartbeat.cgi",
     "/x/json-heartbeat-slow.cgi",
@@ -149,6 +154,7 @@
     "/recordings.html",
     "/tool-record.html",
     "/tool-timelapse.html",
+    "/timelapse-player.html",
     "/tool-sensor-data.html"
   ]
 }

--- a/package/timps/files/www/a/timelapse-player.js
+++ b/package/timps/files/www/a/timelapse-player.js
@@ -75,10 +75,7 @@
     return m[1] + "-" + m[2] + "-" + m[3] + " " + m[4] + ":" + m[5] + ":" + m[6];
   }
 
-  // Same stamp, as milliseconds since epoch - null when the name carries none
-  // (non-default template). Used to measure the REAL span a frame list
-  // covers, since frame count * interval_s silently assumes zero gaps and is
-  // wrong across a day-mode folder boundary or a missed capture.
+  // Same stamp as milliseconds since epoch, null if unparseable.
   function frameEpochMs(name) {
     var m = /(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})/.exec(name);
     if (!m) return null;
@@ -256,20 +253,15 @@
     updateMeta();
   }
 
-  // Coverage + the dialed-in compression - NOT a promise of actual playback
-  // duration. Real throughput is bounded by the camera's SD card / network
-  // (measured ~1 fps on a T23 over WiFi at a 10 fps setting), so "N fps for
-  // M frames finishes in M/N seconds" does not hold; only the span covered
-  // and the nominal ratio the fps control is set to are stated.
+  // Coverage + the dialed-in compression, not a promise of actual playback
+  // duration - real throughput is SD-card/network bound, not fps bound.
   function speedHint() {
     if (!frames.length) { hintEl.innerHTML = "&nbsp;"; return; }
     var bits = [frames.length + " frame" + (frames.length === 1 ? "" : "s")];
     if (frames.length === 1) {
       bits.push("nothing to animate - showing it as a still");
     } else {
-      // Real span from the first/last frame's OWN timestamps when the name
-      // carries one; falls back to the frame-count*interval_s estimate only
-      // when it doesn't (non-default name template - no better source then).
+      // First/last frame's own timestamps when parseable, else estimate.
       var t0 = frameEpochMs(frames[0].f), t1 = frameEpochMs(frames[frames.length - 1].f);
       var spanS = (t0 != null && t1 != null) ? (t1 - t0) / 1000
         : (intervalS > 0 ? (frames.length - 1) * intervalS : 0);

--- a/package/timps/files/www/a/timelapse-player.js
+++ b/package/timps/files/www/a/timelapse-player.js
@@ -1,0 +1,387 @@
+/* timelapse-player.js - play back the timps timelapse shots listed by
+ * /x/json-timelapse.cgi (a filesystem helper) as a client-side slideshow.
+ *
+ * There is no video here and deliberately so: the shots are individual JPEGs
+ * on the SD card, and muxing them into a clip would mean an encoder pass on a
+ * camera SoC. Playback is an <img> src swap driven by a timer, which costs the
+ * camera nothing beyond serving the files.
+ *
+ * Two things keep that workable for a folder holding thousands of frames:
+ *   - only the frame NAMES are fetched up front (one CGI call per folder, no
+ *     per-file stat on the camera), never the images;
+ *   - the images are pulled one at a time, with a LOOKAHEAD-frame prefetch
+ *     into the browser's HTTP cache (the CGI marks shots immutable, so the
+ *     src swap that follows is a cache hit, not a second trip to the SD card).
+ * Nothing is ever held in the DOM except the single <img> being shown.
+ *
+ * Dependency-free, same shape as a/recordings.js. */
+(function () {
+  "use strict";
+
+  if (!document.body || document.body.id !== "page-timelapse-player") return;
+
+  var CGI = "/x/json-timelapse.cgi";
+  var LOOKAHEAD = 3;       // frames prefetched ahead of the one on screen
+  var MIN_DELAY_MS = 20;   // ceiling of ~50 fps, whatever the select says
+
+  var $ = function (id) { return document.getElementById(id); };
+
+  var seqEl = $("tlp-seq");
+  var fpsEl = $("tlp-fps");
+  var loopEl = $("tlp-loop");
+  var frameEl = $("tlp-frame");
+  var stampEl = $("tlp-stamp");
+  var emptyEl = $("tlp-empty");
+  var counterEl = $("tlp-counter");
+  var scrubEl = $("tlp-scrub");
+  var hintEl = $("tlp-hint");
+  var infoEl = $("tlp-info");
+  var dlEl = $("tlp-dl");
+  var playBtn = $("tlp-play");
+  var playIcon = $("tlp-play-icon");
+  var reloadBtn = $("tlp-reload");
+
+  var seqs = [];      // [{seq, frames}] from the index
+  var curSeq = "";    // folder currently loaded ("." = the tree root)
+  var frames = [];    // [{f, s}] of curSeq, ascending
+  var idx = 0;        // frame on screen
+  var playing = false;
+  var timer = null;
+  var prefetched = {}; // idx -> Image, kept only as a sliding window
+  var intervalS = 0;   // timelapse.interval_s, for the "x real time" hint
+
+  function toast(type, msg, ms) {
+    if (typeof window.showAlert === "function") window.showAlert(type, msg, ms);
+    else console.log("[timelapse-player]", type + ":", msg);
+  }
+
+  // "20260912T093000.jpg" -> "2026-09-12 09:30:00". Falls back to the bare
+  // name when the shot was written with a non-default name template.
+  function stampOf(name) {
+    var m = /(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})/.exec(name);
+    if (!m) return name.replace(/\.jpe?g$/i, "");
+    return m[1] + "-" + m[2] + "-" + m[3] + " " + m[4] + ":" + m[5] + ":" + m[6];
+  }
+
+  // "20260912/09" -> "2026-09-12 09:00", "20260912" -> "2026-09-12",
+  // "." -> the tree root. Anything else is shown verbatim.
+  function seqLabel(seq) {
+    if (seq === ".") return "(timelapse folder root)";
+    var m = /^(\d{4})(\d{2})(\d{2})(?:\/(\d{2}))?$/.exec(seq);
+    if (!m) return seq;
+    var d = m[1] + "-" + m[2] + "-" + m[3];
+    return m[4] ? d + " " + m[4] + ":00" : d;
+  }
+
+  // day bucket for the <optgroup>, so a week of hour folders reads as seven
+  // groups of 24 rather than 168 flat rows
+  function dayOf(seq) {
+    var m = /^(\d{4})(\d{2})(\d{2})(?:\/|$)/.exec(seq);
+    return m ? m[1] + "-" + m[2] + "-" + m[3] : "Other";
+  }
+
+  function relPath(i) {
+    var f = frames[i] && frames[i].f;
+    if (!f) return "";
+    return curSeq === "." ? f : curSeq + "/" + f;
+  }
+
+  function frameUrl(i) {
+    var rel = relPath(i);
+    return rel ? CGI + "?file=" + encodeURIComponent(rel) : "";
+  }
+
+  function fps() {
+    var v = parseFloat(fpsEl.value);
+    return isFinite(v) && v > 0 ? v : 10;
+  }
+
+  function delayMs() {
+    return Math.max(MIN_DELAY_MS, Math.round(1000 / fps()));
+  }
+
+  // Warm the browser cache for the next few frames. References are dropped
+  // as the window slides, so at most LOOKAHEAD decoded images are held alive;
+  // the cached HTTP responses outlive them, which is the point.
+  function prefetch(from) {
+    if (!frames.length) return;
+    var keep = {}, i, k;
+    for (k = 0; k < LOOKAHEAD; k++) {
+      i = from + k;
+      if (i >= frames.length) {
+        if (!loopEl.checked) break;
+        i = i % frames.length;
+      }
+      keep[i] = true;
+      if (!prefetched[i]) {
+        var im = new Image();
+        im.src = frameUrl(i);
+        prefetched[i] = im;
+      }
+    }
+    Object.keys(prefetched).forEach(function (key) {
+      if (!keep[key]) delete prefetched[key];
+    });
+  }
+
+  function updateMeta() {
+    var n = frames.length;
+    counterEl.textContent = (n ? idx + 1 : 0) + " / " + n;
+    scrubEl.value = String(idx);
+    if (n) {
+      stampEl.hidden = false;
+      stampEl.textContent = stampOf(frames[idx].f);
+      dlEl.href = frameUrl(idx);
+      dlEl.setAttribute("download", relPath(idx).replace(/\//g, "_"));
+      dlEl.classList.remove("disabled");
+    } else {
+      stampEl.hidden = true;
+      dlEl.removeAttribute("href");
+      dlEl.classList.add("disabled");
+    }
+  }
+
+  // Show frame i and call done() once its load settles (either way). Pacing
+  // playback off the settle rather than off a bare interval keeps the frame
+  // rate honest on a slow link instead of queueing up requests.
+  function showFrame(i, done) {
+    if (!frames.length) { if (done) done(); return; }
+    var n = frames.length;
+    idx = ((i % n) + n) % n;
+    var url = frameUrl(idx);
+    var settled = false;
+    function settle() {
+      if (settled) return;
+      settled = true;
+      if (done) done();
+    }
+    frameEl.onload = settle;
+    frameEl.onerror = settle;
+    if (frameEl.getAttribute("src") === url) {
+      // same URL (single-frame folder, or a re-show): no load event would
+      // fire, so settle on our own instead of stalling the loop
+      setTimeout(settle, 0);
+    } else {
+      frameEl.src = url;
+      frameEl.hidden = false;
+      // a cache hit can already be complete here and some browsers then fire
+      // no further load event on this element
+      if (frameEl.complete) setTimeout(settle, 0);
+    }
+    updateMeta();
+    prefetch(idx + 1);
+  }
+
+  function setPlaying(on) {
+    playing = !!on && frames.length > 1;
+    if (timer) { clearTimeout(timer); timer = null; }
+    playIcon.className = playing ? "bi bi-pause-fill" : "bi bi-play-fill";
+    playBtn.title = playing ? "Pause (Space)" : "Play (Space)";
+    if (playing) tick();
+  }
+
+  function tick() {
+    if (!playing) return;
+    var t0 = Date.now();
+    var next = idx + 1;
+    if (next >= frames.length) {
+      if (!loopEl.checked) { setPlaying(false); return; }
+      next = 0;
+    }
+    showFrame(next, function () {
+      if (!playing) return;
+      timer = setTimeout(tick, Math.max(0, delayMs() - (Date.now() - t0)));
+    });
+  }
+
+  function setEmpty(msg) {
+    setPlaying(false);
+    frames = [];
+    prefetched = {};
+    idx = 0;
+    frameEl.hidden = true;
+    frameEl.removeAttribute("src");
+    emptyEl.hidden = false;
+    emptyEl.textContent = msg;
+    scrubEl.max = "0";
+    scrubEl.disabled = true;
+    playBtn.disabled = true;
+    updateMeta();
+  }
+
+  // How much faster than life this plays: one frame is interval_s of real
+  // time, so N fps compresses N*interval_s seconds into one second.
+  function speedHint() {
+    if (!frames.length) { hintEl.innerHTML = "&nbsp;"; return; }
+    var bits = [frames.length + " frame" + (frames.length === 1 ? "" : "s")];
+    if (frames.length === 1) {
+      bits.push("nothing to animate - showing it as a still");
+    } else if (intervalS > 0) {
+      var factor = Math.round(fps() * intervalS);
+      var span = (frames.length - 1) * intervalS;
+      bits.push("~" + factor + "x real time");
+      bits.push("covering ~" + Math.round(span / 60) + " min in " +
+        Math.round((frames.length - 1) / fps()) + " s");
+    }
+    hintEl.textContent = bits.join(" · ");
+  }
+
+  function loadSeq(seq) {
+    setPlaying(false);
+    curSeq = seq;
+    prefetched = {};
+    if (!seq) { setEmpty("Select a sequence."); return; }
+    emptyEl.hidden = false;
+    emptyEl.textContent = "Loading frames…";
+    frameEl.hidden = true;
+    fetch(CGI + "?seq=" + encodeURIComponent(seq), { cache: "no-store" })
+      .then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
+      .then(function (data) {
+        // sort by name rather than trusting the listing order: the default
+        // template makes the name sort BE the chronological order
+        frames = (data.frames || []).slice().sort(function (a, b) {
+          return a.f < b.f ? -1 : a.f > b.f ? 1 : 0;
+        });
+        if (!frames.length) {
+          setEmpty("This folder holds no shots (it may have just been pruned). Try Reload.");
+          return;
+        }
+        idx = 0;
+        scrubEl.max = String(frames.length - 1);
+        scrubEl.disabled = frames.length < 2;
+        playBtn.disabled = frames.length < 2;
+        emptyEl.hidden = true;
+        speedHint();
+        showFrame(0);
+        if (window.location.hash !== "#seq=" + seq)
+          window.history.replaceState(null, "", "#seq=" + seq);
+      })
+      .catch(function (e) {
+        setEmpty("Failed to list frames: " + (e.message || e));
+      });
+  }
+
+  function renderSeqs() {
+    seqEl.innerHTML = "";
+    var group = null, groupName = null;
+    // newest first in the picker (the index comes back ascending): the shots
+    // someone opens this page for are almost always the most recent ones
+    seqs.slice().reverse().forEach(function (s) {
+      var day = dayOf(s.seq);
+      if (day !== groupName) {
+        groupName = day;
+        group = document.createElement("optgroup");
+        group.label = day;
+        seqEl.appendChild(group);
+      }
+      var opt = document.createElement("option");
+      opt.value = s.seq;
+      // textContent, not innerHTML: folder names come off the SD card and
+      // must never be interpreted as HTML
+      opt.textContent = seqLabel(s.seq) + "  (" + s.frames +
+        " shot" + (s.frames === 1 ? "" : "s") + ")";
+      group.appendChild(opt);
+    });
+  }
+
+  function load() {
+    reloadBtn.disabled = true;
+    emptyEl.hidden = false;
+    emptyEl.textContent = "Scanning the timelapse folder…";
+    fetch(CGI, { cache: "no-store" })
+      .then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
+      .then(function (data) {
+        seqs = data.seqs || [];
+        if (infoEl) infoEl.textContent = data.base || "";
+        if (!data.exists) {
+          seqEl.innerHTML = '<option value="">No timelapse folder yet</option>';
+          seqEl.disabled = true;
+          setEmpty("Nothing recorded yet - " + (data.base || "the timelapse folder") +
+            " does not exist. Enable the timelapse recorder in Settings and give it " +
+            "one interval to write the first shot.");
+          hintEl.innerHTML = "&nbsp;";
+          return;
+        }
+        if (!seqs.length) {
+          seqEl.innerHTML = '<option value="">No shots yet</option>';
+          seqEl.disabled = true;
+          setEmpty("The timelapse folder exists but holds no shots yet. " +
+            "If the recorder was just enabled, wait one interval and hit Reload.");
+          hintEl.innerHTML = "&nbsp;";
+          return;
+        }
+        seqEl.disabled = false;
+        renderSeqs();
+        // deep link (#seq=20260912/09) wins, else the newest folder
+        var want = /^#seq=(.+)$/.exec(window.location.hash);
+        var pick = want ? decodeURIComponent(want[1]) : "";
+        var known = seqs.some(function (s) { return s.seq === pick; });
+        if (!known) pick = seqs[seqs.length - 1].seq;
+        seqEl.value = pick;
+        loadSeq(pick);
+      })
+      .catch(function (e) {
+        setEmpty("Failed to scan the timelapse folder: " + (e.message || e));
+        toast("danger", "Timelapse listing failed: " + (e.message || e));
+      })
+      .finally(function () { reloadBtn.disabled = false; });
+
+    // interval_s drives the "x real time" hint; free_mb is a nice extra.
+    // Best effort only - the player works without timps answering at all.
+    if (window.timpsApi) {
+      window.timpsApi.get().then(function (j) {
+        var tl = j && j.timelapse;
+        if (!tl) return;
+        intervalS = parseInt(tl.interval_s, 10) || 0;
+        if (infoEl) {
+          var bits = [];
+          if (intervalS > 0) bits.push("every " + intervalS + "s");
+          bits.push(tl.enabled ? "recording" : "recorder off");
+          if (tl.free_mb != null && tl.free_mb >= 0) bits.push(tl.free_mb + " MB free");
+          infoEl.textContent = bits.join(" · ");
+        }
+        speedHint();
+      }).catch(function () { /* hint stays generic */ });
+    }
+  }
+
+  seqEl.addEventListener("change", function () { loadSeq(seqEl.value); });
+  fpsEl.addEventListener("change", speedHint);
+  playBtn.addEventListener("click", function () { setPlaying(!playing); });
+  $("tlp-first").addEventListener("click", function () { setPlaying(false); showFrame(0); });
+  $("tlp-last").addEventListener("click", function () { setPlaying(false); showFrame(frames.length - 1); });
+  $("tlp-prev").addEventListener("click", function () { setPlaying(false); showFrame(idx - 1); });
+  $("tlp-next").addEventListener("click", function () { setPlaying(false); showFrame(idx + 1); });
+  reloadBtn.addEventListener("click", load);
+  // scrubbing jumps without stopping: the loop picks up from the new index
+  scrubEl.addEventListener("input", function () {
+    showFrame(parseInt(scrubEl.value, 10) || 0);
+  });
+
+  document.addEventListener("keydown", function (ev) {
+    var t = ev.target;
+    // never swallow keys aimed at a control (the fps/sequence selects, the
+    // scrub slider) or at any other input
+    if (t && /^(INPUT|SELECT|TEXTAREA)$/.test(t.tagName)) return;
+    if (ev.ctrlKey || ev.altKey || ev.metaKey) return;
+    switch (ev.key) {
+      case " ": setPlaying(!playing); break;
+      case "ArrowLeft": setPlaying(false); showFrame(idx - 1); break;
+      case "ArrowRight": setPlaying(false); showFrame(idx + 1); break;
+      case "Home": setPlaying(false); showFrame(0); break;
+      case "End": setPlaying(false); showFrame(frames.length - 1); break;
+      default: return;
+    }
+    ev.preventDefault();
+  });
+
+  // a backgrounded tab throttles timers to ~1/s, which would silently turn
+  // playback into a crawl and keep hammering the camera - stop instead
+  document.addEventListener("visibilitychange", function () {
+    if (document.hidden && playing) setPlaying(false);
+  });
+
+  if (document.readyState === "loading")
+    document.addEventListener("DOMContentLoaded", load, { once: true });
+  else load();
+})();

--- a/package/timps/files/www/a/timelapse-player.js
+++ b/package/timps/files/www/a/timelapse-player.js
@@ -75,6 +75,16 @@
     return m[1] + "-" + m[2] + "-" + m[3] + " " + m[4] + ":" + m[5] + ":" + m[6];
   }
 
+  // Same stamp, as milliseconds since epoch - null when the name carries none
+  // (non-default template). Used to measure the REAL span a frame list
+  // covers, since frame count * interval_s silently assumes zero gaps and is
+  // wrong across a day-mode folder boundary or a missed capture.
+  function frameEpochMs(name) {
+    var m = /(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})/.exec(name);
+    if (!m) return null;
+    return Date.UTC(+m[1], +m[2] - 1, +m[3], +m[4], +m[5], +m[6]);
+  }
+
   // "20260912/09" -> "2026-09-12 09:00", "20260912" -> "2026-09-12",
   // "." -> the tree root. Anything else is shown verbatim.
   function seqLabel(seq) {
@@ -246,19 +256,26 @@
     updateMeta();
   }
 
-  // How much faster than life this plays: one frame is interval_s of real
-  // time, so N fps compresses N*interval_s seconds into one second.
+  // Coverage + the dialed-in compression - NOT a promise of actual playback
+  // duration. Real throughput is bounded by the camera's SD card / network
+  // (measured ~1 fps on a T23 over WiFi at a 10 fps setting), so "N fps for
+  // M frames finishes in M/N seconds" does not hold; only the span covered
+  // and the nominal ratio the fps control is set to are stated.
   function speedHint() {
     if (!frames.length) { hintEl.innerHTML = "&nbsp;"; return; }
     var bits = [frames.length + " frame" + (frames.length === 1 ? "" : "s")];
     if (frames.length === 1) {
       bits.push("nothing to animate - showing it as a still");
-    } else if (intervalS > 0) {
-      var factor = Math.round(fps() * intervalS);
-      var span = (frames.length - 1) * intervalS;
-      bits.push("~" + factor + "x real time");
-      bits.push("covering ~" + Math.round(span / 60) + " min in " +
-        Math.round((frames.length - 1) / fps()) + " s");
+    } else {
+      // Real span from the first/last frame's OWN timestamps when the name
+      // carries one; falls back to the frame-count*interval_s estimate only
+      // when it doesn't (non-default name template - no better source then).
+      var t0 = frameEpochMs(frames[0].f), t1 = frameEpochMs(frames[frames.length - 1].f);
+      var spanS = (t0 != null && t1 != null) ? (t1 - t0) / 1000
+        : (intervalS > 0 ? (frames.length - 1) * intervalS : 0);
+      if (spanS > 0) bits.push("covering ~" + Math.round(spanS / 60) + " min of footage");
+      if (intervalS > 0)
+        bits.push("target ~" + Math.round(fps() * intervalS) + "x real time at " + fps() + " fps");
     }
     if (hintExtra) bits.push(hintExtra);
     hintEl.textContent = bits.join(" · ");

--- a/package/timps/files/www/a/timelapse-player.js
+++ b/package/timps/files/www/a/timelapse-player.js
@@ -23,6 +23,16 @@
   var CGI = "/x/json-timelapse.cgi";
   var LOOKAHEAD = 3;       // frames prefetched ahead of the one on screen
   var MIN_DELAY_MS = 20;   // ceiling of ~50 fps, whatever the select says
+  // Whole-day playback stitches one day's hour folders together by asking the
+  // per-folder endpoint for each of them. Kept to the same in-flight budget as
+  // the JPEG look-ahead: every call forks a shell and an `ls` on the camera,
+  // and 24 of those at once for a week-old tree is a needless spike. Three
+  // keeps the wall time at ~8 rounds of a cheap listing.
+  var DAY_CONCURRENCY = 3;
+  // marks a picker row / deep link as "the whole day", not a folder rel. A
+  // bare YYYYMMDD is itself a legal folder rel (a name template may write one
+  // folder per day), so day mode needs a namespace of its own.
+  var DAY_PREFIX = "day:";
 
   var $ = function (id) { return document.getElementById(id); };
 
@@ -43,12 +53,14 @@
 
   var seqs = [];      // [{seq, frames}] from the index
   var curSeq = "";    // folder currently loaded ("." = the tree root)
-  var frames = [];    // [{f, s}] of curSeq, ascending
+  var frames = [];    // [{f, s, d}] ascending; d is the folder each frame is in
   var idx = 0;        // frame on screen
   var playing = false;
   var timer = null;
   var prefetched = {}; // idx -> Image, kept only as a sliding window
   var intervalS = 0;   // timelapse.interval_s, for the "x real time" hint
+  var hintExtra = "";  // day-mode note appended to the speed hint (skipped folders)
+  var loadGen = 0;     // bumped per pick, so a slow load can't land after a newer one
 
   function toast(type, msg, ms) {
     if (typeof window.showAlert === "function") window.showAlert(type, msg, ms);
@@ -80,10 +92,35 @@
     return m ? m[1] + "-" + m[2] + "-" + m[3] : "Other";
   }
 
+  // raw day bucket ("20260912/09" -> "20260912"), "" for a folder whose name
+  // the default template did not produce - those get no whole-day row.
+  function dayKeyOf(seq) {
+    var m = /^(\d{8})(?:\/|$)/.exec(seq);
+    return m ? m[1] : "";
+  }
+
+  // every indexed folder of one day, ascending (= chronological under the
+  // default template). This is the same index the <optgroup>s are built from.
+  function daySeqs(key) {
+    return seqs.filter(function (s) { return dayKeyOf(s.seq) === key; })
+      .map(function (s) { return s.seq; })
+      .sort();
+  }
+
+  function dayShots(key) {
+    return seqs.reduce(function (n, s) {
+      return dayKeyOf(s.seq) === key ? n + (s.frames || 0) : n;
+    }, 0);
+  }
+
+  // Each frame carries the folder it was listed from, so a merged whole-day
+  // list resolves every frame against ITS OWN hour rather than one shared
+  // prefix. Single-folder mode tags them all with that one folder.
   function relPath(i) {
-    var f = frames[i] && frames[i].f;
-    if (!f) return "";
-    return curSeq === "." ? f : curSeq + "/" + f;
+    var fr = frames[i];
+    if (!fr || !fr.f) return "";
+    var d = fr.d == null ? curSeq : fr.d;
+    return (!d || d === ".") ? fr.f : d + "/" + fr.f;
   }
 
   function frameUrl(i) {
@@ -223,42 +260,135 @@
       bits.push("covering ~" + Math.round(span / 60) + " min in " +
         Math.round((frames.length - 1) / fps()) + " s");
     }
+    if (hintExtra) bits.push(hintExtra);
     hintEl.textContent = bits.join(" · ");
   }
 
-  function loadSeq(seq) {
-    setPlaying(false);
-    curSeq = seq;
-    prefetched = {};
-    if (!seq) { setEmpty("Select a sequence."); return; }
-    emptyEl.hidden = false;
-    emptyEl.textContent = "Loading frames…";
-    frameEl.hidden = true;
-    fetch(CGI + "?seq=" + encodeURIComponent(seq), { cache: "no-store" })
+  // One folder's frames, names only, tagged with the folder they came from.
+  // The whole-day loader calls this once per hour folder - the endpoint and
+  // its response are exactly what single-folder playback has always used.
+  function fetchSeq(seq) {
+    return fetch(CGI + "?seq=" + encodeURIComponent(seq), { cache: "no-store" })
       .then(function (r) { if (!r.ok) throw new Error("HTTP " + r.status); return r.json(); })
       .then(function (data) {
         // sort by name rather than trusting the listing order: the default
         // template makes the name sort BE the chronological order
-        frames = (data.frames || []).slice().sort(function (a, b) {
+        return (data.frames || []).slice().sort(function (a, b) {
           return a.f < b.f ? -1 : a.f > b.f ? 1 : 0;
+        }).map(function (fr) {
+          return { f: fr.f, s: fr.s, d: seq };
         });
-        if (!frames.length) {
-          setEmpty("This folder holds no shots (it may have just been pruned). Try Reload.");
-          return;
-        }
-        idx = 0;
-        scrubEl.max = String(frames.length - 1);
-        scrubEl.disabled = frames.length < 2;
-        playBtn.disabled = frames.length < 2;
-        emptyEl.hidden = true;
-        speedHint();
-        showFrame(0);
-        if (window.location.hash !== "#seq=" + seq)
-          window.history.replaceState(null, "", "#seq=" + seq);
+      });
+  }
+
+  // The single hand-off into the playback state machine: both loaders end
+  // here, and nothing past this point knows whether the list came from one
+  // folder or from a day's worth of them.
+  function applyFrames(list, emptyMsg, hash) {
+    frames = list;
+    if (!frames.length) { setEmpty(emptyMsg); return; }
+    idx = 0;
+    scrubEl.max = String(frames.length - 1);
+    scrubEl.disabled = frames.length < 2;
+    playBtn.disabled = frames.length < 2;
+    emptyEl.hidden = true;
+    speedHint();
+    showFrame(0);
+    if (window.location.hash !== hash)
+      window.history.replaceState(null, "", hash);
+  }
+
+  function loadSeq(seq) {
+    setPlaying(false);
+    prefetched = {};
+    hintExtra = "";
+    curSeq = seq;
+    var gen = ++loadGen;
+    if (!seq) { setEmpty("Select a sequence."); return; }
+    if (seq.indexOf(DAY_PREFIX) === 0) {
+      loadDay(seq.slice(DAY_PREFIX.length), gen);
+      return;
+    }
+    emptyEl.hidden = false;
+    emptyEl.textContent = "Loading frames…";
+    frameEl.hidden = true;
+    fetchSeq(seq)
+      .then(function (list) {
+        if (gen !== loadGen) return;
+        applyFrames(list,
+          "This folder holds no shots (it may have just been pruned). Try Reload.",
+          "#seq=" + seq);
       })
       .catch(function (e) {
+        if (gen !== loadGen) return;
         setEmpty("Failed to list frames: " + (e.message || e));
       });
+  }
+
+  // Whole day: the day's hour folders, fetched through the SAME per-folder
+  // endpoint and concatenated in hour order. No server-side recursion, and
+  // one unreadable hour costs that hour only - the rest of the day still
+  // plays, with the gap named in the hint and a toast.
+  function loadDay(key, gen) {
+    var list = daySeqs(key);
+    if (!list.length) {
+      setEmpty("No folders left for that day - they may have just been pruned. Try Reload.");
+      return;
+    }
+    curSeq = "";
+    frameEl.hidden = true;
+    emptyEl.hidden = false;
+
+    var parts = new Array(list.length);  // by slot, so hour order survives
+    var failed = [];
+    var done = 0, next = 0, inflight = 0;
+
+    function progress() {
+      emptyEl.textContent = "Loading " + seqLabel(key) + " - folder " +
+        done + " / " + list.length + "…";
+    }
+
+    function finish() {
+      var all = [], i;
+      for (i = 0; i < list.length; i++)
+        if (parts[i] && parts[i].length) all = all.concat(parts[i]);
+      var ok = list.length - failed.length;
+      hintExtra = "whole day, " + ok + " folder" + (ok === 1 ? "" : "s");
+      if (failed.length) {
+        failed.sort();
+        var note = "skipped " + failed.length + " unreadable folder" +
+          (failed.length === 1 ? "" : "s") + " (" + failed.join(", ") + ")";
+        hintExtra += " · " + note;
+        toast("warning", "Whole day: " + note, 6000);
+      }
+      applyFrames(all, failed.length === list.length
+        ? "None of that day's folders could be listed. Try Reload."
+        : "That day's folders hold no shots any more. Try Reload.",
+        "#day=" + key);
+    }
+
+    function pump() {
+      while (inflight < DAY_CONCURRENCY && next < list.length) {
+        (function (slot, seq) {
+          inflight++;
+          fetchSeq(seq)
+            .then(function (fr) { parts[slot] = fr; })
+            .catch(function () { parts[slot] = []; failed.push(seq); })
+            .then(function () {
+              inflight--;
+              done++;
+              if (gen !== loadGen) return;  // a newer pick owns the player now
+              progress();
+              if (done === list.length) finish();
+              else pump();
+            });
+        })(next, list[next]);
+        next++;
+      }
+    }
+
+    progress();
+    pump();
   }
 
   function renderSeqs() {
@@ -273,6 +403,18 @@
         group = document.createElement("optgroup");
         group.label = day;
         seqEl.appendChild(group);
+        // First row of the group plays the day end to end. Offered only when
+        // there is more than one folder to stitch - with a single folder the
+        // plain row below already IS the whole day.
+        var key = dayKeyOf(s.seq);
+        var members = key ? daySeqs(key) : [];
+        if (members.length > 1) {
+          var all = document.createElement("option");
+          all.value = DAY_PREFIX + key;
+          all.textContent = "Whole day  (" + members.length + " folders, " +
+            dayShots(key) + " shots)";
+          group.appendChild(all);
+        }
       }
       var opt = document.createElement("option");
       opt.value = s.seq;
@@ -312,11 +454,25 @@
         }
         seqEl.disabled = false;
         renderSeqs();
-        // deep link (#seq=20260912/09) wins, else the newest folder
-        var want = /^#seq=(.+)$/.exec(window.location.hash);
-        var pick = want ? decodeURIComponent(want[1]) : "";
-        var known = seqs.some(function (s) { return s.seq === pick; });
-        if (!known) pick = seqs[seqs.length - 1].seq;
+        // A deep link wins over the newest folder: #seq=20260912/09 for one
+        // folder, #day=20260912 for the whole day. Two keys rather than
+        // "#seq= with no /HH", because a bare YYYYMMDD can itself be a real
+        // folder rel and the two would then be indistinguishable.
+        var pick = "";
+        var wantDay = /^#day=(.+)$/.exec(window.location.hash);
+        var wantSeq = /^#seq=(.+)$/.exec(window.location.hash);
+        if (wantDay) {
+          var key = decodeURIComponent(wantDay[1]);
+          var members = daySeqs(key);
+          // a day pruned down to one folder has no whole-day row any more -
+          // resume on the folder that is left rather than on the newest day
+          if (members.length > 1) pick = DAY_PREFIX + key;
+          else if (members.length === 1) pick = members[0];
+        } else if (wantSeq) {
+          var seq = decodeURIComponent(wantSeq[1]);
+          if (seqs.some(function (s) { return s.seq === seq; })) pick = seq;
+        }
+        if (!pick) pick = seqs[seqs.length - 1].seq;
         seqEl.value = pick;
         loadSeq(pick);
       })

--- a/package/timps/files/www/timelapse-player.html
+++ b/package/timps/files/www/timelapse-player.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<!-- thingino · Timelapse Player (timps JPEG shots, via /x/json-timelapse.cgi) -->
+<html lang="en" data-bs-theme="dark">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>thingino · Timelapse Player</title>
+  <script src="/a/theme-init.js"></script>
+  <link rel="icon" type="image/svg+xml" href="/a/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;500;600;700&display=swap">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css"
+    integrity="sha384-sRIl4kxILFvY47J16cr9ZwB07vP4J8+LH7qKQnuqkuIAvNWLzeN8tE5YBujZqJLB" crossorigin="anonymous">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.13.1/font/bootstrap-icons.min.css">
+  <link rel="stylesheet" href="/a/main.css">
+  <style>
+    /* Fixed-aspect stage: the frame count can change under us and the shots
+       themselves may be any resolution, so the stage never resizes - the
+       image is letterboxed inside it instead. Without this the whole control
+       row jumps on the first frame of every sequence. */
+    #tlp-stage {
+      position: relative;
+      width: 100%;
+      aspect-ratio: 16 / 9;
+      background: #000;
+      border-radius: .375rem;
+      overflow: hidden;
+    }
+
+    #tlp-frame {
+      width: 100%;
+      height: 100%;
+      object-fit: contain;
+      display: block;
+    }
+
+    #tlp-stamp {
+      position: absolute;
+      left: .5rem;
+      bottom: .5rem;
+      padding: .1rem .45rem;
+      border-radius: .25rem;
+      background: rgba(0, 0, 0, .55);
+      color: #fff;
+      font-variant-numeric: tabular-nums;
+      font-size: .85rem;
+      pointer-events: none;
+    }
+
+    #tlp-empty {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      padding: 1rem;
+      color: #adb5bd;
+    }
+
+    #tlp-counter {
+      font-variant-numeric: tabular-nums;
+      white-space: nowrap;
+    }
+  </style>
+</head>
+
+<body id="page-timelapse-player">
+<nav data-app-nav></nav>
+
+<main class="pb-4">
+  <div class="container" style="min-height:80vh">
+    <div data-app-controls></div>
+
+    <div class="d-flex align-items-center flex-wrap gap-2">
+      <h3 class="mb-0">Timelapse Player</h3>
+      <button type="button" id="tlp-reload" class="btn btn-outline-secondary btn-sm" title="Rescan the timelapse folder">
+        <i class="bi bi-arrow-clockwise"></i>
+      </button>
+      <span class="text-secondary small" id="tlp-info"></span>
+      <a href="/tool-timelapse.html" class="btn btn-outline-secondary btn-sm ms-auto">
+        <i class="bi bi-sliders me-1"></i> Settings
+      </a>
+    </div>
+
+    <div class="card mt-2">
+      <div class="card-body">
+        <div class="row g-2 align-items-end mb-2">
+          <div class="col-12 col-md">
+            <label for="tlp-seq" class="form-label mb-1">Sequence</label>
+            <select class="form-select" id="tlp-seq">
+              <option value="">Loading…</option>
+            </select>
+          </div>
+          <div class="col-6 col-md-auto">
+            <label for="tlp-fps" class="form-label mb-1">Speed</label>
+            <select class="form-select" id="tlp-fps">
+              <option value="0.5">0.5 fps</option>
+              <option value="1">1 fps</option>
+              <option value="2">2 fps</option>
+              <option value="5">5 fps</option>
+              <option value="10" selected>10 fps</option>
+              <option value="15">15 fps</option>
+              <option value="25">25 fps</option>
+            </select>
+          </div>
+          <div class="col-6 col-md-auto">
+            <div class="form-check form-switch mb-2">
+              <input class="form-check-input" type="checkbox" role="switch" id="tlp-loop" checked>
+              <label class="form-check-label" for="tlp-loop">Loop</label>
+            </div>
+          </div>
+        </div>
+
+        <div id="tlp-stage">
+          <!-- alt stays empty: the frame is decorative here, the timestamp
+               overlay and the counter carry the information -->
+          <img id="tlp-frame" alt="" hidden>
+          <div id="tlp-stamp" hidden></div>
+          <div id="tlp-empty">Loading…</div>
+        </div>
+
+        <div class="d-flex align-items-center flex-wrap gap-2 mt-2">
+          <div class="btn-group" role="group" aria-label="Playback">
+            <button type="button" class="btn btn-outline-secondary" id="tlp-first" title="First frame (Home)">
+              <i class="bi bi-skip-backward-fill"></i>
+            </button>
+            <button type="button" class="btn btn-outline-secondary" id="tlp-prev" title="Previous frame (Left arrow)">
+              <i class="bi bi-caret-left-fill"></i>
+            </button>
+            <button type="button" class="btn btn-primary" id="tlp-play" title="Play / pause (Space)">
+              <i class="bi bi-play-fill" id="tlp-play-icon"></i>
+            </button>
+            <button type="button" class="btn btn-outline-secondary" id="tlp-next" title="Next frame (Right arrow)">
+              <i class="bi bi-caret-right-fill"></i>
+            </button>
+            <button type="button" class="btn btn-outline-secondary" id="tlp-last" title="Last frame (End)">
+              <i class="bi bi-skip-forward-fill"></i>
+            </button>
+          </div>
+          <span class="text-secondary small" id="tlp-counter">0 / 0</span>
+          <input type="range" class="form-range flex-grow-1" id="tlp-scrub" min="0" max="0" value="0" step="1"
+            style="min-width:10rem" aria-label="Seek to frame">
+          <a class="btn btn-outline-secondary btn-sm" id="tlp-dl" href="#" download title="Download this frame">
+            <i class="bi bi-download"></i>
+          </a>
+        </div>
+
+        <p class="small text-secondary mb-0 mt-2" id="tlp-hint">&nbsp;</p>
+      </div>
+    </div>
+  </div>
+</main>
+
+<footer data-app-footer></footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-FKyoEForCGlyvwx9Hj09JcYn3nv7wiPVlz7YYwJrWVcXK/BmnVDxM+D2scQbITxI" crossorigin="anonymous"></script>
+<script src="/a/main.js"></script>
+<script src="/a/runtime-config.js"></script>
+<script src="/a/control-bar.js"></script>
+<script src="/a/navigation.js"></script>
+<script src="/a/footer.js"></script>
+<script src="/a/timps-api.js"></script>
+<script src="/a/timelapse-player.js"></script>
+</body>
+</html>

--- a/package/timps/files/www/tool-timelapse.html
+++ b/package/timps/files/www/tool-timelapse.html
@@ -27,7 +27,10 @@
         <div class="card mb-3">
           <div class="card-header">
             <h2 class="card-title">Timelapse Recorder</h2>
-            <small>timps saves a JPEG snapshot every interval. Settings are saved live into <code>/etc/timps.conf</code>; shots go under <code>&lt;dir&gt;/&lt;hostname&gt;/timelapses/</code>. The control-bar timelapse button toggles the same switch.</small>
+            <small>timps saves a JPEG snapshot every interval. Settings are saved live into <code>/etc/timps.conf</code>; shots go under <code>&lt;dir&gt;/&lt;hostname&gt;/timelapses/</code>. The control-bar timelapse button toggles the same switch. Watch what has been captured in the <a href="/timelapse-player.html" class="link-light text-decoration-none">Timelapse Player</a>.</small>
+            <a href="/timelapse-player.html" class="btn btn-outline-primary" id="tl-play" title="Play back captured shots">
+              <i class="bi bi-play-btn"></i> Play back
+            </a>
             <button type="button" class="btn btn-outline-secondary" id="tl-reload" title="Reload values from camera">
               <i class="bi bi-arrow-clockwise"></i> Reload
             </button>

--- a/package/timps/files/www/x/json-timelapse.cgi
+++ b/package/timps/files/www/x/json-timelapse.cgi
@@ -1,5 +1,7 @@
 #!/bin/sh
-# shellcheck disable=SC1091,SC2086
+# shellcheck disable=SC1091,SC2086,SC2012
+# SC2012: `ls` here is deliberate, not a `find` oversight - see the frame
+# listing below for why (one fork for the whole folder, no per-file stat).
 # json-timelapse.cgi - browse/serve the timps timelapse shots. A FILESYSTEM
 # helper next to json-recordings.cgi (not a streamer bridge):
 #   GET                -> JSON index of shot FOLDERS under <timelapse.dir>/<host>/timelapses

--- a/package/timps/files/www/x/json-timelapse.cgi
+++ b/package/timps/files/www/x/json-timelapse.cgi
@@ -1,0 +1,156 @@
+#!/bin/sh
+# shellcheck disable=SC1091,SC2086
+# json-timelapse.cgi - browse/serve the timps timelapse shots. A FILESYSTEM
+# helper next to json-recordings.cgi (not a streamer bridge):
+#   GET                -> JSON index of shot FOLDERS under <timelapse.dir>/<host>/timelapses
+#   GET ?seq=<rel>     -> JSON frame list for ONE folder ("." = the tree root)
+#   GET ?file=<rel>    -> serves that one shot as image/jpeg
+# Auth-protected; seq/file are guarded against path traversal exactly the way
+# json-recordings.cgi guards its file/del (safe() + within_base()).
+#
+# Why an index of FOLDERS and not of frames: the default name template
+# (%Y%m%d/%H/%Y%m%dT%H%M%S) buckets shots into one folder per hour, so at a
+# 10 s interval a 7-day tree holds ~60k JPEGs but only ~170 folders. Walking
+# every file to build a global index would be the expensive part; the index
+# therefore stats no files at all (the per-folder frame count falls out of a
+# shell glob, no fork) and the player asks for one folder's frames at a time.
+
+. /var/www/x/auth.sh
+require_auth
+
+CONF=/etc/timps.conf
+DIR=$(sed -n 's/^[[:space:]]*timelapse\.dir[[:space:]]*=[[:space:]]*"\{0,1\}\([^"#]*\).*/\1/p' "$CONF" 2>/dev/null | head -n1 | tr -d ' \t')
+[ -z "$DIR" ] && DIR=/mnt/mmcblk0p1
+BASE="$DIR/$(hostname)/timelapses"
+# Resolved once, used by within_base() below - if BASE itself doesn't exist
+# yet (timelapse never enabled), fall back to the literal path so the index
+# branch still reports an empty tree instead of erroring.
+REAL_BASE=$(readlink -f "$BASE" 2>/dev/null) || REAL_BASE=$BASE
+
+qval() { printf '%s' "$QUERY_STRING" | sed -n "s/.*$1=\([^&]*\).*/\1/p"; }
+# Backslashes are doubled BEFORE the %XX -> \xHH substitution so printf '%b'
+# folds an already-present literal backslash back to one instead of reading
+# it as one of its own escapes (e.g. \c, "stop all output now") and
+# truncating the value - same fix as json-recordings.cgi's urldec.
+urldec() { printf '%b' "$(printf '%s' "$1" | sed 's/\\/\\\\/g; s/+/ /g; s/%\(..\)/\\x\1/g')"; }
+
+# JSON-escape a name that came off the SD card: backslash + double-quote, and
+# drop control characters outright so an odd filename can neither break the
+# JSON nor inject into the WebUI.
+esc() { printf '%s' "$1" | tr -d '\001-\037\177' | sed 's/\\/\\\\/g; s/"/\\"/g'; }
+
+# reject absolute paths and traversal
+safe() { case "$1" in "" | /* | *..*) return 1 ;; *) return 0 ;; esac }
+
+# A leaf-only symlink check (-L on the requested path) catches a symlinked
+# FILE but walks straight past a symlinked DIRECTORY planted anywhere under
+# BASE (e.g. "timelapses/x -> /etc"), since the leaf is then an ordinary
+# file. Resolving the whole path and requiring it to still be under BASE
+# closes that. within_base_dir also accepts BASE itself, which is the "."
+# sequence (a flat name template writes shots straight into the root).
+within_base() {
+	resolved=$(readlink -f "$1" 2>/dev/null) || return 1
+	case "$resolved" in
+		"$REAL_BASE"/*) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+within_base_dir() {
+	resolved=$(readlink -f "$1" 2>/dev/null) || return 1
+	[ "$resolved" = "$REAL_BASE" ] && return 0
+	case "$resolved" in
+		"$REAL_BASE"/*) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+not_found() { printf 'Status: 404 Not Found\r\n\r\n'; exit 0; }
+
+FILE=$(urldec "$(qval file)")
+SEQ=$(urldec "$(qval seq)")
+
+# ---- one shot (the hot path: the player asks for these back to back) ----
+if [ -n "$FILE" ]; then
+	# extension whitelist on top of within_base: even inside the tree this
+	# endpoint can only ever hand out a JPEG.
+	case "$FILE" in *.jpg | *.JPG | *.jpeg | *.JPEG) ;; *) not_found ;; esac
+	if ! safe "$FILE" || [ ! -f "$BASE/$FILE" ] || [ -L "$BASE/$FILE" ] || ! within_base "$BASE/$FILE"; then
+		not_found
+	fi
+	F="$BASE/$FILE"
+	SZ=$(stat -c%s "$F" 2>/dev/null || echo 0)
+	printf 'Status: 200 OK\r\n'
+	printf 'Content-Type: image/jpeg\r\n'
+	printf 'Content-Length: %s\r\n' "$SZ"
+	printf 'Content-Disposition: inline; filename="%s"\r\n' "$(basename "$F")"
+	# Shots are write-once (timps writes to .tmp and renames, and retention
+	# only ever DELETES), so they are safely cacheable - which is what makes
+	# the player's look-ahead prefetch free: the <img> src swap then hits the
+	# browser cache instead of the SD card. "private" keeps an intermediary
+	# from storing an auth-protected image.
+	printf 'Cache-Control: private, max-age=86400, immutable\r\n'
+	printf 'Connection: close\r\n\r\n'
+	cat "$F"
+	exit 0
+fi
+
+# ---- frames of ONE folder ----
+if [ -n "$SEQ" ]; then
+	D="$BASE/$SEQ"
+	if ! safe "$SEQ" || [ ! -d "$D" ] || ! within_base_dir "$D"; then
+		not_found
+	fi
+	printf 'Content-Type: application/json\r\n'
+	printf 'Cache-Control: no-store\r\n\r\n'
+	printf '{"base":"%s","seq":"%s","frames":[' "$(esc "$BASE")" "$(esc "$SEQ")"
+	# ONE ls fork for the whole folder, whatever the frame count: a per-file
+	# stat would be ~1440 forks for an hour at the default interval. Sizes
+	# come out of the same listing; the player derives each frame's timestamp
+	# from its name, so no mtime is needed. Names are sorted again client
+	# side, so ls's own ordering is not relied upon.
+	LC_ALL=C ls -lnA "$D" 2>/dev/null | awk '
+function escape(str) {
+  gsub(/\\/, "\\\\", str)
+  gsub(/"/, "\\\"", str)
+  gsub(/[\001-\037\177]/, "", str)
+  return str
+}
+$1 == "total" { next }
+substr($1, 1, 1) != "-" { next }
+{
+  name = ""
+  for (i = 9; i <= NF; i++) name = name (i == 9 ? "" : OFS) $i
+  if (name !~ /\.[Jj][Pp][Ee]?[Gg]$/) next
+  if (n++) printf(",")
+  printf("{\"f\":\"%s\",\"s\":%s}", escape(name), $5 + 0)
+}'
+	printf ']}\n'
+	exit 0
+fi
+
+# ---- index: folders that actually hold shots ----
+printf 'Content-Type: application/json\r\n'
+printf 'Cache-Control: no-store\r\n\r\n'
+if [ ! -d "$BASE" ]; then
+	printf '{"base":"%s","exists":false,"seqs":[]}\n' "$(esc "$BASE")"
+	exit 0
+fi
+printf '{"base":"%s","exists":true,"seqs":[' "$(esc "$BASE")"
+# -maxdepth bounds the walk to the shapes a name template can plausibly
+# produce. The `set --` glob both tests "does this folder hold shots" and
+# yields the count in $# without a single fork; a `while read` (rather than
+# `for d in $(find ...)`) keeps folder names with spaces intact.
+find "$BASE" -maxdepth 4 -type d 2>/dev/null | sort | (
+	i=0
+	while IFS= read -r d; do
+		set -- "$d"/*.jpg
+		[ -e "$1" ] || continue
+		rel=${d#"$BASE"}
+		rel=${rel#/}
+		[ -z "$rel" ] && rel="."
+		[ $i -gt 0 ] && printf ','
+		printf '{"seq":"%s","frames":%s}' "$(esc "$rel")" "$#"
+		i=$((i + 1))
+	done
+)
+printf ']}\n'

--- a/package/timps/files/www/x/json-timelapse.cgi
+++ b/package/timps/files/www/x/json-timelapse.cgi
@@ -143,13 +143,8 @@ printf '{"base":"%s","exists":true,"seqs":[' "$(esc "$BASE")"
 find "$BASE" -maxdepth 4 -type d 2>/dev/null | sort | (
 	i=0
 	while IFS= read -r d; do
-		# Same 4 case variants the ?file= fetch whitelist accepts (above) and
-		# the ?seq= single-folder listing's regex matches - a single *.jpg
-		# glob undercounted (or hid entirely) folders holding only .JPEG etc.
-		# Globbing all 4 patterns at once can leave unmatched ones as literal
-		# unexpanded strings (no nullglob in busybox ash), so count with a
-		# builtin -e test per token instead of trusting $# - no extra forks,
-		# `[` and arithmetic are shell builtins.
+		# Match the same 4 case variants ?file=/?seq= already accept. No
+		# nullglob in busybox ash, so count via builtin -e tests, not $#.
 		set -- "$d"/*.jpg "$d"/*.JPG "$d"/*.jpeg "$d"/*.JPEG
 		n=0
 		for f in "$@"; do

--- a/package/timps/files/www/x/json-timelapse.cgi
+++ b/package/timps/files/www/x/json-timelapse.cgi
@@ -143,13 +143,24 @@ printf '{"base":"%s","exists":true,"seqs":[' "$(esc "$BASE")"
 find "$BASE" -maxdepth 4 -type d 2>/dev/null | sort | (
 	i=0
 	while IFS= read -r d; do
-		set -- "$d"/*.jpg
-		[ -e "$1" ] || continue
+		# Same 4 case variants the ?file= fetch whitelist accepts (above) and
+		# the ?seq= single-folder listing's regex matches - a single *.jpg
+		# glob undercounted (or hid entirely) folders holding only .JPEG etc.
+		# Globbing all 4 patterns at once can leave unmatched ones as literal
+		# unexpanded strings (no nullglob in busybox ash), so count with a
+		# builtin -e test per token instead of trusting $# - no extra forks,
+		# `[` and arithmetic are shell builtins.
+		set -- "$d"/*.jpg "$d"/*.JPG "$d"/*.jpeg "$d"/*.JPEG
+		n=0
+		for f in "$@"; do
+			[ -e "$f" ] && n=$((n + 1))
+		done
+		[ "$n" -gt 0 ] || continue
 		rel=${d#"$BASE"}
 		rel=${rel#/}
 		[ -z "$rel" ] && rel="."
 		[ $i -gt 0 ] && printf ','
-		printf '{"seq":"%s","frames":%s}' "$(esc "$rel")" "$#"
+		printf '{"seq":"%s","frames":%s}' "$(esc "$rel")" "$n"
 		i=$((i + 1))
 	done
 )

--- a/package/timps/files/www/x/json-timelapse.cgi
+++ b/package/timps/files/www/x/json-timelapse.cgi
@@ -64,7 +64,10 @@ within_base_dir() {
 	esac
 }
 
-not_found() { printf 'Status: 404 Not Found\r\n\r\n'; exit 0; }
+not_found() {
+	printf 'Status: 404 Not Found\r\n\r\n'
+	exit 0
+}
 
 FILE=$(urldec "$(qval file)")
 SEQ=$(urldec "$(qval seq)")


### PR DESCRIPTION
## Summary
Identical change to #1650 (same base), applied against `master` instead of `ciao`.

- Adds a timelapse playback page to the timps WebUI: per-hour playback (existing capture folders) plus a "whole day" mode that merges multiple hour-folders client-side through the same existing per-folder endpoint (no new/changed CGI surface for that part).
- New `x/json-timelapse.cgi` endpoint (modeled on the existing `json-recordings.cgi` pattern: same auth guard, same path-traversal safety checks).
- Fixes two bugs found during real-hardware verification: the folder index undercounted/hid `.JPEG`-suffixed frames (glob only matched `.jpg`), and the player's speed/coverage hint fabricated a wall-clock completion estimate that didn't hold once real SD-card/network throughput was measured.
- Fixes an unrelated but real bug in `timps-irprobe` (the day/night silent-probe's illuminator helper): its 60s failsafe watchdog fired unconditionally, so a night→day switch that had already correctly turned the illuminator off got silently re-lit ~60s later by a stale watchdog from the probe that led to the switch. Found live on a test camera (IR LED stuck on for over an hour despite the daemon correctly reporting day mode). Fixed with a PID-nonce stamp so any newer on/off invalidates every older watchdog instead of racing it; also stopped arming the watchdog when the underlying `light off` call itself fails.

## Test plan
- [x] `sh -n` / `node --check` on all new/changed scripts
- [x] Synthetic local test harness for the timelapse player (multi-day, multi-hour folders, deliberately broken/sparse folders, deep links) — grouped picker, single-hour playback, whole-day merge, partial-folder-failure handling, all verified
- [x] Real-hardware verification against a live camera (real BusyBox `ls`/`find`, real vfat SD card, real captured JPEGs): whole-day merge via genuine concurrent per-folder HTTP requests, hour-boundary frame ordering, broken-folder skip with visible warning, security checks (path traversal, symlink escape) against the real CGI under real BusyBox
- [x] `timps-irprobe` watchdog fix verified live: a stale watchdog (superseded by a newer probe) correctly no-ops, while a genuinely-unanswered watchdog still fires as the real failsafe

🤖 Generated with [Claude Code](https://claude.com/claude-code)